### PR TITLE
Fix find_pycompat.py warning: replace subprocess.DEVNULL with os.devnull

### DIFF
--- a/test/apache_log_analysis_cron_test.py
+++ b/test/apache_log_analysis_cron_test.py
@@ -89,9 +89,10 @@ class TestApacheLogAnalysisCron(unittest.TestCase):
         wrapper = self.build_wrapper()
         # The wrapper refuses to run with a terminal attached, so stdin must
         # not be inherited from an interactive test session.
-        process = subprocess.Popen(['/bin/sh', wrapper],
-                                   stdin=subprocess.DEVNULL,
-                                   stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        with open(os.devnull, 'r') as devnull:
+            process = subprocess.Popen(['/bin/sh', wrapper],
+                                       stdin=devnull,
+                                       stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         _, stderr = process.communicate()
         self.assertTrue(os.path.isfile(self.joblog),
                         'job log was not created: %s' % stderr.decode('utf-8'))


### PR DESCRIPTION
## Summary
- `find_pycompat.py` flagged `test/apache_log_analysis_cron_test.py` for using `subprocess.DEVNULL`, which requires Python 3.3+
- The repo targets partial compatibility back to Python 3.1, and other scripts (`tcmount.py`, `cal.py`, `chmodtree.py`, `pyping.py`, `du.py`) already avoid `subprocess.DEVNULL` in favor of `open(os.devnull, ...)`
- Applied the same pattern to `run_wrapper()` in the test file

## Test plan
- [x] `python3 test/apache_log_analysis_cron_test.py -v` — all 3 tests pass
- [x] `python3 find_pycompat.py .` — no longer flags this file (only `dummy.py`, as expected)

---
_Generated by [Claude Code](https://claude.ai/code/session_016B5tiErZFko3uDAC1qmGtr)_