### PR TITLE
Check for touch and chown before managing mail spools in setup_aliases.sh

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -10,6 +10,7 @@ v1.7.3 (Release Date: TBD)
 - Create the yearly destination directory before moving files in dashcam_sync.sh.
 - Create the yearly destination directory before copying files in gpx_sync.sh.
 - Replace GNU-only sed -i with a temporary file and mv in setup_aliases.sh for POSIX portability.
+- Check touch and chown availability before setup_aliases.sh manages mail spools.
 - Specify UTF-8 encoding for html2yaml.py, usershells.py, userlist.py, apache_calculater.py.
 - Exclude symlinks from chmodtree.py ownership normalization by default, opt in with --chown-symlinks.
 - Add --chown-symlinks to fix-permissions.conf for version-switch symlink paths.

--- a/installer/setup_aliases.sh
+++ b/installer/setup_aliases.sh
@@ -171,7 +171,7 @@ main() {
     esac
 
     check_system
-    check_commands sudo grep tee newaliases sed mv id truncate
+    check_commands sudo grep tee newaliases sed mv id truncate touch chown
     check_scripts
 
     SCRIPT_PATH="$SCRIPTS/usershells.py"


### PR DESCRIPTION
### Motivation

- Ensure the installer verifies that `touch` and `chown` are available before performing mail spool operations to avoid runtime failures.

### Description

- Add `touch` and `chown` to the `check_commands` invocation in `installer/setup_aliases.sh` and update `doc/VERSIONS` to document the change.

### Testing

- Performed a shell syntax check with `bash -n installer/setup_aliases.sh` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5432f0bc5083228ee266ed5f1a394f)