### PR TITLE
Drop the changelog entry for the reflow of doc/VERSIONS

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -7,7 +7,6 @@ v2.0.1 (Release Date: TBD)
 - Add .gitattributes, marking the Markdown documents for diff.
 - Add the document file naming and attribute rules to doc/POLICY.
 - Remove etc/pathext.txt, an obsolete list of Windows PATHEXT values.
-- Wrap the lines of this file at 75 columns.
 
 v2.0 (2026-07-31)
 -----------------


### PR DESCRIPTION
Withdrawn. Reflowing a document **is** a change this version carries, so the bullet belongs in the `v2.0.1` entry where #38 put it. It stays.

The equivalent pull requests in `id774/dot_emacs` and `id774/ai-digest` are withdrawn for the same reason, and [#39](https://github.com/id774/scripts/pull/39) now records its own reflow of `doc/POLICY` beside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhHYVD2rQF6CxAUPqLuVZH