### PR TITLE
Deterministic JST timestamps and pyping robustness/range validation

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -20,6 +20,8 @@ v1.7.3 (Release Date: TBD)
 - Replace awk {n,} interval expression in usage() with a portable equivalent for mawk compatibility.
 - Refactor Ruby scripts for consistency.
 - Use sys.executable instead of hardcoded 'python' in png_info_test.py subprocess calls.
+- Use explicit JST conversion in unixtime2date.py for deterministic timestamp output.
+- Validate pyping.py host ranges and handle ping execution failures as unreachable hosts.
 
 v1.7.2 (2026-06-30)
 -------------------

--- a/pyping.py
+++ b/pyping.py
@@ -35,6 +35,8 @@
 #  - This script may take time to complete based on the range specified.
 #
 #  Version History:
+#  v1.5 2026-07-14
+#       Added range validation and robust handling when ping command cannot be executed.
 #  v1.4 2025-07-01
 #       Standardized termination behavior for consistent script execution.
 #  v1.3 2025-06-23
@@ -93,8 +95,21 @@ def ping(ip, results):
             subprocess.check_output(
                 ["ping", "-c", "1", "-i", "1", ip], stderr=DEVNULL)
             results[ip] = "alive"
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, OSError):
         results[ip] = "-----"
+
+
+def validate_range(start_ip, end_ip):
+    """Validate the host-number range used for the ping sweep."""
+    if start_ip < 0 or end_ip > 255:
+        print("[ERROR] IP range values must be between 0 and 255.", file=sys.stderr)
+        return False
+
+    if start_ip > end_ip:
+        print("[ERROR] start_ip must be less than or equal to end_ip.", file=sys.stderr)
+        return False
+
+    return True
 
 
 def main(subnet, start_ip, end_ip, ordered):
@@ -107,6 +122,9 @@ def main(subnet, start_ip, end_ip, ordered):
         end_ip (int): End of the IP address range.
         ordered (bool): Whether to sort the results before displaying.
     """
+    if not validate_range(start_ip, end_ip):
+        return 1
+
     threads = []  # List to store threading.Thread objects
     results = {}  # Dictionary to store ping results
 

--- a/test/pyping_test.py
+++ b/test/pyping_test.py
@@ -17,6 +17,8 @@
 #    - Verifies that the script prints usage and exits with code 0 when invoked with -h option.
 #    - Mark an IP address as "alive" when ping returns successfully.
 #    - Mark an IP address as "-----" when ping returns no response (CalledProcessError).
+#    - Mark an IP address as "-----" when ping command execution fails (OSError).
+#    - Reject invalid IP ranges before launching worker threads.
 #    - Sort ping results in numeric IP order when the --ordered option behavior is used.
 #
 #  Notes:
@@ -24,6 +26,8 @@
 #    - The script is designed to work with Python 3.
 #
 #  Version History:
+#  v1.2 2026-07-14
+#       Added validation tests for invalid ranges and unavailable ping command handling.
 #  v1.1 2025-01-06
 #       Added test case for the --ordered option to verify sorted output.
 #  v1.0 2024-01-12
@@ -71,6 +75,27 @@ class TestPyPing(unittest.TestCase):
         results = {}
         pyping.ping('192.168.11.2', results)
         self.assertEqual(results['192.168.11.2'], '-----')
+
+    @patch('subprocess.check_output', side_effect=FileNotFoundError('ping'))
+    def test_ping_command_unavailable(self, mock_check_output):
+        """ Test if ping execution errors are treated as no response. """
+        results = {}
+        pyping.ping('192.168.11.3', results)
+        self.assertEqual(results['192.168.11.3'], '-----')
+
+    def test_validate_range_rejects_reversed_range(self):
+        """ Test if start_ip greater than end_ip is rejected. """
+        with patch('sys.stderr'):
+            self.assertFalse(pyping.validate_range(10, 1))
+
+    def test_validate_range_rejects_out_of_bounds_range(self):
+        """ Test if host-number values outside 0-255 are rejected. """
+        with patch('sys.stderr'):
+            self.assertFalse(pyping.validate_range(-1, 256))
+
+    def test_validate_range_accepts_valid_range(self):
+        """ Test if a valid host-number range is accepted. """
+        self.assertTrue(pyping.validate_range(1, 254))
 
     @patch('subprocess.check_output')
     def test_ordered_option(self, mock_check_output):

--- a/unixtime2date.py
+++ b/unixtime2date.py
@@ -5,7 +5,7 @@
 #
 #  Description:
 #  This script converts a Unix timestamp to a human-readable date format in ISO 8601.
-#  It uses the local timezone for conversion.
+#  It uses Japan Standard Time (UTC+09:00) for deterministic conversion.
 #
 #  Author: id774 (More info: http://id774.net)
 #  Source Code: https://github.com/id774/scripts
@@ -23,6 +23,8 @@
 #  - Python Version: 3.3 or later
 #
 #  Version History:
+#  v1.6 2026-07-14
+#       Use an explicit Japan Standard Time timezone instead of environment-dependent local time.
 #  v1.5 2025-07-01
 #       Standardized termination behavior for consistent script execution.
 #  v1.4 2025-06-23
@@ -66,10 +68,12 @@ def usage():
         sys.exit(1)
     sys.exit(0)
 
+JST = datetime.timezone(datetime.timedelta(hours=9))
+
+
 def unixtime2date(its):
-    """ Convert Unix timestamp to human-readable date in local timezone (ISO 8601 format). """
-    local_datetime = datetime.datetime.fromtimestamp(
-        its, datetime.timezone.utc).astimezone()
+    """ Convert Unix timestamp to ISO 8601 date in Japan Standard Time. """
+    local_datetime = datetime.datetime.fromtimestamp(its, JST)
     return local_datetime.isoformat()
 
 def main(args):


### PR DESCRIPTION
### Motivation

- `unixtime2date.py` produced environment-dependent results because it used the local timezone, so conversions must be deterministic for tests and reproducible outputs. 
- `pyping.py` could crash or misbehave when the `ping` command was unavailable or when given invalid host-number ranges, so it needs hardened error handling and input validation. 

### Description

- Use an explicit JST timezone by adding `JST = datetime.timezone(datetime.timedelta(hours=9))` and update `unixtime2date()` to produce ISO 8601 timestamps in JST. 
- Treat `OSError` (e.g. missing `ping` executable) the same as `CalledProcessError` in `pyping.ping()` so execution errors mark the host unreachable. 
- Add `validate_range(start_ip, end_ip)` and call it at the start of `pyping.main()` to reject out-of-bounds or reversed ranges before launching threads. 
- Add regression tests in `test/pyping_test.py` covering `FileNotFoundError` (ping unavailable) and the new range validation, and bump header version notes in modified files. 

### Testing

- Ran `python test/unixtime2date_test.py` and the test suite passed. 
- Ran `python test/pyping_test.py` and the test suite passed. 
- Ran the full test runner with `SCRIPTS=$PWD ./run_tests.sh` and the repository tests completed with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5615c6e44c8322bc049b594773b02d)