### PR TITLE
doc: add shared version history description guidelines

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -8,6 +8,7 @@ v2.0.1 (Release Date: TBD)
 - Add the document file naming and attribute rules to doc/POLICY.
 - Remove etc/pathext.txt, an obsolete list of Windows PATHEXT values.
 - Wrap the lines of this file at 75 columns.
+- Add the shared version history description guidelines to the end of this file.
 
 v2.0 (2026-07-31)
 -----------------
@@ -634,3 +635,18 @@ First Commit (2008-08-22)
 -------------------------
 - Commemorating the first commit and push, marking the inception of the
   project.
+
+Version History Guidelines
+==========================
+- Write one coherent change per physical line.
+- Keep entries near 100 columns where practical. Necessary file names,
+  command names, option names, and configuration names may extend an entry
+  to approximately 120 columns.
+- When an entry becomes substantially longer, omit or abstract implementation
+  details, examples, reasons, and secondary effects where possible.
+- Preserve the changed target, externally observable behavior, compatibility
+  or security impact, and important option or configuration names.
+- Combine related changes within the same version, especially changes to the
+  same file or feature.
+- Place closely related entries near each other.
+- Append an independent new change to the end of the current version entry.


### PR DESCRIPTION
## Summary

Append a common `Version History Guidelines` section to the end of `doc/VERSIONS`, so release entries keep the same granularity, ordering, and formatting over time regardless of who (or which agent) writes them. The wording is intended to be identical across repositories.

## Changes

- Add the `Version History Guidelines` section at the end of `doc/VERSIONS`, covering one-change-per-line entries, the ~100/120 column targets, what must never be dropped from an entry (changed target, externally observable behavior, compatibility or security impact, option and configuration names), and how to group and order entries within a version.
- Record the change as a single entry under the unreleased `v2.0.1` section.

## Notes

- Existing release history entries are intentionally left untouched; this change alone is not a reason to rewrite them.
- No repository-specific file names or examples were added to the guidelines, so the text stays identical across repositories.
- The program version is not bumped for this documentation-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tvRVNpDKRbo6H3kixXCZx