### PR TITLE
Reorder POLICY sections: move Control Flow and CLI Conventions before Exit Code Conventions

### DIFF
--- a/doc/POLICY
+++ b/doc/POLICY
@@ -40,6 +40,21 @@ or additions to this common policy, in order to avoid redundancy.
   (e.g. `[cron]`, `[admin]`) in the subject line so recipients can easily
   classify, filter, or route messages.
 
+### Control Flow Rules
+- Use explicit termination (`exit`, `sys.exit`, `exit()`) **only for abnormal or forced termination**.
+- Normal execution paths must return normally and propagate status explicitly.
+- Do not rely on implicit termination or language-specific shortcuts
+  (e.g. `set -e` in shell, bare `except` in Python).
+
+### CLI Conventions
+- All command-line tools must provide consistent options:
+  - `-h`, `--help` to display usage information and exit with code `0`.
+  - `-v`, `--version` to display version information and exit with code `0`.
+- Help or version output represents a successful, user-requested termination.
+- Invalid or unsupported options must result in usage output.
+- Exit code may be `1` (error) or `0` (non-error usage display),
+- depending on the tool's design, but must be consistent and documented.
+
 ### Error Handling and Exit Codes
 - Detect command failures and unmet prerequisites early.
 - Always log the reason and affected target when an error occurs.
@@ -68,21 +83,6 @@ or additions to this common policy, in order to avoid redundancy.
 
 > If finer-grained classification is truly required, `sysexits` codes (64–78)
 > may be used, but must be explicitly documented in the script or program header.
-
-### Control Flow Rules
-- Use explicit termination (`exit`, `sys.exit`, `exit()`) **only for abnormal or forced termination**.
-- Normal execution paths must return normally and propagate status explicitly.
-- Do not rely on implicit termination or language-specific shortcuts
-  (e.g. `set -e` in shell, bare `except` in Python).
-
-### CLI Conventions
-- All command-line tools must provide consistent options:
-  - `-h`, `--help` to display usage information and exit with code `0`.
-  - `-v`, `--version` to display version information and exit with code `0`.
-- Help or version output represents a successful, user-requested termination.
-- Invalid or unsupported options must result in usage output.
-- Exit code may be `1` (error) or `0` (non-error usage display),
-- depending on the tool's design, but must be consistent and documented.
 
 ### Documentation and Versioning
 - Every executable must contain a structured header with:

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -24,6 +24,7 @@ v1.7.3 (Release Date: TBD)
 - Validate pyping.py host ranges and handle ping execution failures as unreachable hosts.
 - Validate unzip_subdir.py archive members before creating extraction directories.
 - Quote file and directory paths in pyck.py before interpolating them into shell commands.
+- Reorder the common policy so exit-code conventions follow the general CLI rules.
 
 v1.7.2 (2026-06-30)
 -------------------


### PR DESCRIPTION
### Motivation
- Reorder the common policy so exit-code conventions follow general CLI rules and remove duplicated sections to clarify documentation structure.

### Description
- Move `Control Flow Rules` and `CLI Conventions` earlier in `doc/POLICY`, remove the duplicate trailing copies, and update `doc/VERSIONS` to record the change.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5871b72adc8322a651c5805796f2ff)