### PR TITLE
Add document file naming rules and .gitattributes configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Markdown documents, including the fixed names that carry no extension.
+# Each path is named on its own: a glob would catch the `#` comment lines of
+# the scripts and the configuration files.
+*.md        diff=markdown
+doc/POLICY  diff=markdown linguist-language=Markdown
+doc/LICENSE diff=markdown linguist-language=Markdown
+
+# doc/VERSIONS is underlined plain text, not Markdown. With diff=markdown its
+# hunk headers lose the version line they now carry. doc/COPYING and
+# doc/COPYING.LESSER are the licence texts.

--- a/doc/POLICY
+++ b/doc/POLICY
@@ -222,17 +222,22 @@ or additions to this common policy, in order to avoid redundancy.
   - Use UTF-8 by default.
 
 #### Document File Naming
-- A document written in Markdown is named with a `.md` extension, except for
-  the fixed names below.
-- `doc/POLICY`, `doc/VERSIONS`, `doc/LICENSE`, `doc/COPYING`, and
-  `doc/COPYING.LESSER` carry no extension. They are the fixed document names
-  shared with the author's other repositories, found by name rather than by
-  extension. A new repository creates them under the same names.
-- Every other document is named for what it holds and takes `.md`.
+- A document written in Markdown takes a `.md` extension when it is newly
+  created. This holds for the documents under `doc/` as well: a repository
+  created from now on names its policy `doc/POLICY.md`.
+- The licence files are the exception. `COPYING`, `COPYING.LESSER`, and
+  `LICENSE` keep the extensionless names by which they are recognised, whether
+  they are new or not.
+- A document that is not Markdown takes no extension, or `.txt`.
 - An existing document is never renamed to add or change an extension. A path
   here is a public URL that the README, the other repositories, and pages
   outside them link to. Renaming breaks those links, and the ones outside
   cannot be found or repaired.
+- `doc/POLICY` and `doc/VERSIONS` therefore keep their names here. The same
+  document is `POLICY` in this repository and `POLICY.md` in one started later,
+  and that is the intended result. The rule applies at creation, and naming
+  that matches across repositories is not a goal that outranks a published path
+  staying where it is.
 - Rename only when the current name causes an actual failure, and only after
   examining the references to it. Being shown as plain text on GitHub is not a
   failure: `doc/POLICY` is Markdown that GitHub does not render, and that is
@@ -244,10 +249,13 @@ or additions to this common policy, in order to avoid redundancy.
   `doc/POLICY` and `doc/LICENSE` also take `linguist-language=Markdown`, which
   gives them Markdown highlighting on GitHub. No attribute makes GitHub render
   them.
+- A document created with `.md` is covered by the `*.md` line and needs no
+  entry of its own.
 - `doc/VERSIONS` is excluded. It is underlined plain text, and `diff=markdown`
   empties the hunk headers that otherwise name the version.
 - `doc/COPYING` and `doc/COPYING.LESSER` are excluded as the licence texts.
-- Attributes name each path. A glob would catch the `#` comment lines of the
+- The extensionless documents are listed one path at a time. A glob over the
+  files that carry no extension would catch the `#` comment lines of the
   scripts and the configuration files.
 
 ### License

--- a/doc/POLICY
+++ b/doc/POLICY
@@ -221,6 +221,35 @@ or additions to this common policy, in order to avoid redundancy.
 - Encoding rules:
   - Use UTF-8 by default.
 
+#### Document File Naming
+- A document written in Markdown is named with a `.md` extension, except for
+  the fixed names below.
+- `doc/POLICY`, `doc/VERSIONS`, `doc/LICENSE`, `doc/COPYING`, and
+  `doc/COPYING.LESSER` carry no extension. They are the fixed document names
+  shared with the author's other repositories, found by name rather than by
+  extension. A new repository creates them under the same names.
+- Every other document is named for what it holds and takes `.md`.
+- An existing document is never renamed to add or change an extension. A path
+  here is a public URL that the README, the other repositories, and pages
+  outside them link to. Renaming breaks those links, and the ones outside
+  cannot be found or repaired.
+- Rename only when the current name causes an actual failure, and only after
+  examining the references to it. Being shown as plain text on GitHub is not a
+  failure: `doc/POLICY` is Markdown that GitHub does not render, and that is
+  accepted.
+
+#### Document File Attributes
+- `.gitattributes` gives `diff=markdown` to `*.md` and to the extensionless
+  Markdown documents, so that a diff hunk header names the section it falls in.
+  `doc/POLICY` and `doc/LICENSE` also take `linguist-language=Markdown`, which
+  gives them Markdown highlighting on GitHub. No attribute makes GitHub render
+  them.
+- `doc/VERSIONS` is excluded. It is underlined plain text, and `diff=markdown`
+  empties the hunk headers that otherwise name the version.
+- `doc/COPYING` and `doc/COPYING.LESSER` are excluded as the licence texts.
+- Attributes name each path. A glob would catch the `#` comment lines of the
+  scripts and the configuration files.
+
 ### License
 - The repository is dual licensed under the GPL version 3 or the LGPL version 3,
   at the user's option. The full texts live in `doc/LICENSE`, `doc/COPYING`,

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -4,6 +4,16 @@ scripts Repository Version History
 v2.0.1 (Release Date: TBD)
 --------------------------
 - Large-scale documentation revision, recorded here as an exception.
+- Add .gitattributes. The Markdown documents take diff=markdown, so that a
+  diff hunk header names the section it falls in; doc/POLICY and doc/LICENSE
+  also take linguist-language=Markdown for highlighting on GitHub. doc/VERSIONS
+  is left out because it is underlined plain text, and diff=markdown empties
+  the hunk headers that otherwise name the version.
+- State the document file naming and attribute rules in doc/POLICY: a Markdown
+  document takes .md, the fixed names under doc/ keep no extension, and an
+  existing document is not renamed for its extension.
+- Remove etc/pathext.txt. It listed Windows PATHEXT values, was read by nothing
+  in the repository, and is obsolete.
 
 v2.0 (2026-07-31)
 -----------------

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -4,16 +4,9 @@ scripts Repository Version History
 v2.0.1 (Release Date: TBD)
 --------------------------
 - Large-scale documentation revision, recorded here as an exception.
-- Add .gitattributes. The Markdown documents take diff=markdown, so that a
-  diff hunk header names the section it falls in; doc/POLICY and doc/LICENSE
-  also take linguist-language=Markdown for highlighting on GitHub. doc/VERSIONS
-  is left out because it is underlined plain text, and diff=markdown empties
-  the hunk headers that otherwise name the version.
-- State the document file naming and attribute rules in doc/POLICY: a Markdown
-  document takes .md, the fixed names under doc/ keep no extension, and an
-  existing document is not renamed for its extension.
-- Remove etc/pathext.txt. It listed Windows PATHEXT values, was read by nothing
-  in the repository, and is obsolete.
+- Add .gitattributes, marking the Markdown documents for diff and language.
+- Add the document file naming and attribute rules to doc/POLICY.
+- Remove etc/pathext.txt, an obsolete list of Windows PATHEXT values.
 
 v2.0 (2026-07-31)
 -----------------

--- a/etc/pathext.txt
+++ b/etc/pathext.txt
@@ -1,1 +1,0 @@
-.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.pl;.rb;.pyo;.pyc;.py;.pyw;.PSC1;.RBW


### PR DESCRIPTION
## Summary
This PR establishes formal policies for document file naming and git attributes configuration, along with corresponding documentation updates.

## Key Changes
- **Added `.gitattributes`**: New file that configures git diff and language attributes for Markdown documents
  - Applies `diff=markdown` to all `*.md` files and extensionless Markdown documents (`doc/POLICY`, `doc/LICENSE`)
  - Adds `linguist-language=Markdown` to `doc/POLICY` and `doc/LICENSE` for GitHub syntax highlighting
  - Excludes `doc/VERSIONS`, `doc/COPYING`, and `doc/COPYING.LESSER` from Markdown attributes

- **Updated `doc/POLICY`**: Added two new sections documenting file naming and attribute conventions
  - **Document File Naming**: Establishes that new Markdown documents use `.md` extension, with exceptions for license files (`COPYING`, `COPYING.LESSER`, `LICENSE`). Emphasizes that existing documents should not be renamed to preserve public URLs and prevent broken links.
  - **Document File Attributes**: Explains the `.gitattributes` configuration rationale and lists which documents receive which attributes

- **Updated `doc/VERSIONS`**: Added changelog entries documenting these changes and removal of obsolete `etc/pathext.txt`

- **Removed `etc/pathext.txt`**: Deleted obsolete Windows PATHEXT values list

## Notable Details
- The policy explicitly acknowledges that `doc/POLICY` and `doc/VERSIONS` will remain extensionless in this repository while new repositories will use `.md` extensions—this inconsistency is intentional to preserve existing public URLs
- The `.gitattributes` configuration uses explicit path listings rather than globs for extensionless files to avoid unintended matches with script and configuration files

https://claude.ai/code/session_01HhHYVD2rQF6CxAUPqLuVZH