### PR TITLE
Expand the implementation policy to cover the judgement it had left implicit

### DIFF
--- a/doc/POLICY
+++ b/doc/POLICY
@@ -132,6 +132,28 @@ or additions to this common policy, in order to avoid redundancy.
 > may be used, but must be explicitly documented in the script or program
 > header.
 
+### Optional Dependencies
+- `check_commands` declares what a script requires. A capability the script can
+  work without is not declared there; it is detected where it is used.
+- Detection asks whether the capability is usable, not only whether the command
+  exists. A command may be present while the subcommand or the option the
+  script needs is not.
+- Decide in advance what an absent optional capability leads to: use the
+  alternative, skip the step and say so once, or refuse the run. Which one is
+  right depends on where the script runs.
+- An unattended script in an environment that will never supply what it needs
+  says so once and ends with a documented status, rather than reporting an
+  error on every scheduled run. A failure the operator can act on is still
+  reported as one.
+
+### Environment Differences
+- Branch on what the environment provides, not on what it is called. A
+  distribution name, a release number, and a desktop session name each answer a
+  question the script is not asking. The question is whether the command, the
+  file, the service, or the configuration format it needs is there.
+- Keep that detection in one place. The same question answered separately in
+  several places drifts apart as environments change.
+
 ### Documentation and Versioning
 - Every executable must contain a structured header block, delimited above and
   below by a separator line of 20 or more `#` characters.
@@ -458,9 +480,13 @@ or additions to this common policy, in order to avoid redundancy.
 - A test writes nothing outside a temporary directory, and needs no credential
   and no reachable host.
 - A fix for a defect arrives together with the test that fails without it.
-- A script a cron job runs must be safe to run twice. A second run over the
-  same input replaces or skips what the first one produced, rather than
-  duplicating it or refusing to start.
+- A script that changes state is safe to run twice, whether a cron job runs it
+  or a person does. This covers the installers as much as the scheduled jobs: a
+  second run over the same input replaces or skips what the first one produced,
+  rather than duplicating it or refusing to start.
+- Check the current state before changing it. Appending a line, creating a
+  link, enabling a service, and installing a package each need to know whether
+  an earlier run already did it.
 
 ---
 
@@ -470,8 +496,24 @@ or additions to this common policy, in order to avoid redundancy.
 - Comply strictly with POSIX (`#!/bin/sh`).
 - Avoid Bash-specific syntax and extensions.
 - Do not use `local`.
+- `/bin/sh` is dash on Debian and Ubuntu. A construct that works because
+  `/bin/sh` links to bash elsewhere is still a defect here.
+- The constructs most often mistaken for portable are `[[ ... ]]`, arrays, the
+  `function` keyword, `source`, and process substitution. Use `[ ... ]`,
+  positional parameters or a delimited string, a plain `name()` definition,
+  `.`, and a temporary file or a pipeline instead.
 - Modularize using small, single-purpose functions.
 - Follow the structured header requirements defined in the Common Policy.
+
+### Quoting and Word Splitting
+- Quote every variable expansion that is not deliberately being split. A path
+  holding a space, an empty value, and an unset variable each turn an unquoted
+  expansion into a different command.
+- Guard a value that may be empty or unset before it reaches a command that
+  would otherwise act on the wrong target.
+- Do not let a pattern reach a destructive command unexamined. A glob that
+  matches nothing and a glob that matches more than intended both change what
+  the command operates on.
 
 ### Dependency and Environment Checks
 - Validate required commands and environment variables at startup.
@@ -501,6 +543,8 @@ check_commands() {
 - A script that has `check_sudo` does not also list `sudo` in `check_commands`:
   `sudo -v` already establishes that `sudo` is present and usable, so the
   second check adds nothing.
+- Elevated privileges cover the operations that need them and no more. A script
+  that needs root for one step does not run its whole body under it.
 - For network operations, verify connectivity before execution.
 
 ### Logging Style

--- a/doc/POLICY
+++ b/doc/POLICY
@@ -81,7 +81,7 @@ or additions to this common policy, in order to avoid redundancy.
   forced termination**.
 - Normal execution paths must return normally and propagate status explicitly.
 - Do not rely on implicit termination or language-specific shortcuts
-  (e.g. `set -e` in shell, bare `except` in Python).
+  (e.g. `set -e` in a shell script, bare `except` in Python).
 
 ### CLI Conventions
 - All command-line tools must provide consistent options:
@@ -397,6 +397,12 @@ or additions to this common policy, in order to avoid redundancy.
   portable substitute for a construct that some implementation gets wrong, a
   retention period, or a hard-coded fallback, the comment gives the reason, so
   that a later change does not quietly undo it.
+- Name a thing by what it is, not by a part of it. A shell script is a shell
+  script: the shell is the interpreter that runs it, and naming the script
+  after the interpreter is as loose as calling a USB memory stick a USB. The
+  same holds wherever a shorthand reaches for the interface, the format, or
+  the container instead of the thing itself. This applies to the headers, the
+  documents, and the commit messages as much as to the comments.
 
 ### Configuration Files
 - A script that needs site-specific values reads them from a file under `etc/`,
@@ -621,7 +627,7 @@ log_info_time() {
 ### Dependencies and I/O
 - Depend only on the standard library.
 - Implement manual PATH search if command lookup is required, and exit `127`
-  when the command is not found, matching the shell helper.
+  when the command is not found, matching the shell script helper.
 - Always use `encoding="utf-8"` for file operations.
 
 ### Docstrings

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -5,7 +5,7 @@ v2.0.1 (Release Date: TBD)
 --------------------------
 - Large-scale documentation revision, recorded here as an exception.
 - Add .gitattributes, marking the Markdown documents for diff.
-- Add the document file naming and attribute rules to doc/POLICY.
+- Expand doc/POLICY substantially across documents, portability, dependencies, environments, and repeated execution.
 - Remove etc/pathext.txt, an obsolete list of Windows PATHEXT values.
 - Wrap the lines of this file at 75 columns.
 - Add the shared version history description guidelines to the end of this file.


### PR DESCRIPTION
## Purpose

The permanent context that AI agents work from was rewritten so that it holds reasoning rather than specifications, on the principle that a specification belongs with the project it governs and a general context should carry only the thinking behind it. That rewrite removed the shell syntax list, the version numbering scheme, the named schedulers and privilege mechanisms, and the quoting hazards, on the understanding that this document already held them.

That made this document the only place several rules live, so every rule removed from the general context was compared against it. Most were already here, stated more fully than in the context that was carrying a copy: the version numbering with its rollover, the repository versioning and tag rules, the `doc/VERSIONS` structure, the header and documentation requirements, the comment conventions, the exit code semantics, the cron-friendly logging, and the validation required before a destructive operation.

Six were not, and this change adds them, together with a naming rule found while auditing the document.

## Changes

**Portability.** The existing instruction to avoid Bash syntax did not say which syntax it meant. Name the constructs most often mistaken for portable, with the portable form for each, and state that `/bin/sh` is dash on the distributions in use, which is the reason strict POSIX compliance matters rather than a preference.

**Quoting and word splitting.** A new section in the shell script policy. An unquoted expansion of a path holding a space, of an empty value, or of an unset variable each turn into a different command, and a glob that reaches a destructive command changes what that command operates on. Nothing here addressed this class of defect.

**Optional dependencies.** A new section in the common policy. `check_commands` declares what a script requires and exits when it is absent, which left nothing said about a capability a script can work without. The section covers detecting that a capability is usable rather than merely present, deciding in advance what an absent one leads to, and why an unattended script should report an environment that will never support it once rather than on every scheduled run.

**Environment differences.** A new section in the common policy: branch on what the environment provides rather than on what it is called, and keep that detection in one place.

**Repeated execution.** The rule that a script must be safe to run twice applied only to a script a cron job runs, which left the installers outside it. Widen it to any script that changes state, and add that a change checks the current state first, since appending a line, creating a link, enabling a service and installing a package each need to know whether an earlier run already did it.

**Privilege scope.** `check_sudo` established that privileges are available but said nothing about their extent. State that they cover the operations needing them and no more.

**Naming.** A shell script was called a "shell" in two places, once beside Python as though the two named the same kind of thing, and once for the helper defined in the shell script section. The shell is the interpreter that runs the script, so naming the script after it loses a distinction the surrounding text relies on. Both are corrected, and the rule is stated in the comments and language section, since the same loss happens wherever a shorthand reaches for the interface, the format, or the container rather than the thing itself.

## Scope

`doc/POLICY` gains 54 lines against 638, all of them wrapped inside 80 columns as the plain text guidance asks. No script changes, so no executable version is bumped.

`doc/VERSIONS` keeps its single open entry. The line recording the earlier document naming and attribute rules is replaced by one line covering the policy expansion as a whole, since more than one change in this release has revised the policy and separate lines for each would not read as a version-level summary.

## Points for review

Whether the optional dependency rule belongs in the common policy or in the shell script policy. It is placed in the common policy because the judgement applies to the Python and Ruby scripts as well, but the mechanism it contrasts itself against, `check_commands`, is defined in the shell script section.

Whether the repeated execution rule reads correctly where it stands. It sits under Testing and Operation because that is where the cron sentence it replaces lived, though the rule is about operational design rather than testing, and a section of its own directly under the common policy would arguably suit it better.

Whether the naming rule reads well in the comments and language section. It applies to the headers, the documents and the commit messages as much as to the comments, which the bullet says explicitly, but a section of its own would carry that without the sentence.