### PR TITLE
Fix Apache analysis header docs and drop an unused definition

### DIFF
--- a/apache_blog_analysis.py
+++ b/apache_blog_analysis.py
@@ -139,7 +139,7 @@ import gzip
 import os
 import re
 import sys
-from collections import Counter, defaultdict, namedtuple
+from collections import Counter, defaultdict
 from datetime import datetime, timedelta, timezone
 from urllib.parse import urlsplit
 
@@ -202,8 +202,6 @@ LOG_LINE_RE = re.compile(
 
 APACHE_TIME_RE = re.compile(
     r'^(\d{2})/([A-Za-z]{3})/(\d{4}):(\d{2}):(\d{2}):(\d{2}) ([+-]\d{4})$')
-
-Candidate = namedtuple('Candidate', ['ip', 'ua', 'article_path', 'ts'])
 
 
 class MutableCandidate(object):

--- a/apache_calculater.py
+++ b/apache_calculater.py
@@ -10,7 +10,7 @@
 #  When multiple log files are specified, IP hit counts and cache statistics
 #  are aggregated across all provided logs before reporting results.
 #
-#  log files and excludes IPs listed in apache_ignore.list, which is searched
+#  It excludes IPs listed in apache_ignore.list, which is searched
 #  in <script_dir>/etc/, <script_dir>/../etc/ and /etc/cron.config in that order.
 #  It is designed to provide insights into web server traffic and client behavior.
 #

--- a/apache_log_analysis.sh
+++ b/apache_log_analysis.sh
@@ -8,7 +8,8 @@
 #  web server traffic. It reports on top accessed URLs, referrers, user
 #  agents, browser counts, daily accesses, access by time, and recent
 #  accesses and referrers. It excludes requests from IPs listed in
-#  apache_ignore.list, searched in ./etc/, ../etc/ and /etc/cron.config.
+#  apache_ignore.list, searched in <script_dir>/etc/, <script_dir>/../etc/
+#  and /etc/cron.config in that order.
 #  Blog-entry page-view metrics are reported by the separate, independently
 #  deployed apache_blog_analysis.py script; this script does not compute
 #  them, to avoid two scripts implementing the same aggregation.


### PR DESCRIPTION
Pre-release cleanup for v1.7.3. Three low-risk fixes found while reviewing this release cycle's changes. No behavior changes, and per POLICY no executable version bumps (documentation-only edits, plus a dead-code removal with no observable effect).

The release date in `doc/VERSIONS` is intentionally left as `TBD` — not part of this change.

## Changes

**`apache_calculater.py` — repair a broken description sentence**

The Description block contained a leftover sentence fragment starting mid-phrase in lowercase:

```
#  log files and excludes IPs listed in apache_ignore.list, which is searched
```

Since `usage()` prints the header verbatim, this was visible in `-h` output. Rewritten as `It excludes IPs listed in apache_ignore.list, which is searched ...`.

**`apache_log_analysis.sh` — correct the documented ignore-list search order**

The header stated the list was searched in `./etc/, ../etc/ and /etc/cron.config`, but the implementation resolves it via `$(dirname "$0")`. This cycle updated both `apache_calculater.py` and `apache_blog_analysis.py` to `<script_dir>/...` and documented them as matching this script's `dirname "$0"` resolution, which left the referenced script itself as the only one still describing CWD-relative behavior it never had. The header now uses the same `<script_dir>/` wording.

**`apache_blog_analysis.py` — remove the unused `Candidate` namedtuple**

`Candidate` was superseded by `MutableCandidate` and referenced nowhere; the `namedtuple` import existed solely for it and is removed as well.

## Verification

- `./run_tests.sh` — 39 test scripts, 470 cases, all pass (34 skipped; Ruby skipped, RSpec unavailable)
- `test/check_scripts.sh` — 140/140 scripts succeed
- `check_header_doc.py` — no findings
- `find_pycompat.py` — only `test/dummy.py`, as expected
- `sh -n` on all `*.sh` and `cron/bin/*` — clean
- `apache_calculater.py -h` output confirmed to render the corrected description

---
_Generated by [Claude Code](https://claude.ai/code/session_018efhWris55pkesaER33hAg)_