### PR TITLE
Clarify version bumping and numbering policy in doc/POLICY

### DIFF
--- a/doc/POLICY
+++ b/doc/POLICY
@@ -91,8 +91,41 @@ or additions to this common policy, in order to avoid redundancy.
 - "Test Cases" section must NOT be included in production scripts.
 - "Test Cases" must be defined only in dedicated test code (e.g., test/, spec/).
 - Documentation must be updated in sync with behavior changes.
-- Do not increment version numbers multiple times on the same date.
-- Multiple updates on the same date must be consolidated into a single version entry.
+
+#### When to Bump the Version
+- Do not bump the version mechanically every time a file is touched. Decide
+  based on the nature of the change:
+  - Documentation-only changes (comments, help text, README/POLICY/VERSIONS
+    wording, etc. with no effect on behavior) do not bump the version.
+  - Any change that affects code behavior (bug fixes, new options, and
+    refactors that change observable behavior) bumps the version.
+  - Multiple updates on the same date must be consolidated into a single
+    version entry; do not increment version numbers multiple times on the
+    same date.
+  - Finalizing only the release date of an already-added `Version History`
+    entry (e.g. changing `TBD` to the actual release date) is not by itself
+    a new change. Classify that entry as version-only or as containing real
+    changes based on what the entry actually contains, not on the date edit.
+
+#### Version Numbering
+- Versions use a two-level `major.minor` scheme.
+- When incrementing `minor` would reach `10`, roll over instead: increment
+  `major` by 1 and reset `minor` to `0` (e.g. `v0.9` -> `v1.0`,
+  `v1.9` -> `v2.0`, `v2.9` -> `v3.0`).
+- Do not continue `minor` past `9` as in standard semantic versioning
+  (e.g. do not use `v1.10`, `v1.11`, ...).
+
+#### doc/VERSIONS Structure
+- `doc/VERSIONS` must read as a version-level summary of overall changes, not
+  a raw commit log:
+  - When multiple changes to the same file within one version are really one
+    coherent change, merge them into a single bullet instead of listing them
+    separately.
+  - When changes are independent, still place entries that touch the same
+    file or the same feature near each other, so that each version's entry
+    reads as a coherent, reviewable whole rather than an unordered sequence
+    of unrelated lines.
+
 - Header indentation:
   - Title line: 1 space after `#`
   - Other lines: 2 spaces after `#`


### PR DESCRIPTION
## Summary
This PR expands and clarifies the version management policy in `doc/POLICY` to provide explicit guidance on when to bump versions, how to number them, and how to structure the `doc/VERSIONS` file.

## Key Changes
- **When to Bump the Version**: Added detailed criteria distinguishing between changes that require version bumps (behavior changes, bug fixes, new options) and those that don't (documentation-only changes). Clarified that finalizing release dates alone doesn't constitute a new version bump.

- **Version Numbering Scheme**: Documented the two-level `major.minor` versioning scheme with explicit rollover rules (e.g., `v0.9` → `v1.0` instead of `v0.10`), preventing the use of double-digit minor versions.

- **doc/VERSIONS Structure**: Added guidelines for maintaining `doc/VERSIONS` as a coherent summary rather than a raw commit log, including:
  - Merging related changes to the same file into single bullets
  - Grouping independent but related changes together for readability
  - Ensuring each version entry reads as a cohesive, reviewable unit

## Notable Details
The policy now explicitly addresses edge cases like consolidating multiple updates on the same date and distinguishes between version-only edits (date finalization) and substantive changes, providing clearer guidance for maintainers on version management decisions.

https://claude.ai/code/session_01QaSavUYUBm7uDLiv6kcqdB