### PR TITLE
Treat non-zero Python and RSpec exit codes as test failures in run_tests.sh

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -26,6 +26,7 @@ v1.7.3 (Release Date: TBD)
 - Quote file and directory paths in pyck.py before interpolating them into shell commands.
 - Reorder the common policy so exit-code conventions follow the general CLI rules.
 - Set SCRIPTS automatically in run_tests.sh when it is not provided.
+- Treat non-zero Python and RSpec exit codes as test failures in run_tests.sh.
 
 v1.7.2 (2026-06-30)
 -------------------

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -22,6 +22,8 @@
 #  If SCRIPTS is unset, this script uses its own directory automatically.
 #
 #  Version History:
+#  v3.5 2026-07-21
+#       Treat non-zero Python and RSpec exit codes as test failures.
 #  v3.4 2026-07-17
 #       Initialize SCRIPTS from the script directory when it is unset.
 #  v3.3 2026-07-11
@@ -168,8 +170,10 @@ run_python_tests() {
         if [ -f "$file" ]; then
             echo "[INFO] Running Python test: $file"
             output=$("$python_path" "$file" 2>&1)
+            test_status=$?
             echo "$output"
-            if ! echo "$output" | grep -qE "OK|SKIPPED|OK (skipped=[0-9]+)"; then
+            if [ "$test_status" -ne 0 ] ||
+                ! echo "$output" | grep -qE "OK|SKIPPED|OK (skipped=[0-9]+)"; then
                 echo "[WARN] Failure in Python test: $file" >&2
                 python_failures=$((python_failures + 1))
             fi
@@ -233,8 +237,10 @@ run_ruby_tests() {
         if [ -f "$file" ]; then
             echo "[INFO] Running Ruby test: $file"
             output=$("$rspec_path" "$file" 2>&1)
+            test_status=$?
             echo "$output"
-            if ! echo "$output" | grep -q "0 failures"; then
+            if [ "$test_status" -ne 0 ] ||
+                ! echo "$output" | grep -q "0 failures"; then
                 echo "[WARN] Failure in Ruby test: $file" >&2
                 ruby_failures=$(expr "$ruby_failures" + 1)
             fi


### PR DESCRIPTION
### Motivation
- Ensure that test runners which exit with a non-zero status are considered failures even when their textual output does not include the expected failure keywords.
- Make test result detection more robust for both Python and Ruby test invocations so the overall test summary reflects actual process exit codes.

### Description
- Capture the subprocess exit status into `test_status=$?` after running each Python and Ruby test invocation. 
- Treat a non-zero `test_status` as a test failure in addition to existing output-pattern checks for Python and RSpec results. 
- Bump the `run_tests.sh` header to `v3.5` and add a `doc/VERSIONS` entry documenting the change.

### Testing
- Ran `./run_tests.sh` against the repository `test/` directory and verified that a Python test script that exits non-zero is reported as a failure and increments the Python failure counter. 
- Ran `./run_tests.sh` against the repository `test/` directory and verified that an RSpec invocation exiting non-zero is reported as a failure and increments the Ruby failure counter. 
- Existing passing tests continue to be detected as passing and the script produces the expected summary output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f1015c2808322bb4ae131fc6c31e4)