### PR TITLE
unzip_subdir: use zipfile for extraction and prevent zip-slip traversal

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -22,6 +22,7 @@ v1.7.3 (Release Date: TBD)
 - Use sys.executable instead of hardcoded 'python' in png_info_test.py subprocess calls.
 - Use explicit JST conversion in unixtime2date.py for deterministic timestamp output.
 - Validate pyping.py host ranges and handle ping execution failures as unreachable hosts.
+- Fix unzip_subdir.py archive extraction paths and reject unsafe zip member traversal.
 
 v1.7.2 (2026-06-30)
 -------------------

--- a/test/unzip_subdir_test.py
+++ b/test/unzip_subdir_test.py
@@ -6,7 +6,8 @@
 #  Description:
 #  This script tests unzip_subdir.py, which extracts each .zip file in a
 #  given directory into a separate subdirectory. It verifies dry-run behavior,
-#  skipping existing directories, and proper help message output.
+#  skipping existing directories, safe zipfile extraction, nested directory
+#  traversal, unsafe archive member rejection, and proper help message output.
 #
 #  Author: id774 (More info: http://id774.net)
 #  Source Code: https://github.com/id774/scripts
@@ -17,9 +18,13 @@
 #    - Verifies that the script prints usage and exits with code 0 when invoked with -h option.
 #    - In dry-run mode, lists .zip files found in the target directory without creating directories or executing unzip.
 #    - Skips extraction (and listing in dry-run) when the target subdirectory already exists.
-#    - In execution mode (non–dry-run), creates a subdirectory per .zip file and invokes the unzip command exactly once per archive.
+#    - In execution mode (non–dry-run), creates a subdirectory per .zip file and extracts archive contents with zipfile.
+#    - Rejects archive entries that would be written outside the target directory.
+#    - Extracts .zip files discovered in nested subdirectories using the discovered archive path.
 #
 #  Version History:
+#  v1.2 2026-07-14
+#       Documented and tested zipfile extraction, nested paths, and unsafe member rejection.
 #  v1.1 2025-07-08
 #       Fixed compatibility issues with Python 3.4.
 #  v1.0 2025-07-07
@@ -32,8 +37,8 @@ import os
 import sys
 import tempfile
 import unittest
+import zipfile
 from contextlib import redirect_stdout
-from unittest.mock import patch
 
 # Adjust the path to import script from the parent directory
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -77,24 +82,46 @@ class TestUnzipSubdir(unittest.TestCase):
             # Should not list it because dir already exists
             self.assertNotIn("data.zip", output)
 
-    @patch('os.system')
-    def test_actual_unzip_command_called(self, mock_system):
+    def test_actual_unzip_extracts_archive_contents(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             zip_path = os.path.join(tmpdir, 'foo.zip')
-            with open(zip_path, 'w') as f:
-                f.write('dummy zip')
+            with zipfile.ZipFile(zip_path, 'w') as archive:
+                archive.writestr('bar.txt', 'extracted content')
 
-            # no target dir should exist
             f = io.StringIO()
             with redirect_stdout(f):
                 unzip_subdir.unzip_files([tmpdir], dry_run=False)
-            output = f.getvalue()
 
-            # Ensure directory was created
+            extracted_path = os.path.join(tmpdir, 'foo', 'bar.txt')
             self.assertTrue(os.path.isdir(os.path.join(tmpdir, 'foo')))
-            # Replace assert_called_once (Python 3.6+ only)
-            self.assertEqual(mock_system.call_count, 1)
-            self.assertIn('foo', os.listdir(tmpdir))
+            self.assertTrue(os.path.isfile(extracted_path))
+            with open(extracted_path) as extracted:
+                self.assertEqual(extracted.read(), 'extracted content')
+
+    def test_rejects_zip_entries_outside_target_directory(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            zip_path = os.path.join(tmpdir, 'evil.zip')
+            with zipfile.ZipFile(zip_path, 'w') as archive:
+                archive.writestr('../outside.txt', 'should not escape')
+
+            unzip_subdir.unzip_files([tmpdir], dry_run=False)
+
+            self.assertFalse(os.path.exists(os.path.join(tmpdir, 'outside.txt')))
+
+    def test_extracts_zip_files_from_nested_directories(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nested_dir = os.path.join(tmpdir, 'nested')
+            os.mkdir(nested_dir)
+            zip_path = os.path.join(nested_dir, 'child.zip')
+            with zipfile.ZipFile(zip_path, 'w') as archive:
+                archive.writestr('child.txt', 'nested content')
+
+            unzip_subdir.unzip_files([tmpdir], dry_run=False)
+
+            extracted_path = os.path.join(nested_dir, 'child', 'child.txt')
+            self.assertTrue(os.path.isfile(extracted_path))
+            with open(extracted_path) as extracted:
+                self.assertEqual(extracted.read(), 'nested content')
 
 
 if __name__ == '__main__':

--- a/unzip_subdir.py
+++ b/unzip_subdir.py
@@ -8,7 +8,8 @@
 #  into separate subdirectories. If a subdirectory already exists, it
 #  skips the extraction for that zip file. The --dry-run option lists
 #  the zip files that would be extracted without performing the actual
-#  extraction.
+#  extraction. Archives are extracted with Python's zipfile module
+#  and entries that would escape the target directory are rejected.
 #
 #  Author: id774 (More info: http://id774.net)
 #  Source Code: https://github.com/id774/scripts
@@ -27,8 +28,12 @@
 #  - Ensure that you have the necessary permissions to read and write
 #    files in the source directory.
 #  - The script does not overwrite existing directories.
+#  - Archive members containing unsafe paths are rejected before extraction.
 #
 #  Version History:
+#  v1.7 2026-07-14
+#       Replaced shell unzip execution with zipfile extraction, fixed nested
+#       archive paths, and rejected unsafe zip member traversal.
 #  v1.6 2025-07-08
 #       Fixed compatibility issues with Python 3.4.
 #  v1.5 2025-07-01
@@ -49,6 +54,7 @@
 import os
 import re
 import sys
+import zipfile
 from optparse import OptionParser
 
 
@@ -75,6 +81,16 @@ def usage():
         sys.exit(1)
     sys.exit(0)
 
+def safe_extract(archive, target_dir):
+    """Extract a ZipFile while preventing path traversal entries."""
+    target_abs = os.path.abspath(target_dir)
+    for member in archive.infolist():
+        destination = os.path.abspath(os.path.join(target_dir, member.filename))
+        if destination != target_abs and not destination.startswith(target_abs + os.sep):
+            raise ValueError("Unsafe zip member path: {}".format(member.filename))
+    archive.extractall(target_dir)
+
+
 def unzip_files(args, dry_run=False):
     for root, dirs, files in os.walk(args[0]):
         for f in files:
@@ -89,15 +105,13 @@ def unzip_files(args, dry_run=False):
             if dry_run:
                 print("[INFO] DRY RUN: Would unzip {} into {}".format(f, target_dir))
             else:
+                zip_path = os.path.join(root, f)
                 try:
                     os.mkdir(target_dir)
-                    current = os.getcwd()
-                    os.chdir(target_dir)
-                    cmd = "unzip {}".format(os.path.join(args[0], f))
-                    os.system(cmd)
-                    os.chdir(current)
+                    with zipfile.ZipFile(zip_path) as archive:
+                        safe_extract(archive, target_dir)
                 except Exception as e:
-                    print("Error unzipping {}: {}".format(f, str(e)), file=sys.stderr)
+                    print("Error unzipping {}: {}".format(zip_path, str(e)), file=sys.stderr)
 
 
 def main():


### PR DESCRIPTION
### Motivation

- Replace the previous shell-based `unzip` execution with a pure-Python extraction to remove an external command dependency and correctly handle nested archive paths.  
- Prevent directory traversal (zip-slip) by rejecting archive members that would be extracted outside the intended target directory.  
- Improve test coverage to validate dry-run behavior, actual extraction, nested discovery, and unsafe-member rejection.

### Description

- Replaced `os.system("unzip ...")` invocation with `zipfile.ZipFile` extraction in `unzip_subdir.py`.  
- Added a `safe_extract` helper that checks each `ZipInfo` entry to ensure the resolved destination path is within the target extraction directory and raises on unsafe members.  
- Create the per-archive target directory and extract archive contents with `archive.extractall(target_dir)` inside the safe-check block, and improved error messages to include the archive path.  
- Expanded and updated `test/unzip_subdir_test.py` to use the `zipfile` module for test archives and to verify extraction, nested directory discovery, and that entries attempting to escape the target are rejected.

### Testing

- Ran the unzip subdir unit tests with `python -m unittest test/unzip_subdir_test.py` and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a563b5fca60832293b10054c3d7f0db)