### PR TITLE
Drop linguist-language from the document attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,8 +2,12 @@
 # Each path is named on its own: a glob would catch the `#` comment lines of
 # the scripts and the configuration files.
 *.md        diff=markdown
-doc/POLICY  diff=markdown linguist-language=Markdown
-doc/LICENSE diff=markdown linguist-language=Markdown
+doc/POLICY  diff=markdown
+doc/LICENSE diff=markdown
+
+# No file is given linguist-language. It does not make GitHub render a document
+# that carries no extension, and setting it changed how doc/POLICY and
+# doc/LICENSE are displayed on the web, for the worse.
 
 # doc/VERSIONS is underlined plain text, not Markdown. With diff=markdown its
 # hunk headers lose the version line they now carry. doc/COPYING and

--- a/doc/POLICY
+++ b/doc/POLICY
@@ -238,19 +238,22 @@ or additions to this common policy, in order to avoid redundancy.
   and that is the intended result. The rule applies at creation, and naming
   that matches across repositories is not a goal that outranks a published path
   staying where it is.
-- Rename only when the current name causes an actual failure, and only after
-  examining the references to it. Being shown as plain text on GitHub is not a
-  failure: `doc/POLICY` is Markdown that GitHub does not render, and that is
-  accepted.
+- Rename only when the current name causes a failure that outweighs the links
+  it breaks, and only after examining the references to it. GitHub shows
+  `doc/POLICY` as plain text instead of rendering it, and that cost is accepted
+  here, because the references that live outside this repository can be neither
+  found nor repaired.
 
 #### Document File Attributes
 - `.gitattributes` gives `diff=markdown` to `*.md` and to the extensionless
   Markdown documents, so that a diff hunk header names the section it falls in.
-  `doc/POLICY` and `doc/LICENSE` also take `linguist-language=Markdown`, which
-  gives them Markdown highlighting on GitHub. No attribute makes GitHub render
-  them.
 - A document created with `.md` is covered by the `*.md` line and needs no
   entry of its own.
+- No file is given `linguist-language`. Nothing in `.gitattributes` makes GitHub
+  render a document that carries no extension, and setting that attribute
+  changed how `doc/POLICY` and `doc/LICENSE` are displayed on the web, for the
+  worse. How a document reads on GitHub is decided by its name, not by an
+  attribute.
 - `doc/VERSIONS` is excluded. It is underlined plain text, and `diff=markdown`
   empties the hunk headers that otherwise name the version.
 - `doc/COPYING` and `doc/COPYING.LESSER` are excluded as the licence texts.

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -4,7 +4,7 @@ scripts Repository Version History
 v2.0.1 (Release Date: TBD)
 --------------------------
 - Large-scale documentation revision, recorded here as an exception.
-- Add .gitattributes, marking the Markdown documents for diff and language.
+- Add .gitattributes, marking the Markdown documents for diff.
 - Add the document file naming and attribute rules to doc/POLICY.
 - Remove etc/pathext.txt, an obsolete list of Windows PATHEXT values.
 


### PR DESCRIPTION
Follow-up to #36, which set `linguist-language=Markdown` on `doc/POLICY` and `doc/LICENSE`.

## The problem

On github.com the two documents now display worse than they did before #36. The attribute was reached for so that GitHub would treat them as Markdown, and it does not do that: nothing in `.gitattributes` makes GitHub render a document that carries no extension. `github/markup` selects a renderer by file extension, and Markdown is a `prose` language that the repository language statistics exclude in any case. The attribute only changed how the blob view presents the file, and the change was for the worse.

## The change

`linguist-language=Markdown` is removed from both entries. `.gitattributes` itself stays.

```diff
-doc/POLICY  diff=markdown linguist-language=Markdown
-doc/LICENSE diff=markdown linguist-language=Markdown
+doc/POLICY  diff=markdown
+doc/LICENSE diff=markdown
```

No file is renamed. `doc/POLICY` is linked from outside this repository and those links can be neither found nor repaired, so GitHub showing it as plain text is accepted as the cost of keeping the path where it is. `doc/POLICY` records that reasoning in place of the removed text, and says plainly that how a document reads on GitHub is decided by its name rather than by an attribute.

`doc/VERSIONS` has its `v2.0.1` line corrected, since the attributes no longer touch language.

## Note on the sibling repositories

`id774/ai-digest` and `id774/sizu-writer` take the other route in their own pull requests: their policy and licence documents are renamed to `.md`, because every reference to them lives inside those repositories and can be corrected in the same change. This repository does not have that property, which is why the names stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhHYVD2rQF6CxAUPqLuVZH

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhHYVD2rQF6CxAUPqLuVZH)_