### PR TITLE
Write down the policies scripts follows but never recorded

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ This script will:
 - Run all test files in the `test` directory.
 - Output paths and versions for troubleshooting.
 
+It exits with a non-zero status when any test fails.
+
+A second layer runs nightly from `cron/bin/run_tests`, which drives
+`run_tests.sh` once per configured Python and Ruby version and then applies the
+repository-wide gates: the shell script validation (`test/check_scripts.sh`),
+the header documentation check (`check_header_doc.py -a`), and the
+compatibility check (`find_pycompat.py`). Checks that belong to the repository
+as a whole, rather than to one interpreter version, are wired there instead of
+into `run_tests.sh`.
+
 ---
 
 ## 5. Contribution
@@ -91,6 +101,12 @@ We welcome contributions! Here's how you can help:
 3. Submit a pull request with clear documentation and changes.
 
 Please ensure your code is well-structured and documented.
+
+Every executable carries a structured header block stating what it is, who
+wrote it, how it is driven, and what changed in each version. Read
+[doc/POLICY](doc/POLICY) before adding one: it defines the sections that block
+contains, when a version is bumped, and how configuration files, exit codes,
+and logging are expected to behave.
 
 ### Implementation Policy
 

--- a/check_header_doc.py
+++ b/check_header_doc.py
@@ -39,6 +39,13 @@
 #  - This script does not depend on Git and works in non-repository directories.
 #  - When violations are found in readable files, diagnostic lines are printed.
 #  - Intended to be used as a mandatory quality gate in automated test pipelines.
+#  - This gate is wired into the nightly cron job cron/bin/run_tests, which
+#    invokes it once as 'check_header_doc.py -a --root $SCRIPTS' after the
+#    per-interpreter test runs. It is deliberately not called from
+#    run_tests.sh: the header documentation of a file does not depend on the
+#    Python or Ruby version under test, so running it there would repeat the
+#    same whole-repository scan once per interpreter and report the same
+#    violations several times in one job log.
 #
 #  Example:
 #      python check_header_doc.py -a --root /path/to/repo

--- a/check_reboot.sh
+++ b/check_reboot.sh
@@ -38,7 +38,7 @@
 #      -h, --help:     Show this help and exit.
 #      -v, --version:  Show this help and exit (unified behavior).
 #
-#  Error Conditions:
+#  Exit Status:
 #      0: Success (check completed; see logs for reboot requirement)
 #      1: General Failure
 #    126: Command exists but is not executable

--- a/cron/etc/clamscan.conf
+++ b/cron/etc/clamscan.conf
@@ -1,5 +1,5 @@
 ########################################################################
-# ClamAV Exclude List Configuration
+# clamscan.conf
 #
 #  This file is read by clamscan.sh and passed to ClamAV as --exclude or
 #  --exclude-dir options. Use it to skip directories or files that are
@@ -8,6 +8,9 @@
 #  Rules:
 #  - Blank lines are ignored.
 #  - Lines starting with '#' are treated as comments (leading spaces allowed).
+#  - This file is a list, not shell code. It is read line by line, not
+#    sourced, and each non-comment line is one exclusion entry.
+#  - Do not add a shebang; this file is data and is never executed.
 #  - Add a trailing '/' to a directory path to use --exclude-dir.
 #  - Omit the trailing '/' for file paths or patterns to use --exclude.
 #  - No regex is needed. Each entry will be converted to an anchored

--- a/dashcam_sync.sh
+++ b/dashcam_sync.sh
@@ -28,7 +28,7 @@
 #  - Both source and destination directories must exist and be writable.
 #  - Files are first synced to a 'daily' subdirectory, then moved to a yearly directory.
 #
-#  Error Conditions:
+#  Exit Status:
 #  1. Source or destination directory does not exist.
 #  2. Rsync operation failed.
 #  3. Moving files failed.

--- a/doc/POLICY
+++ b/doc/POLICY
@@ -238,26 +238,43 @@ or additions to this common policy, in order to avoid redundancy.
   that a later change does not quietly undo it.
 
 ### Configuration Files
-- A script that needs site-specific values reads them from a configuration file
-  under `etc/`, named after the script (e.g. `etc/dashcam_sync.conf`), instead
-  of carrying them as constants.
-- Resolve the file relative to the script's own directory and fall back to the
-  parent's `etc/`, so that the script works both inside the repository and from
-  a deployed location: `$SCRIPT_DIR/etc/NAME.conf`, then
-  `$SCRIPT_DIR/../etc/NAME.conf`.
-- A missing configuration file, and a required variable left unset, are both
-  refused before any work starts, each with its own exit status and an
-  `[ERROR]` message naming what is missing.
-- A configuration file is sourced, not executed. It must be POSIX sh
-  compatible, must not carry a shebang, and must not be executable.
-- Each configuration file opens with the same header block used by scripts,
-  stating what sources it, a `Rules` section (blank lines are allowed, lines
-  starting with `#` are comments, POSIX sh compatible, no shebang), and a
-  `Variables` section naming every variable, what it decides, and whether it is
-  required.
+- A script that needs site-specific values reads them from a file under `etc/`,
+  named after the script (e.g. `etc/dashcam_sync.conf`), instead of carrying
+  them as constants.
+- A top-level script resolves the file relative to its own directory and falls
+  back to the parent's `etc/`, so that it works both inside the repository and
+  from a deployed location: `$SCRIPT_DIR/etc/NAME.conf`, then
+  `$SCRIPT_DIR/../etc/NAME.conf`. A `cron/bin/` job reads its deployed path
+  under `/etc/cron.config/` directly, since it only ever runs from
+  `/etc/cron.exec`.
+- A missing file, and a required value left unset, are both refused before any
+  work starts, each with its own exit status and an `[ERROR]` message naming
+  what is missing.
+- Every such file opens with the same header block used by scripts: a title
+  line naming the file, a sentence saying which script reads it and what it
+  decides, and a `Rules` section describing its format. It carries no shebang
+  and is not executable.
+- Two kinds exist, and the `Rules` section says which one the file is.
+
+#### Sourced Configuration Files
+- Sourced by the script, so the file must be POSIX sh compatible. Its `Rules`
+  section states that blank lines are allowed, that lines starting with `#` are
+  comments, that the file must be POSIX sh compatible, and that it carries no
+  shebang because it is sourced rather than executed.
+- A `Variables` section names every variable, what it decides, and whether it
+  is required. A file that also defines a function documents it under
+  `Functions`.
 - The variables a script requires are named in two places that must agree: the
   `Variables` section of the configuration file, and the header of the script
   that reads it.
+
+#### List Files
+- Read line by line rather than sourced, so the file is data and not shell
+  code: `etc/apache_ignore.list` and `cron/etc/clamscan.conf` are of this kind.
+- Its `Rules` section states that blank lines are ignored, that lines starting
+  with `#` are comments, that the file is read line by line rather than
+  sourced, and what one non-comment line means.
+- An `Examples` section shows the accepted line forms.
 
 ### Network Operations
 - Every outbound request carries an explicit timeout. An unattended run must

--- a/doc/POLICY
+++ b/doc/POLICY
@@ -20,6 +20,20 @@ or additions to this common policy, in order to avoid redundancy.
 - Favor predictable behavior and long-term maintainability.
 - Avoid implicit behavior; make control flow, errors, and side effects explicit.
 
+### Repository Layout
+- Top level: the scripts a user runs directly, in Shell Script, Python, and Ruby.
+- `installer/`: setup and installation scripts. They follow the same header,
+  logging, CLI, and exit code rules as the top level, and `test/check_scripts.sh`
+  exercises them through their `-h` option.
+- `cron/bin/`: job scripts deployed as `/etc/cron.exec`.
+  `cron/etc/`: their configuration files, deployed as `/etc/cron.config`.
+- `etc/`: configuration files and data files read by the top-level scripts.
+- `dot_files/`: dot files deployed into a user's home directory.
+- `test/`: the test suite.
+- `doc/`: this policy, the repository version history, and the license texts.
+- Placement says what a file is for, not which rules apply to it. Every
+  executable in the repository follows the Common Policy.
+
 ### Logging and Output
 - Use unified log prefixes: `[INFO]`, `[WARN]`, `[ERROR]`.
 - Informational messages go to standard output.
@@ -40,6 +54,21 @@ or additions to this common policy, in order to avoid redundancy.
   (e.g. `[cron]`, `[admin]`) in the subject line so recipients can easily
   classify, filter, or route messages.
 
+### Credentials and Secrets
+- A credential that authenticates against a remote service is read from a
+  configuration file or from the environment. It is never passed as a command
+  line argument, because a command line is readable by every user of the host.
+- A credential is never logged and never quoted in an error message.
+  Report it as present or absent.
+- No configuration file under `etc/` carries a credential. Those files are
+  committed with real values, so a setting that must stay secret does not
+  belong in them.
+- Exception: a secret that the script itself generates for local use, that
+  authenticates nothing remote, and that exists in order to be handed to the
+  operator, may be passed to a local command and printed. `send_files.sh`
+  generates an archive password this way; the password is stored locally and
+  is never sent together with the archive.
+
 ### Control Flow Rules
 - Use explicit termination (`exit`, `sys.exit`, `exit()`) **only for abnormal or forced termination**.
 - Normal execution paths must return normally and propagate status explicitly.
@@ -54,6 +83,15 @@ or additions to this common policy, in order to avoid redundancy.
 - Invalid or unsupported options must result in usage output.
 - Exit code may be `1` (error) or `0` (non-error usage display),
 - depending on the tool's design, but must be consistent and documented.
+
+#### Recommended Option Names
+- The following names are recommendations, not requirements. A script that has
+  a reason to differ may differ; a script that has none should reuse the
+  established name rather than invent a synonym for it.
+  - `--dry-run`: report what would be done, and change nothing.
+  - `-q`, `--quiet`: suppress non-error messages.
+  - `--force`: process every matched entry, skipping the checks that normally
+    narrow the work.
 
 ### Error Handling and Exit Codes
 - Detect command failures and unmet prerequisites early.
@@ -85,9 +123,34 @@ or additions to this common policy, in order to avoid redundancy.
 > may be used, but must be explicitly documented in the script or program header.
 
 ### Documentation and Versioning
-- Every executable must contain a structured header with:
-  `Description`, `Usage`, `Options`, `Requirements`, `Version History`
-  (in this order).
+- Every executable must contain a structured header block, delimited above and
+  below by a separator line of 20 or more `#` characters.
+- The header contains the following sections, in this order:
+  `Description`, the standard `Author`, `Source Code`, `License`, `Contact`
+  block, `Usage`, `Options` (scripts that take options only), `Requirements`,
+  `Exit Status` (scripts that can end with more than one status),
+  `Version History`.
+- `Description` says what the script is, and the identifying block follows it
+  because it says whose it is. `Usage`, `Options`, and `Exit Status` say how
+  the script is driven, and come after both.
+- Optional sections such as `Notes`, `Example`, `Features`, `Design Notes`, and
+  the configuration file requirements of a script that reads one, are placed
+  where they read best between `Usage` and `Version History`.
+- `Requirements` names the language version first (`Python Version: 3.1 or
+  later`, `Ruby Version: 2.0 or later`), then what the script needs beyond it.
+  A shell script may omit the section: the commands it needs are already
+  declared by its `check_commands` call, and repeating them in the header only
+  creates a second list to keep in sync.
+- Name the section that lists exit codes `Exit Status`. Do not use
+  `Error Conditions`, `Exit Codes`, or any other synonym.
+- Every line inside the header block is a comment line. A line that would be
+  blank is written as a bare `#`, never as an empty line and never as `##`.
+  `check_header_doc.py` enforces this.
+- Header indentation:
+  - Title line: 1 space after `#`
+  - Other lines: 2 spaces after `#`
+- `Version History` entries are written as `vX.Y YYYY-MM-DD`, newest first,
+  each followed by an indented description of what changed.
 - "Test Cases" section must NOT be included in production scripts.
 - "Test Cases" must be defined only in dedicated test code (e.g., test/, spec/).
 - Documentation must be updated in sync with behavior changes.
@@ -116,11 +179,28 @@ or additions to this common policy, in order to avoid redundancy.
   `v1.9` -> `v2.0`, `v2.9` -> `v3.0`).
 - Do not continue `minor` past `9` as in standard semantic versioning
   (e.g. do not use `v1.10`, `v1.11`, ...).
+- A change that is not backward compatible bumps `major` and resets `minor` to
+  `0`, whatever `minor` currently stands at (e.g. `v2.4` -> `v3.0`). Reaching
+  `10` is not the only reason to raise `major`.
+- Removing or renaming an option, changing what an existing argument means,
+  changing a default so that an unchanged invocation does something else, and
+  changing how a path or a configuration value is resolved are all
+  incompatible changes.
 
 #### Repository Versioning
 - Repository release versions are independent of individual executable versions.
 - Record repository release versions in `doc/VERSIONS` and use the same versions for Git tags.
 - Repository release versions may use a three-level `major.minor.patch` scheme.
+- A release that carries an incompatible change to any script takes the next
+  `major`, on the same reasoning as an executable version.
+- Work that is not released yet takes no version of its own: it belongs to the
+  entry already standing at the top of `doc/VERSIONS`.
+- An unreleased entry carries `(Release Date: TBD)`, and its version number
+  stays provisional until it ships. An entry opened as
+  `v1.7.3 (Release Date: TBD)` is released as `v2.0` when what accumulated in
+  it turns out to be incompatible.
+- Replacing `TBD` with the actual release date is the release itself, not a
+  change to record in the entry.
 
 #### doc/VERSIONS Structure
 - `doc/VERSIONS` must read as a version-level summary of overall changes, not
@@ -133,16 +213,68 @@ or additions to this common policy, in order to avoid redundancy.
     reads as a coherent, reviewable whole rather than an unordered sequence
     of unrelated lines.
 
-- Header indentation:
-  - Title line: 1 space after `#`
-  - Other lines: 2 spaces after `#`
+- Each entry opens with a heading of the form `vX.Y.Z (YYYY-MM-DD)`, or
+  `vX.Y.Z (Release Date: TBD)` while it is unreleased, underlined with `-`
+  characters, followed by one `-` bullet per change.
 - Encoding rules:
   - Use UTF-8 by default.
+
+### License
+- The repository is dual licensed under the GPL version 3 or the LGPL version 3,
+  at the user's option. The full texts live in `doc/LICENSE`, `doc/COPYING`,
+  and `doc/COPYING.LESSER`.
+- Every script header repeats the license line of the standard identifying
+  block, so that a file read on its own still states its terms:
+  `License: The GPL version 3, or LGPL version 3 (Dual License).`
+- Add a dependency only when its license is compatible with that choice.
 
 ### Comments and Language
 - Comments must be written in **English** only.
 - Comments must be imperative, concise, and action-oriented
   (e.g. `# Validate input`, `# Initialize environment`).
+- A comment says why, not what. Where a decision looks arbitrary, such as a
+  portable substitute for a construct that some implementation gets wrong, a
+  retention period, or a hard-coded fallback, the comment gives the reason, so
+  that a later change does not quietly undo it.
+
+### Configuration Files
+- A script that needs site-specific values reads them from a configuration file
+  under `etc/`, named after the script (e.g. `etc/dashcam_sync.conf`), instead
+  of carrying them as constants.
+- Resolve the file relative to the script's own directory and fall back to the
+  parent's `etc/`, so that the script works both inside the repository and from
+  a deployed location: `$SCRIPT_DIR/etc/NAME.conf`, then
+  `$SCRIPT_DIR/../etc/NAME.conf`.
+- A missing configuration file, and a required variable left unset, are both
+  refused before any work starts, each with its own exit status and an
+  `[ERROR]` message naming what is missing.
+- A configuration file is sourced, not executed. It must be POSIX sh
+  compatible, must not carry a shebang, and must not be executable.
+- Each configuration file opens with the same header block used by scripts,
+  stating what sources it, a `Rules` section (blank lines are allowed, lines
+  starting with `#` are comments, POSIX sh compatible, no shebang), and a
+  `Variables` section naming every variable, what it decides, and whether it is
+  required.
+- The variables a script requires are named in two places that must agree: the
+  `Variables` section of the configuration file, and the header of the script
+  that reads it.
+
+### Network Operations
+- Every outbound request carries an explicit timeout. An unattended run must
+  not hang until the next one starts.
+- Exception: a script whose primary use is manual, run in the foreground by a
+  person who can see it hang and interrupt it, may leave the timeout to the
+  caller.
+- Report an unreachable target as a failure, naming the target.
+
+### Destructive Operations
+- The following are recommendations. A script that has a reason to skip a check
+  may skip it, but should say why in a comment.
+- Validate existence, type, and permissions before a destructive operation, and
+  validate a path before modifying it.
+- Offer `--dry-run` on a script that renames, moves, or deletes.
+- Do not widen the scope of a deletion in order to recover from unexpected
+  input.
 
 ### Testing and Operation
 - Test code must include a "Test Cases" section placed immediately before "Version History".
@@ -150,6 +282,26 @@ or additions to this common policy, in order to avoid redundancy.
 - Assume cron execution by default; define `PATH` and required environment variables explicitly.
 - Validation must include syntax checks and exit-code verification.
 - In plugin-based systems, loaders must collect and propagate plugin return codes.
+- `run_tests.sh` is the entry point of the suite. It runs the Python tests and
+  the Ruby specs under `test/` for one interpreter pair, reports the counts,
+  and exits non-zero when any of them fails.
+- The nightly `cron/bin/run_tests` job is the second layer. It drives
+  `run_tests.sh` once per configured Python and Ruby version, then runs
+  `test/check_scripts.sh` (which exercises every shell script through `-h`),
+  `check_header_doc.py -a`, and the `find_pycompat.py` compatibility check
+  across the repository, and mails the result to the administrator.
+- A gate that belongs to the repository as a whole, rather than to one
+  interpreter version, is wired into the cron job rather than into
+  `run_tests.sh`, so that it runs once per night instead of once per
+  interpreter.
+- A test must not perform network access. Replace the fetch with a stub and
+  feed the code fixed input instead.
+- A test writes nothing outside a temporary directory, and needs no credential
+  and no reachable host.
+- A fix for a defect arrives together with the test that fails without it.
+- A script a cron job runs must be safe to run twice. A second run over the
+  same input replaces or skips what the first one produced, rather than
+  duplicating it or refusing to start.
 
 ---
 
@@ -164,6 +316,32 @@ or additions to this common policy, in order to avoid redundancy.
 
 ### Dependency and Environment Checks
 - Validate required commands and environment variables at startup.
+- Declare the commands a script needs with the following POSIX-compliant
+  helper, which maps a missing command to `127` and a present but
+  non-executable one to `126`:
+
+```sh
+check_commands() {
+    for cmd in "$@"; do
+        cmd_path=$(command -v "$cmd" 2>/dev/null)
+        if [ -z "$cmd_path" ]; then
+            echo "[ERROR] Command '$cmd' is not installed. Please install $cmd and try again." >&2
+            exit 127
+        elif [ ! -x "$cmd_path" ]; then
+            echo "[ERROR] Command '$cmd' is not executable. Please check the permissions." >&2
+            exit 126
+        fi
+    done
+}
+```
+
+- Call it once, before any work begins, listing the commands the script
+  actually runs.
+- A script that requires elevated privileges checks them with `check_sudo`,
+  which runs `sudo -v` and refuses the run when it fails.
+- A script that has `check_sudo` does not also list `sudo` in `check_commands`:
+  `sudo -v` already establishes that `sudo` is present and usable, so the
+  second check adds nothing.
 - For network operations, verify connectivity before execution.
 
 ### Logging Style
@@ -193,7 +371,9 @@ log_info_time() {
 
 ### I/O and Side Effects
 - Respect existing temporary file logic and directory structures.
-- Avoid destructive overwrites; validate paths before modification.
+- Follow the destructive operation recommendations of the Common Policy; in
+  particular, avoid destructive overwrites and validate paths before
+  modification.
 - Align log writing and rotation with system log policy.
 
 ---
@@ -229,8 +409,18 @@ log_info_time() {
 
 ### Dependencies and I/O
 - Depend only on the standard library.
-- Implement manual PATH search if command lookup is required.
+- Implement manual PATH search if command lookup is required, and exit `127`
+  when the command is not found, matching the shell helper.
 - Always use `encoding="utf-8"` for file operations.
+
+### Docstrings
+- Every function and class carries a docstring stating what the call does or
+  returns.
+- A one-line docstring stays on one line, with a space inside each pair of
+  quotes: `""" Return True when the path is inside the target directory. """`.
+- A longer docstring opens on the line after the quotes.
+- Modules that still use the tight form (`"""Do the thing."""`) are normalized
+  when they are next edited for another reason, not in bulk.
 
 ### Testing
 - Store tests in `test/` as `FILENAME_test.py`.
@@ -268,7 +458,7 @@ log_info_time() {
 - Use `Open3.capture3` for external command execution when stdout, stderr, or exit status must be inspected.
 - `system` may be used only when command output is intentionally ignored and success or failure alone is sufficient.
 - Always specify UTF-8 encoding for file operations.
-- Validate file existence, type, and permissions before destructive operations.
+- Follow the destructive operation recommendations of the Common Policy.
 
 ### Testing
 - Store tests in `test/` using RSpec as `FILENAME_test.rb`.

--- a/doc/POLICY
+++ b/doc/POLICY
@@ -201,6 +201,8 @@ or additions to this common policy, in order to avoid redundancy.
   it turns out to be incompatible.
 - Replacing `TBD` with the actual release date is the release itself, not a
   change to record in the entry.
+- A documentation-only change takes no `doc/VERSIONS` entry, unless its scale
+  makes it worth one line saying so.
 
 #### doc/VERSIONS Structure
 - `doc/VERSIONS` must read as a version-level summary of overall changes, not

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -3,23 +3,7 @@ scripts Repository Version History
 
 v2.0.1 (Release Date: TBD)
 --------------------------
-- Document the structured header block as it is actually written, including the
-  Author/Source Code/License/Contact block and the optional sections.
-- Unify the header section that lists exit codes under the name Exit Status.
-- Record the repository layout, the license policy, and the etc/ configuration
-  file conventions in doc/POLICY, distinguishing sourced configuration files
-  from list files that are read line by line.
-- State in clamscan.conf and apache_ignore.list that they are lists rather than
-  shell code, and name clamscan.conf after its file name like the others.
-- Document check_commands as the standard dependency check, and note that a
-  script with check_sudo need not also check sudo itself.
-- State that an incompatible change bumps the major version regardless of the
-  minor rollover rule, for both executables and repository releases.
-- Record the (Release Date: TBD) workflow and the doc/VERSIONS entry format.
-- Add credential handling, network timeout, re-run safety, and test isolation
-  policies, each with the exceptions the repository actually relies on.
-- Describe the two-layer test structure and note in check_header_doc.py why its
-  gate belongs to the nightly cron job rather than to run_tests.sh.
+- Large-scale documentation revision, recorded here as an exception.
 
 v2.0 (2026-07-31)
 -----------------

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -1,6 +1,23 @@
 scripts Repository Version History
 ==================================
 
+v2.0.1 (Release Date: TBD)
+--------------------------
+- Document the structured header block as it is actually written, including the
+  Author/Source Code/License/Contact block and the optional sections.
+- Unify the header section that lists exit codes under the name Exit Status.
+- Record the repository layout, the license policy, and the etc/ configuration
+  file conventions in doc/POLICY.
+- Document check_commands as the standard dependency check, and note that a
+  script with check_sudo need not also check sudo itself.
+- State that an incompatible change bumps the major version regardless of the
+  minor rollover rule, for both executables and repository releases.
+- Record the (Release Date: TBD) workflow and the doc/VERSIONS entry format.
+- Add credential handling, network timeout, re-run safety, and test isolation
+  policies, each with the exceptions the repository actually relies on.
+- Describe the two-layer test structure and note in check_header_doc.py why its
+  gate belongs to the nightly cron job rather than to run_tests.sh.
+
 v2.0 (2026-07-31)
 -----------------
 - Preserve sd_extract.sh failed file tracking across its find pipeline subshell.

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -7,7 +7,10 @@ v2.0.1 (Release Date: TBD)
   Author/Source Code/License/Contact block and the optional sections.
 - Unify the header section that lists exit codes under the name Exit Status.
 - Record the repository layout, the license policy, and the etc/ configuration
-  file conventions in doc/POLICY.
+  file conventions in doc/POLICY, distinguishing sourced configuration files
+  from list files that are read line by line.
+- State in clamscan.conf and apache_ignore.list that they are lists rather than
+  shell code, and name clamscan.conf after its file name like the others.
 - Document check_commands as the standard dependency check, and note that a
   script with check_sudo need not also check sudo itself.
 - State that an incompatible change bumps the major version regardless of the

--- a/etc/apache_ignore.list
+++ b/etc/apache_ignore.list
@@ -7,7 +7,9 @@
 #  Rules:
 #  - Blank lines are allowed.
 #  - Lines starting with '#' are comments.
-#  - Each non-comment line must contain a single IP address.
+#  - This file is a list, not shell code. It is read line by line, not
+#    sourced, and each non-comment line must contain a single IP address.
+#  - Do not add a shebang; this file is data and is never executed.
 #
 #  Examples:
 #    192.168.1.1

--- a/find_range.py
+++ b/find_range.py
@@ -55,7 +55,7 @@
 #  - Either the start datetime '-s' or the end datetime '-e' can be specified independently for
 #    more flexible searches, both expected to be in UTC unless '--localtime' is used.
 #
-#  Error Conditions and Return Codes:
+#  Exit Status:
 #  0: Success
 #  1: Specified path does not exist or no arguments provided
 #  2: Incorrect datetime format or mutually exclusive options '-f' and '-fp' were used together

--- a/get-device.sh
+++ b/get-device.sh
@@ -37,16 +37,16 @@
 #      get-device.sh ~/mnt/disk1
 #      => /dev/sdc
 #
-#  Error Conditions:
+#  Requirements:
+#    - Linux, findmnt(8), lsblk(8), sed(1), head(1), tail(1), awk(1)
+#
+#  Exit Status:
 #  0. Success.
 #  1. General failure.
 #  2. Mountpoint or source not found.
 #  3. Source is not a block device.
 #  126. Required command is not executable.
 #  127. Required command is not installed.
-#
-#  Requirements:
-#    - Linux, findmnt(8), lsblk(8), sed(1), head(1), tail(1), awk(1)
 #
 #  Version History:
 #  v1.2 2026-07-11

--- a/get-mountpoint.sh
+++ b/get-mountpoint.sh
@@ -39,16 +39,16 @@
 #      get-mountpoint.sh /dev/sde
 #      => /            # when the deepest descendant mounts "/"
 #
-#  Error Conditions:
+#  Requirements:
+#    - Linux, findmnt(8), lsblk(8), awk(1), mktemp(1)
+#
+#  Exit Status:
 #  0. Success.
 #  1. General failure.
 #  2. Device not found or not mounted.
 #  3. Path is not a block device.
 #  126. Required command is not executable.
 #  127. Required command is not installed.
-#
-#  Requirements:
-#    - Linux, findmnt(8), lsblk(8), awk(1), mktemp(1)
 #
 #  Version History:
 #  v1.3 2026-07-11

--- a/get-serial.sh
+++ b/get-serial.sh
@@ -24,7 +24,10 @@
 #    Compose with get-device.sh:
 #      get-serial.sh "$(get-device.sh ~/mnt/disk1)"
 #
-#  Exit Codes:
+#  Requirements:
+#    - Linux, udevadm(8), lsblk(8), sed(1), head(1), awk(1)
+#
+#  Exit Status:
 #  0. Success.
 #  1. General failure.
 #  2. Invalid argument or device not found.
@@ -32,9 +35,6 @@
 #  4. Serial number could not be determined.
 #  126. Required command is not executable.
 #  127. Required command is not installed.
-#
-#  Requirements:
-#    - Linux, udevadm(8), lsblk(8), sed(1), head(1), awk(1)
 #
 #  Version History:
 #  v1.3 2026-07-11

--- a/git-archive-repo.sh
+++ b/git-archive-repo.sh
@@ -33,7 +33,7 @@
 #  - Each archive stores the source directory by its basename, not by its
 #    absolute path.
 #
-#  Error Conditions:
+#  Exit Status:
 #  1. Source directory not found.
 #  2. Archive parent directory not found.
 #  3. Failed to remove existing archive.

--- a/gpx_sync.sh
+++ b/gpx_sync.sh
@@ -42,7 +42,7 @@
 #  - Remote synchronization is attempted only if the remote server is reachable.
 #  - The permissions argument must be a 3-digit or 4-digit octal number. Any other format will result in an error.
 #
-#  Error Conditions:
+#  Exit Status:
 #  1. No GPX files found in the specified temporary directory.
 #  2. Failed to create the destination directory for copying files.
 #  3. Configuration file not found.

--- a/insta_sync.sh
+++ b/insta_sync.sh
@@ -42,7 +42,7 @@
 #  - Local backup directory must exist prior to running this script.
 #  - Remote sync is attempted only if the remote server is reachable.
 #
-#  Error Conditions:
+#  Exit Status:
 #  1. No argument provided.
 #  2. Instagram account directory does not exist.
 #  3. Local backup directory does not exist.

--- a/insta_update.sh
+++ b/insta_update.sh
@@ -56,7 +56,7 @@
 #  - Lines starting with '#' in 'exclude_accounts.txt'
 #    and 'include_accounts.txt' are treated as comments and ignored.
 #
-#  Error Conditions:
+#  Exit Status:
 #  1. Configuration file not found or incomplete: The script will terminate if
 #     it cannot find 'insta_update.conf' or if any required variables are unset.
 #  2. Unknown command-line options: If any unrecognized options are provided,

--- a/installer/debian_apt.sh
+++ b/installer/debian_apt.sh
@@ -70,7 +70,7 @@
 #      * calendar: BSD "calendar" program
 #      * bsdextrautils: col/colcrt/colrm/column/hd/hexdump/look/ul/write
 #
-#  Error Conditions:
+#  Exit Status:
 #  The script checks if each package is already installed to prevent unnecessary reinstallation.
 #  However, it does not explicitly handle errors such as package unavailability or network issues.
 #  These should be resolved based on the output of the apt-get command.

--- a/installer/debian_desktop_apt.sh
+++ b/installer/debian_desktop_apt.sh
@@ -53,7 +53,7 @@
 #  - Internet connectivity is required for package downloads.
 #  - Review and modify the package lists as needed for your setup.
 #
-#  Error Conditions:
+#  Exit Status:
 #  The script checks if each package is already installed to prevent unnecessary reinstallation.
 #  However, it does not explicitly handle errors such as package unavailability or network issues.
 #  These should be resolved based on the output of the apt-get command.

--- a/installer/debian_desktop_setup.sh
+++ b/installer/debian_desktop_setup.sh
@@ -30,7 +30,7 @@
 #      $HOME/scripts/installer/debian_gnome_flashback_setup.sh
 #      $HOME/scripts/installer/debian_gnome_setup.sh
 #
-#  Error Conditions:
+#  Exit Status:
 #  - Non-Linux system (checked and enforced in the invoked setup scripts, not in this launcher).
 #  - Missing $HOME/scripts directory.
 #  - Target setup script not found or not runnable.

--- a/installer/debian_env.sh
+++ b/installer/debian_env.sh
@@ -33,7 +33,7 @@
 #  - Internet connectivity is required for package updates.
 #  - Review and modify configurations as needed before execution.
 #
-#  Error Conditions:
+#  Exit Status:
 #  - If apt-get is unavailable, the script exits with an error.
 #  - If required commands are missing, execution is halted.
 #  - Errors from underlying scripts should be resolved based on their output.

--- a/installer/debian_gnome_flashback_setup.sh
+++ b/installer/debian_gnome_flashback_setup.sh
@@ -40,7 +40,7 @@
 #  - SCRIPTS environment variable must point to the root of this repo to load
 #    keybinding files and terminal profile.
 #
-#  Error Conditions:
+#  Exit Status:
 #  - If required commands are missing, execution is halted.
 #  - If DBus session is not available, execution is halted.
 #

--- a/installer/debian_gnome_setup.sh
+++ b/installer/debian_gnome_setup.sh
@@ -36,7 +36,7 @@
 #      DISABLE_SERVICES: "yes" to apply service mask steps (default: yes)
 #      If xfce4-terminal is installed, this script installs its terminal profile.
 #
-#  Error Conditions:
+#  Exit Status:
 #  - If required commands are missing, execution is halted.
 #  - If DBus session is not available, execution is halted.
 #

--- a/installer/debian_init.sh
+++ b/installer/debian_init.sh
@@ -46,7 +46,7 @@
 #    runs only when a desktop option is specified to avoid accidental GUI
 #    stack installation on server hosts.
 #
-#  Error Conditions:
+#  Exit Status:
 #  - If the system is not Debian-based, the script exits with an error.
 #  - If the required directory does not exist, an error message is displayed.
 #  - Errors from underlying scripts should be resolved based on their output.

--- a/installer/debian_setup.sh
+++ b/installer/debian_setup.sh
@@ -59,7 +59,7 @@
 #  - Internet connectivity is required for downloading dotfiles and system utilities.
 #  - Review and modify the installation scripts as needed before execution.
 #
-#  Error Conditions:
+#  Exit Status:
 #  - If the system is not Linux, the script exits with an error.
 #  - If required commands are missing, the script exits with an error.
 #  - If the user lacks sudo privileges, execution is halted.

--- a/installer/debian_xfce_setup.sh
+++ b/installer/debian_xfce_setup.sh
@@ -41,7 +41,7 @@
 #  - SCRIPTS environment variable must point to the root of this repo to load
 #    terminal profile and autostart entries.
 #
-#  Error Conditions:
+#  Exit Status:
 #  - If required commands are missing, execution is halted.
 #  - If DBus session is not available, execution is halted.
 #

--- a/installer/disable_freshclam_syslog.sh
+++ b/installer/disable_freshclam_syslog.sh
@@ -22,7 +22,7 @@
 #  - This script has no effect on journal output unless forwarded to syslog.
 #  - Use `journalctl -u clamav-freshclam` to view remaining logs.
 #
-#  Error Conditions:
+#  Exit Status:
 #  1. General failure.
 #  2. Failed to create override directory.
 #  3. Failed to write override file.

--- a/installer/install_brews.sh
+++ b/installer/install_brews.sh
@@ -22,7 +22,7 @@
 #  Requirements:
 #  - Homebrew must be installed prior to executing this script.
 #
-#  Exit Codes:
+#  Exit Status:
 #  0: Success - All packages were installed successfully.
 #  1: Error - Homebrew is not installed or a critical issue occurred.
 #

--- a/installer/install_conda.sh
+++ b/installer/install_conda.sh
@@ -24,7 +24,7 @@
 #  Requirements:
 #  - Conda must be installed prior to executing this script.
 #
-#  Exit Codes:
+#  Exit Status:
 #  0: Success - All libraries were installed successfully.
 #  1: Error - A critical issue occurred (e.g., missing dependencies).
 #

--- a/installer/install_gems.sh
+++ b/installer/install_gems.sh
@@ -25,7 +25,7 @@
 #  Requirements:
 #  - Ruby and gem must be installed prior to executing this script.
 #
-#  Exit Codes:
+#  Exit Status:
 #  0: Success - All gems were installed successfully.
 #  1: Error - A critical issue occurred (e.g., missing dependencies).
 #

--- a/installer/install_munin.sh
+++ b/installer/install_munin.sh
@@ -24,7 +24,7 @@
 #  - Internet connectivity is required for package installation.
 #  - Ensure that $SCRIPTS is set correctly before execution.
 #
-#  Error Conditions:
+#  Exit Status:
 #  - If the system is not Linux, the script exits with an error.
 #  - If required commands are missing, the script exits with an error.
 #  - Errors from underlying commands should be resolved based on their output.

--- a/installer/install_pip.sh
+++ b/installer/install_pip.sh
@@ -28,7 +28,7 @@
 #  Requirements:
 #  - pip must be installed prior to executing this script.
 #
-#  Exit Codes:
+#  Exit Status:
 #  0: Success - All libraries were installed successfully.
 #  1: Error - A critical issue occurred (e.g., missing dependencies).
 #

--- a/installer/setup_iptables.sh
+++ b/installer/setup_iptables.sh
@@ -24,7 +24,7 @@
 #  - Will not overwrite /etc/iptables/rules.v4 if it already exists.
 #  - Designed for Debian and Ubuntu systems using iptables.
 #
-#  Error Conditions:
+#  Exit Status:
 #  - Exits if SCRIPTS is not set.
 #  - Exits if required commands are missing.
 #  - Exits if not running on Linux.

--- a/installer/setup_rsyslog_logrotate.sh
+++ b/installer/setup_rsyslog_logrotate.sh
@@ -99,7 +99,7 @@
 #    - Commands: sudo, awk, cp, cmp, grep, cat, rm, chown, chmod,
 #      mkdir, systemctl, uname
 #
-#  Error Conditions:
+#  Exit Status:
 #  0. Success.
 #  1. General failure. (OS check, sudo, file missing, awk failure, etc.)
 #  126. Required command(s) not executable.

--- a/installer/setup_tune2fs.sh
+++ b/installer/setup_tune2fs.sh
@@ -24,7 +24,7 @@
 #  - Ensure that tune2fs is installed before execution.
 #  - Modifications apply to system partitions; review configurations beforehand.
 #
-#  Error Conditions:
+#  Exit Status:
 #  - If the system is not Linux, the script exits with an error.
 #  - If required commands are missing, the script exits with an error.
 #  - If no applicable devices are found, execution halts.

--- a/sd_extract.sh
+++ b/sd_extract.sh
@@ -34,7 +34,7 @@
 #  - Run this script with sufficient permissions to access source directories and write to the destination directory.
 #  - The permissions argument must be a 3-digit octal number. Any other format will result in an error.
 #
-#  Error Conditions:
+#  Exit Status:
 #  1. No matching files found to copy.
 #  2. Destination directory does not exist.
 #  5. Configuration file not found.

--- a/send_files.sh
+++ b/send_files.sh
@@ -44,7 +44,7 @@
 #  - No password is sent in the email — it is stored locally only.
 #  - To use 7z, the `7z` command must be available in PATH.
 #
-#  Error Conditions:
+#  Exit Status:
 #  1. General failure (e.g., password generation or ZIP failure).
 #  2. Configuration file not found.
 #  3. Source directory does not exist.

--- a/server_alive_check.sh
+++ b/server_alive_check.sh
@@ -69,7 +69,7 @@
 #  - Ensure the monitored servers regularly generate _is_alive files to avoid false alerts.
 #  - Use appropriate permissions and ownership for the monitored directory.
 #
-#  Error Conditions:
+#  Exit Status:
 #  1. One or more regular hosts are stale.
 #  2. No '_is_alive' files found.
 #  3. Source directory does not exist.

--- a/tcmount.py
+++ b/tcmount.py
@@ -82,7 +82,7 @@
 #  This change replaces the legacy behavior (`sudo truecrypt -d ~/mnt/<target>`)
 #  which could fail when the logical path did not match the actual mountpoint.
 #
-#  Note on Custom Return Codes:
+#  Exit Status:
 #  This script uses custom return codes to indicate specific error conditions:
 #  - 0: Success. The operation completed without any errors.
 #  - 1: Neither TrueCrypt nor VeraCrypt is installed. The script requires one of them to be installed to function.


### PR DESCRIPTION
Carry the documentation granularity of `id774/ai-digest` and `id774/sizu-writer` back into this repository. Those two repositories recently wrote down the policies they had been following silently; this applies the same inspection in the other direction, to the repository their policy was derived from.

Documentation only. Outside `doc/POLICY`, `doc/VERSIONS`, and `README.md`, every changed line is inside a header comment block — the diff contains no code changes, so no executable version is bumped.

## Recorded what the repository already does

- **The structured header as it is actually written.** The previous rule listed five sections; the real header also carries the `Author` / `Source Code` / `License` / `Contact` block, which is present in 92 of 92 top-level scripts, plus optional sections such as `Notes`, `Example`, and `Design Notes`. The `vX.Y YYYY-MM-DD` ordering and the "a blank line inside the header is written as a bare `#`" rule that `check_header_doc.py` enforces are recorded as well.
- **The repository layout**: what `installer/`, `cron/bin/`, `cron/etc/`, `etc/`, `dot_files/`, `test/`, and `doc/` hold, and that placement does not change which rules apply.
- **The dual license**, and that every header repeats its license line.
- **The `etc/` configuration file conventions**: naming, the `$SCRIPT_DIR/etc` → `../etc` resolution used by top-level scripts, the deployed `/etc/cron.config/` path used by `cron/bin/` jobs, and the refusal of a missing file or an unset required value. Sourced configuration files and list files are documented separately, since only the former are POSIX sh.
- **`check_commands` as the standard dependency check**, quoted verbatim like `log_info_time` already was. It appears in 111 shell scripts and maps a missing command to `127` and a non-executable one to `126`. A script that has `check_sudo` does not also list `sudo`, since `sudo -v` already establishes both.
- **The `(Release Date: TBD)` workflow** and the `doc/VERSIONS` entry format.

## Corrected what the policy got wrong

- **An incompatible change bumps the major version** whatever the minor currently stands at. Commit 1b983ff raised eleven scripts this way (`v2.4` → `v3.0`), and `v1.7.3 (Release Date: TBD)` shipped as `v2.0`, but the documented minor-rollover rule alone could not account for either.
- **`Requirements` may be omitted by a shell script**, whose commands are already declared by its `check_commands` call. The section was documented as mandatory while 35 of 92 scripts, all shell, do without it.
- The `Header indentation` bullets sat under `doc/VERSIONS Structure` although they describe script headers; they now sit with the header rules.

## Added, each with the exception the repository relies on

- **Credentials**: never a command line argument, never logged. Exception for a secret the script generates for local use and hands to the operator, as `send_files.sh` does with a single-use archive password.
- **Network timeouts**: required, because an unattended run must not hang until the next one starts. Exception for a script whose primary use is manual and interruptible.
- **Destructive operations**: written as recommendations rather than rules, so a script with a reason to skip a check may skip it and say why. This also lifts the validation rule that previously existed only in the Ruby section.
- **Tests**: no network access, nothing written outside a temporary directory, and a defect fix arrives with the test that fails without it. The two-layer structure is described — `run_tests.sh` per interpreter pair, and the nightly `cron/bin/run_tests` for the repository-wide gates.
- **Re-run safety** for a script a cron job runs.
- **Recommended option names** (`--dry-run`, `-q`/`--quiet`, `--force`), and the rule that a comment says why rather than what.

## Header changes

`Error Conditions` (26), `Exit Codes` (5), and two prose variants are unified as **`Exit Status`** across 33 files. In `get-device.sh`, `get-mountpoint.sh`, and `get-serial.sh` the section moved after `Requirements`, matching the other eight scripts that carry both.

`check_header_doc.py` now records in its own header why its gate belongs to the nightly cron job rather than to `run_tests.sh`: the header documentation of a file does not depend on the interpreter under test, so running it there would repeat the same whole-repository scan once per interpreter.

`cron/etc/clamscan.conf` and `etc/apache_ignore.list` now state that they are lists read line by line rather than shell code, and `clamscan.conf` is named after its file name like every other file under `etc/`.

## Verification

| Gate | Result |
| --- | --- |
| `check_header_doc.py -a --root .` | exit 0 |
| `test/check_scripts.sh` | 140 / 140 |
| `run_tests.sh` (Python) | 473 tests passed |
| `find_pycompat.py` | no issues outside `test/dummy.py` |

Ruby specs were not run: RSpec is unavailable in the environment this was prepared in.

---
_Generated by [Claude Code](https://claude.ai/code/session_016jquRspnzw9r48PALF518Q)_