### PR TITLE
Auto-initialize SCRIPTS in run_tests.sh and update VERSIONS

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -25,6 +25,7 @@ v1.7.3 (Release Date: TBD)
 - Validate unzip_subdir.py archive members before creating extraction directories.
 - Quote file and directory paths in pyck.py before interpolating them into shell commands.
 - Reorder the common policy so exit-code conventions follow the general CLI rules.
+- Set SCRIPTS automatically in run_tests.sh when it is not provided.
 
 v1.7.2 (2026-06-30)
 -------------------

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -71,6 +71,13 @@
 # Prevent __pycache__ directory creation
 export PYTHONDONTWRITEBYTECODE=1
 
+# Initialize SCRIPTS from the script directory when unset
+initialize_scripts() {
+    if [ -z "$SCRIPTS" ]; then
+        SCRIPTS=$(CDPATH= cd "$(dirname "$0")" && pwd)
+    fi
+}
+
 # Display full script header information extracted from the top comment block
 usage() {
     awk '
@@ -311,6 +318,7 @@ run_tests() {
 
 # Main entry point of the script
 main() {
+    initialize_scripts
     check_scripts
     run_tests "$@"
     return 0


### PR DESCRIPTION
### Motivation
- Allow `run_tests.sh` to discover the `SCRIPTS` path automatically when the `SCRIPTS` environment variable is not provided, preventing an immediate error and simplifying local invocation; also record the change in `doc/VERSIONS`.

### Description
- Add an `initialize_scripts()` function that sets `SCRIPTS` to the script directory when unset and invoke it from `main` before `check_scripts`, and update `doc/VERSIONS` to document the new behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59c0e930ec8322af4cc84bccdd0977)