### PR TITLE
setup_aliases.sh: preserve /etc/aliases ownership/perms; check mail-tool availability; update VERSIONS

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -10,6 +10,8 @@ v1.7.3 (Release Date: TBD)
 - Create the yearly destination directory before moving files in dashcam_sync.sh.
 - Create the yearly destination directory before copying files in gpx_sync.sh.
 - Replace GNU-only sed -i with a temporary file and mv in setup_aliases.sh for POSIX portability.
+- Check touch and chown availability before setup_aliases.sh manages mail spools.
+- Preserve root-owned aliases file permissions when setup_aliases.sh removes the self alias.
 - Specify UTF-8 encoding for html2yaml.py, usershells.py, userlist.py, apache_calculater.py.
 - Exclude symlinks from chmodtree.py ownership normalization by default, opt in with --chown-symlinks.
 - Add --chown-symlinks to fix-permissions.conf for version-switch symlink paths.

--- a/installer/setup_aliases.sh
+++ b/installer/setup_aliases.sh
@@ -31,6 +31,8 @@
 #  - The system must have a compatible MTA (e.g., Postfix or Sendmail).
 #
 #  Version History:
+#  v1.3 2026-07-13
+#       Preserve root-owned aliases file permissions when removing self alias.
 #  v1.2 2026-07-12
 #       Replace GNU-only sed -i with a temporary file and mv for POSIX
 #       portability, matching the rest of the repository.
@@ -116,7 +118,16 @@ remove_self_alias() {
     if grep -q "^${username}: root$" "$ALIASES_FILE"; then
         echo "[INFO] Removing self alias: $username: root"
         tmp="/tmp/setup_aliases.$$"
-        sed "/^${username}: root$/d" "$ALIASES_FILE" > "$tmp" && sudo mv "$tmp" "$ALIASES_FILE"
+        if sed "/^${username}: root$/d" "$ALIASES_FILE" > "$tmp" &&
+            sudo cp "$tmp" "$ALIASES_FILE" &&
+            sudo chown root:root "$ALIASES_FILE" &&
+            sudo chmod 0644 "$ALIASES_FILE"; then
+            rm "$tmp"
+        else
+            rm -f "$tmp"
+            echo "[ERROR] Failed to update $ALIASES_FILE." >&2
+            exit 1
+        fi
     fi
 }
 
@@ -171,7 +182,7 @@ main() {
     esac
 
     check_system
-    check_commands sudo grep tee newaliases sed mv id truncate
+    check_commands sudo grep tee newaliases sed cp rm id truncate touch chown chmod
     check_scripts
 
     SCRIPT_PATH="$SCRIPTS/usershells.py"


### PR DESCRIPTION
### Motivation
- Ensure the script preserves root ownership and permissions of `/etc/aliases` when removing a user's self-alias. 
- Verify required commands used to manage mail spools are present before touching mail files to avoid runtime failures. 
- Record the change in the repository `doc/VERSIONS` and bump the script version history.

### Description
- Add a `v1.3` entry to `installer/setup_aliases.sh` and update `doc/VERSIONS` to document the new behavior. 
- Replace the previous `sed ... > tmp && sudo mv tmp $ALIASES_FILE` flow in `remove_self_alias()` with a safer sequence that `sed` to a temp file, `sudo cp` the temp file into place, then explicitly `sudo chown root:root` and `sudo chmod 0644` to preserve root-owned file permissions, with error handling and temp-file cleanup. 
- Extend the `check_commands` list to include `touch`, `chown`, and `chmod` so the script verifies availability of tools it uses to manage `/var/mail` spools. 
- Add explicit error reporting if updating `/etc/aliases` fails and ensure temporary files are removed on both success and failure.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5432f0bc5083228ee266ed5f1a394f)