### PR TITLE
Validate zip members before extracting in unzip_subdir, update test and docs

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -22,7 +22,7 @@ v1.7.3 (Release Date: TBD)
 - Use sys.executable instead of hardcoded 'python' in png_info_test.py subprocess calls.
 - Use explicit JST conversion in unixtime2date.py for deterministic timestamp output.
 - Validate pyping.py host ranges and handle ping execution failures as unreachable hosts.
-- Fix unzip_subdir.py archive extraction paths and reject unsafe zip member traversal.
+- Validate unzip_subdir.py archive members before creating extraction directories.
 
 v1.7.2 (2026-06-30)
 -------------------

--- a/test/unzip_subdir_test.py
+++ b/test/unzip_subdir_test.py
@@ -107,6 +107,7 @@ class TestUnzipSubdir(unittest.TestCase):
             unzip_subdir.unzip_files([tmpdir], dry_run=False)
 
             self.assertFalse(os.path.exists(os.path.join(tmpdir, 'outside.txt')))
+            self.assertFalse(os.path.exists(os.path.join(tmpdir, 'evil')))
 
     def test_extracts_zip_files_from_nested_directories(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/unzip_subdir.py
+++ b/unzip_subdir.py
@@ -81,13 +81,18 @@ def usage():
         sys.exit(1)
     sys.exit(0)
 
-def safe_extract(archive, target_dir):
-    """Extract a ZipFile while preventing path traversal entries."""
+def validate_members(archive, target_dir):
+    """Reject ZipFile members that would escape target_dir."""
     target_abs = os.path.abspath(target_dir)
     for member in archive.infolist():
         destination = os.path.abspath(os.path.join(target_dir, member.filename))
         if destination != target_abs and not destination.startswith(target_abs + os.sep):
             raise ValueError("Unsafe zip member path: {}".format(member.filename))
+
+
+def safe_extract(archive, target_dir):
+    """Extract a validated ZipFile into target_dir."""
+    os.mkdir(target_dir)
     archive.extractall(target_dir)
 
 
@@ -107,8 +112,8 @@ def unzip_files(args, dry_run=False):
             else:
                 zip_path = os.path.join(root, f)
                 try:
-                    os.mkdir(target_dir)
                     with zipfile.ZipFile(zip_path) as archive:
+                        validate_members(archive, target_dir)
                         safe_extract(archive, target_dir)
                 except Exception as e:
                     print("Error unzipping {}: {}".format(zip_path, str(e)), file=sys.stderr)


### PR DESCRIPTION
### Motivation
- Prevent zip slip / path traversal by ensuring archive members cannot escape the intended extraction directory before any directories are created.
- Make behavior deterministic so extraction directories are not created when an archive is rejected.
- Document the change in the version history so release notes reflect the safer extraction behavior.

### Description
- Add `validate_members(archive, target_dir)` which checks each `ZipInfo.filename` and raises on paths that would escape `target_dir`.
- Change `safe_extract` to create the target directory and perform the actual `archive.extractall(target_dir)` after validation.
- Update `unzip_files` to open the archive, call `validate_members`, then call `safe_extract`, and handle exceptions without leaving a partially-created directory when validation fails.
- Update `test/unzip_subdir_test.py` to assert that no extraction directory is created for archives with unsafe entries, and update `doc/VERSIONS` to describe the new validation behavior.

### Testing
- Ran the unit test file `test/unzip_subdir_test.py` under the repository test runner, and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a563ec5d8f8832285e8de3ed94472c8)