### PR TITLE
Persist failed-file tracking across find subshell in sd_extract.sh and update VERSIONS

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -3,6 +3,7 @@ scripts Repository Version History
 
 v1.7.3 (Release Date: TBD)
 --------------------------
+- Preserve sd_extract.sh failed file tracking across its find pipeline subshell.
 - Require the configuration file in git-archive-repo.sh and stop auto-creating missing directories.
 - Make recursive directory traversal in swapext.py opt-in via a new -r option.
 - Remove a non-POSIX local keyword from install_dotvim.sh.

--- a/sd_extract.sh
+++ b/sd_extract.sh
@@ -45,6 +45,8 @@
 #  127. Required command(s) not installed.
 #
 #  Version History:
+#  v2.2 2026-07-13
+#       Persist failed file names across the subshell used by the find pipeline.
 #  v2.1 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -158,6 +160,7 @@ sync_files() {
     permissions=$4
     # Create a temporary flag file to detect if any files have been copied
     flag_file="/tmp/files_copied_$$"
+    error_file="/tmp/error_files_$$"
 
     # Check if the source directory exists
     if [ ! -d "$source_dir" ]; then
@@ -177,11 +180,11 @@ sync_files() {
                 touch "$flag_file"
             else
                 echo "[ERROR] Failed to set permissions for $dest_dir/$(basename "$file")."
-                error_files="$error_files $file"
+                echo "$file" >> "$error_file"
             fi
         else
             echo "[ERROR] Rsync failed for $file. Skipping."
-            error_files="$error_files $file"
+            echo "$file" >> "$error_file"
         fi
     done
 
@@ -190,6 +193,13 @@ sync_files() {
         files_copied=true
         # Remove the flag file after setting the flag
         rm "$flag_file"
+    fi
+
+    if [ -f "$error_file" ]; then
+        while IFS= read -r failed_file; do
+            error_files="$error_files $failed_file"
+        done < "$error_file"
+        rm "$error_file"
     fi
 }
 


### PR DESCRIPTION
### Motivation
- Ensure failed file names collected inside the `find ... | while` pipeline subshell are visible to the parent shell so the script can report errors after the loop. 
- Record the change in `doc/VERSIONS` and bump the script version history.

### Description
- In `sd_extract.sh`'s `sync_files()` function, introduce a temporary `error_file` (e.g. `/tmp/error_files_$$`) and write failed file names to it from inside the subshell. 
- After the `find | while` loop, read the temporary `error_file` into the parent `error_files` variable and remove the temporary file so failures persist across the subshell boundary. 
- Update the script header and `doc/VERSIONS` to add a `v2.2` entry describing the new persistent failed-file tracking behavior.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54ecfb724c8322aa34f085a74f0c35)