### PR TITLE
Prune remote-tracking branches during git-all-pull pulls

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -11,6 +11,7 @@ v2.0.1 (Release Date: TBD)
 - Wrap the lines of this file at 75 columns.
 - Add the shared version history description guidelines to the end of this
   file.
+- Prune stale remote-tracking branches when git-all-pull.sh pulls repositories.
 
 v2.0 (2026-07-31)
 -----------------

--- a/git-all-pull.sh
+++ b/git-all-pull.sh
@@ -17,13 +17,19 @@
 #      ./git-all-pull.sh [--hard] [--no-symlink] [--dry-run] [--github-only] [--git-only] [--www-only] [--all]
 #
 #  Default behavior is to show this help message. Use '--all' to pull from github, git, and www targets.
-#  Note: Specifying both '--github-only' and '--git-only' selects both trees (github and git) and does not include www.
-#  '--reset' can be used as an alias of '--hard'.
+#  Notes:
+#      Specifying both '--github-only' and '--git-only' selects both trees
+#      (github and git) and does not include www.
+#      '--reset' can be used as an alias of '--hard'.
+#      Pulls prune remote-tracking branches deleted from remotes.
+#      Pruning does not delete local branches.
 #
 #  WARNING: The '--hard' option performs 'git reset --hard' which can
 #  overwrite local changes. Use with caution.
 #
 #  Version History:
+#  v2.3 2026-08-07
+#       Prune stale remote-tracking branches during repository pulls.
 #  v2.2 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -149,7 +155,7 @@ pull_repo() {
 
     if [ "$DRY_RUN" = false ]; then
         echo "[INFO] Pulling repository: $repo"
-        git -C "$repo" pull
+        git -C "$repo" pull --prune
     else
         echo "[INFO] DRY RUN: Pull repository: $repo"
     fi


### PR DESCRIPTION
### Motivation
- Remove stale remote-tracking branches that remain after remotes delete branches, keeping local refs tidy when running the repository pull script.

### Description
- Add `--prune` to the `git` invocation (`git -C "$repo" pull --prune`), update `git-all-pull.sh` header notes and add a `v2.3` version entry, and record the change in `doc/VERSIONS`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75d9e44484832297e99e8183dc6bd1)