### PR TITLE
Align Ruby minimum supported version in POLICY with README

### DIFF
--- a/doc/POLICY
+++ b/doc/POLICY
@@ -243,8 +243,13 @@ log_info_time() {
 
 ## Ruby Implementation Policy
 
-### Supported Versions
-- Minimum supported version: **Ruby 3.0 or later**.
+### Supported Versions and Compatibility
+- Code must fully support Ruby 2.4+.
+- Backward compatibility down to Ruby 2.0 is maintained on a best-effort basis and must not break existing behavior intentionally.
+- If compatible with Ruby 2.0, documentation must state:
+  `Ruby Version: 2.0 or later`
+- Only when strictly required, state:
+  `Ruby Version: 2.4 or later`
 
 ### Program Structure
 - Define `main` as the entry point.

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -23,6 +23,7 @@ v1.7.3 (Release Date: TBD)
 - Harden unzip_subdir.py extraction: validate archive members, clean up incomplete target directories, and return a non-zero exit status on failure.
 - Quote file and directory paths in pyck.py before interpolating them into shell commands.
 - Reorder the common policy so exit-code conventions follow the general CLI rules.
+- Align the Ruby policy minimum supported version with README as Ruby 2.4 or later.
 - Improve run_tests.sh path initialization, failure detection, and Python interpreter fallback.
 - Support Markdown reference links in fix_anchor.py in addition to HTML anchors, and document the link forms it does not rewrite.
 - Add apache_blog_analysis.py alongside apache_log_analysis.sh, then deduplicate Blog Entry Access logic and align ignore-list resolution across the Apache analysis scripts.


### PR DESCRIPTION
The Ruby Implementation Policy declared Ruby 3.0 as the minimum supported
version, while README.md and the Ruby script headers state Ruby 2.4+ with
best-effort compatibility back to Ruby 2.0. Unify the policy on Ruby 2.4+
and mirror the Python policy wording for the documentation requirements.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HA8GxVNuodB7JXJnd8dBeG