### PR TITLE
Add guideline for consistent line length in version history

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -644,6 +644,8 @@ Version History Guidelines
 - Keep entries near 100 columns where practical. Necessary file names,
   command names, option names, and configuration names may extend an entry
   to approximately 120 columns.
+- When a version history already exists, balance a new entry against the
+  length of the existing lines, so that the whole file stays consistent.
 - When an entry becomes substantially longer, omit or abstract implementation
   details, examples, reasons, and secondary effects where possible.
 - Preserve the changed target, externally observable behavior, compatibility


### PR DESCRIPTION
This change adds a new guideline to the VERSIONS documentation to help maintain consistency in the version history file.

**Summary**
Added a new guideline to the version history documentation that instructs contributors to balance new entries against the length of existing lines to maintain visual consistency throughout the file.

**Key Changes**
- Added a new guideline entry that recommends balancing new version history entries against existing line lengths to keep the file consistent
- This guideline is positioned between the existing column width guidelines (100-120 columns) and the guideline about omitting implementation details for longer entries

**Details**
The new guideline helps ensure that the VERSIONS file maintains a consistent appearance and readability by encouraging contributors to consider the existing line lengths in the file when adding new entries, rather than mechanically adhering to the column limits without regard to context.

https://claude.ai/code/session_01CdASvA6qRYUFi2qckFFFRz