### PR TITLE
Use portable, root-owned update for /etc/aliases in setup_aliases.sh

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -9,7 +9,7 @@ v1.7.3 (Release Date: TBD)
 - Treat grep no-match exit code as a valid result in filter_history.sh to avoid spurious failures.
 - Create the yearly destination directory before moving files in dashcam_sync.sh.
 - Create the yearly destination directory before copying files in gpx_sync.sh.
-- Replace GNU-only sed -i with a temporary file and mv in setup_aliases.sh for POSIX portability.
+- Replace GNU sed -i with a portable root-owned aliases update in setup_aliases.sh.
 - Specify UTF-8 encoding for html2yaml.py, usershells.py, userlist.py, apache_calculater.py.
 - Exclude symlinks from chmodtree.py ownership normalization by default, opt in with --chown-symlinks.
 - Add --chown-symlinks to fix-permissions.conf for version-switch symlink paths.

--- a/installer/setup_aliases.sh
+++ b/installer/setup_aliases.sh
@@ -32,8 +32,7 @@
 #
 #  Version History:
 #  v1.2 2026-07-12
-#       Replace GNU-only sed -i with a temporary file and mv for POSIX
-#       portability, matching the rest of the repository.
+#       Replace GNU sed -i with a portable root-owned aliases update.
 #  v1.1 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -116,7 +115,16 @@ remove_self_alias() {
     if grep -q "^${username}: root$" "$ALIASES_FILE"; then
         echo "[INFO] Removing self alias: $username: root"
         tmp="/tmp/setup_aliases.$$"
-        sed "/^${username}: root$/d" "$ALIASES_FILE" > "$tmp" && sudo mv "$tmp" "$ALIASES_FILE"
+        if sed "/^${username}: root$/d" "$ALIASES_FILE" > "$tmp" &&
+            sudo cp "$tmp" "$ALIASES_FILE" &&
+            sudo chown root:root "$ALIASES_FILE" &&
+            sudo chmod 0644 "$ALIASES_FILE"; then
+            rm "$tmp"
+        else
+            rm -f "$tmp"
+            echo "[ERROR] Failed to update $ALIASES_FILE." >&2
+            exit 1
+        fi
     fi
 }
 
@@ -171,7 +179,7 @@ main() {
     esac
 
     check_system
-    check_commands sudo grep tee newaliases sed mv id truncate
+    check_commands sudo grep tee newaliases sed cp rm id truncate touch chown chmod
     check_scripts
 
     SCRIPT_PATH="$SCRIPTS/usershells.py"


### PR DESCRIPTION
### Motivation
- Avoid GNU-only `sed -i` usage and make alias updates portable across POSIX systems while ensuring `/etc/aliases` remains owned by root with correct permissions.
- Prevent accidental loss of alias file ownership/permissions when removing a self alias and provide robust error handling on update failures.

### Description
- Replaced the previous `sed`+`mv` approach for removing a self alias with a safer sequence that writes to a temporary file, copies it back as root via `sudo cp`, and enforces `root:root` ownership and `0644` permissions with `sudo chown` and `sudo chmod`, plus cleanup and error handling on failure.
- Added `cp`, `rm`, `touch`, `chown`, and `chmod` to the `check_commands` list so required utilities are validated by `check_commands` at startup.
- Adjusted the script header/version comment to describe the new portable root-owned aliases update behavior and updated `doc/VERSIONS` to reflect the same change.

### Testing
- No automated tests were run for this change; manual verification is recommended by running the script on a non-production system and exercising `add_missing_aliases`, `remove_self_alias`, and `apply_changes` paths to confirm correct file updates and permissions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5432f0bc5083228ee266ed5f1a394f)