### PR TITLE
Remove incomplete unzip_subdir target directories on extraction failure and add test

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -24,6 +24,7 @@ v1.7.3 (Release Date: TBD)
 - Quote file and directory paths in pyck.py before interpolating them into shell commands.
 - Reorder the common policy so exit-code conventions follow the general CLI rules.
 - Improve run_tests.sh path initialization, failure detection, and Python interpreter fallback.
+- Remove incomplete unzip_subdir.py target directories when archive extraction fails.
 
 v1.7.2 (2026-06-30)
 -------------------

--- a/test/unzip_subdir_test.py
+++ b/test/unzip_subdir_test.py
@@ -23,6 +23,8 @@
 #    - Extracts .zip files discovered in nested subdirectories using the discovered archive path.
 #
 #  Version History:
+#  v1.3 2026-07-23
+#       Added coverage for cleanup after extraction failures.
 #  v1.2 2026-07-14
 #       Documented and tested zipfile extraction, nested paths, and unsafe member rejection.
 #  v1.1 2025-07-08
@@ -39,6 +41,7 @@ import tempfile
 import unittest
 import zipfile
 from contextlib import redirect_stderr, redirect_stdout
+from unittest import mock
 
 # Adjust the path to import script from the parent directory
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -109,6 +112,19 @@ class TestUnzipSubdir(unittest.TestCase):
 
             self.assertFalse(os.path.exists(os.path.join(tmpdir, 'outside.txt')))
             self.assertFalse(os.path.exists(os.path.join(tmpdir, 'evil')))
+
+    def test_removes_target_directory_when_extraction_fails(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            zip_path = os.path.join(tmpdir, 'broken.zip')
+            with zipfile.ZipFile(zip_path, 'w') as archive:
+                archive.writestr('partial.txt', 'partial content')
+
+            with mock.patch.object(zipfile.ZipFile, 'extractall',
+                                   side_effect=OSError('extraction failed')):
+                with redirect_stderr(io.StringIO()):
+                    unzip_subdir.unzip_files([tmpdir], dry_run=False)
+
+            self.assertFalse(os.path.exists(os.path.join(tmpdir, 'broken')))
 
     def test_extracts_zip_files_from_nested_directories(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/unzip_subdir.py
+++ b/unzip_subdir.py
@@ -31,6 +31,8 @@
 #  - Archive members containing unsafe paths are rejected before extraction.
 #
 #  Version History:
+#  v1.8 2026-07-23
+#       Removed incomplete target directories after extraction failures.
 #  v1.7 2026-07-14
 #       Replaced shell unzip execution with zipfile extraction, fixed nested
 #       archive paths, and rejected unsafe zip member traversal.
@@ -53,6 +55,7 @@
 
 import os
 import re
+import shutil
 import sys
 import zipfile
 from optparse import OptionParser
@@ -93,7 +96,11 @@ def validate_members(archive, target_dir):
 def safe_extract(archive, target_dir):
     """Extract a validated ZipFile into target_dir."""
     os.mkdir(target_dir)
-    archive.extractall(target_dir)
+    try:
+        archive.extractall(target_dir)
+    except Exception:
+        shutil.rmtree(target_dir)
+        raise
 
 
 def unzip_files(args, dry_run=False):


### PR DESCRIPTION
### Motivation
- Prevent leftover partial target directories when zip extraction fails so the filesystem is not left in an inconsistent state.
- Make the failure cleanup behavior explicit and covered by automated tests.

### Description
- Add `shutil.rmtree`-based cleanup in `safe_extract` to remove the created target directory if `archive.extractall` raises an exception and re-raise the error.
- Import `shutil` in `unzip_subdir.py` and update the script version history to document the change via the header comments and `doc/VERSIONS`.
- Add `test_removes_target_directory_when_extraction_fails` to `test/unzip_subdir_test.py` which patches `zipfile.ZipFile.extractall` to raise an `OSError` and asserts the incomplete target directory is removed, and add `unittest.mock` usage and a version note in the test file.

### Testing
- Ran the `unzip_subdir` unit tests via `python -m unittest test/unzip_subdir_test.py` and the test suite covering dry-run, extraction, unsafe-member rejection, nested extraction, and the new failure-cleanup case passed.
- The new failure-cleanup test specifically simulates `extractall` raising an exception and verified the target directory was removed (test succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6225eb655083228647de83b2892cbf)