### PR TITLE
Clarify version bumping and changelog formatting rules

### DIFF
--- a/doc/POLICY
+++ b/doc/POLICY
@@ -373,8 +373,9 @@ or additions to this common policy, in order to avoid redundancy.
 - Repository release versions and Git tags follow the separate rules below.
 - Do not bump the version mechanically every time a file is touched. Decide
   based on the nature of the change:
-  - Documentation-only changes (comments, help text, README/POLICY/VERSIONS
-    wording, etc. with no effect on behavior) do not bump the version.
+  - Documentation-only, comment-only, and formatting-only changes (help text,
+    README/POLICY/VERSIONS wording, whitespace and layout, etc. with no effect
+    on behavior) do not bump the version.
   - Any change that affects code behavior (bug fixes, new options, and
     refactors that change observable behavior) bumps the version.
   - Multiple updates on the same date must be consolidated into a single

--- a/doc/POLICY
+++ b/doc/POLICY
@@ -429,7 +429,8 @@ or additions to this common policy, in order to avoid redundancy.
   - Use UTF-8 by default.
 
 ##### 1.7.4.1 One Change per Line
-- One coherent change is one bullet, written on one physical line. The entry
+- One coherent change is one bullet, written on one physical line. That is the
+  rule, and the one case standing outside it closes this section. The entry
   is a list meant to be scanned, and a wrapped bullet costs it that: the eye
   no longer finds the changes by counting lines, and a diff no longer shows
   one added line per added change.
@@ -447,10 +448,13 @@ or additions to this common policy, in order to avoid redundancy.
   applies to what is written from now on.
 - `doc/VERSIONS` carries these guidelines again at its foot, and an entry
   written into it follows the reasons recorded there.
-- Where the file has settled on a width of its own, a new bullet is wrapped to
+- The case standing outside the rule is a version history that has already
+  settled on a width and a layout of its own. There a new bullet is wrapped to
   that width and balanced against the lines already standing, so that the
-  version history stays of a piece. That consistency comes before the one
-  physical line asked for above.
+  version history stays of a piece, and that consistency comes before the one
+  physical line asked for above. Wrapping to hold an established form does not
+  overturn the rule; where a file has settled on no such form, one change is
+  still one physical line.
 
 ##### 1.7.4.2 Shortening a Long Entry
 - When a bullet runs long, the first move is to abstract it, never to break

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -642,12 +642,14 @@ First Commit (2008-08-22)
 
 Version History Guidelines
 ==========================
-- Write one coherent change per physical line.
+- Write one coherent change per physical line, as a rule.
 - Keep entries near 100 columns where practical. Necessary file names,
   command names, option names, and configuration names may extend an entry
   to approximately 120 columns.
 - When a version history already exists, balance a new entry against the
   length of the existing lines, so that the whole file stays consistent.
+  Holding to the form this file has settled on comes before the one physical
+  line above, and leaves that rule standing wherever no such form exists.
 - When an entry becomes substantially longer, omit or abstract implementation
   details, examples, reasons, and secondary effects where possible.
 - Preserve the changed target, externally observable behavior, compatibility


### PR DESCRIPTION
This PR updates the project policy documentation to provide clearer guidance on version bumping decisions and changelog entry formatting.

## Summary
The changes refine two related policy sections to better explain when versions should be bumped and how changelog entries should be formatted, with explicit acknowledgment of practical exceptions to the stated rules.

## Key Changes

- **Version Bumping Policy (doc/POLICY)**: Expanded the definition of "documentation-only changes" to explicitly include comment-only and formatting-only changes (whitespace, layout) that don't affect behavior and therefore don't require version bumps.

- **Changelog Formatting Rules (doc/POLICY & doc/VERSIONS)**: Clarified the "one change per line" rule by:
  - Explicitly stating it as a general rule with documented exceptions
  - Identifying version history files as the specific case where line wrapping is acceptable when the file has already established a consistent width/layout
  - Emphasizing that maintaining established file consistency takes precedence over strict single-line formatting
  - Clarifying that this exception only applies where a file has already settled on a particular form

## Notable Details
The changes maintain the existing rules while making their practical application clearer through better explanation of the rationale and exceptions. The updates acknowledge that real-world consistency sometimes requires flexibility from strict formatting rules.

https://claude.ai/code/session_017RHX2AC2VBccHpTc7oSyYG