### PR TITLE
Add Directory Structure section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Welcome to the `scripts` repository! This is a curated collection of scripts in 
 2. [Installation](#2-installation)
 3. [Usage](#3-usage)
 4. [Testing](#4-testing)
-5. [Contribution](#5-contribution)
-6. [License](#6-license)
+5. [Directory Structure](#5-directory-structure)
+6. [Contribution](#6-contribution)
+7. [License](#7-license)
 
 ---
 
@@ -66,6 +67,10 @@ Refer to the comments at the beginning of each script for usage instructions. Ex
 $SCRIPTS/example_script.sh
 ```
 
+Every executable carries a header block stating what it does, how it is invoked
+and what it expects, so the script itself is the reference. For where each kind
+of script lives, see [Directory Structure](#5-directory-structure).
+
 ---
 
 ## 4. Testing
@@ -93,7 +98,50 @@ into `run_tests.sh`.
 
 ---
 
-## 5. Contribution
+## 5. Directory Structure
+
+This section describes the main directories of the repository and what each one
+is for. It is not a complete file listing: the top level alone holds roughly a
+hundred scripts, and only the directories and the few files worth knowing about
+up front are shown.
+
+```
+.
+├── *.sh, *.py, *.rb          The scripts a user runs directly. One task per script.
+├── setup_scripts.sh          Sets executable permissions across the repository.
+├── run_tests.sh              Runs the test suite for one Python and Ruby pair.
+├── installer/                Setup and installation scripts, for building a machine.
+├── cron/
+│   ├── bin/                  Scheduled job scripts, deployed as /etc/cron.exec.
+│   └── etc/                  Their configuration files, deployed as /etc/cron.config.
+├── etc/                      Configuration and data files read by the top-level scripts.
+├── dot_files/                Dot files deployed into a user's home directory.
+├── test/                     The test suite, plus check_scripts.sh for the shell scripts.
+└── doc/
+    ├── POLICY                Design and development standards for all languages.
+    ├── VERSIONS              Version history of the repository.
+    ├── LICENSE               License notice.
+    ├── COPYING               GPL version 3 text.
+    └── COPYING.LESSER        LGPL version 3 text.
+```
+
+Placement says what a file is for, not which rules apply to it: every executable
+in the repository follows the same header, logging, CLI and exit code
+conventions, wherever it lives. The distinction the directories draw is how a
+script is invoked — by hand from the top level, once at setup time from
+`installer/`, or unattended from `cron/bin/`.
+
+That last one is why configuration is separated from code. A top-level script
+that needs site-specific values reads them from `etc/<name>.conf`, and a
+`cron/bin/` job reads its deployed copy under `/etc/cron.config/`, so no script
+carries a hostname, a path or a credential in its body.
+
+[doc/POLICY](doc/POLICY) is the authoritative version of this layout and of the
+rules above; the summary here is only an orientation.
+
+---
+
+## 6. Contribution
 
 We welcome contributions! Here's how you can help:
 1. Fork the repository.
@@ -114,7 +162,7 @@ See [doc/POLICY](doc/POLICY) for detailed design and development standards acros
 
 ---
 
-## 6. License
+## 7. License
 
 This repository is dual licensed under the [GPL version 3](https://www.gnu.org/licenses/gpl-3.0.html) or the [LGPL version 3](https://www.gnu.org/licenses/lgpl-3.0.html), at your option.
 For full details, please refer to the [LICENSE](doc/LICENSE) file.  See also [COPYING](doc/COPYING) and [COPYING.LESSER](doc/COPYING.LESSER) for the complete license texts.

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -13,6 +13,7 @@ v2.0.1 (Release Date: TBD)
 - Add the shared version history description guidelines to the end of this
   file.
 - Prune stale remote-tracking branches when git-all-pull.sh pulls repositories.
+- Describe each main directory in the README Directory Structure section.
 
 v2.0 (2026-07-31)
 -----------------


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation of the repository's directory structure to the README, helping users understand the organization and purpose of each main directory and file type.

## Key Changes
- Added new "Directory Structure" section (section 5) to the README table of contents
- Renumbered subsequent sections (Contribution and License) accordingly
- Enhanced the Usage section with a note directing users to the Directory Structure section for script locations
- Included a detailed directory tree showing:
  - Top-level scripts and setup files
  - `installer/` for setup scripts
  - `cron/` for scheduled jobs and their configuration
  - `etc/` for configuration files
  - `dot_files/` for home directory dotfiles
  - `test/` for the test suite
  - `doc/` for policy, versions, and license files
- Added explanatory text clarifying:
  - How placement indicates purpose rather than which rules apply
  - The separation of configuration from code for site-specific values
  - The distinction between how scripts are invoked (manual, setup-time, or unattended)
  - Reference to `doc/POLICY` as the authoritative source for layout and conventions
- Updated `doc/VERSIONS` to note this documentation addition in v2.0.1

## Implementation Details
The new section provides both a visual tree structure and narrative explanation of the repository organization, making it easier for new contributors and users to understand where different types of scripts and configuration files belong.

https://claude.ai/code/session_019uQsKvExppSEhWUrDYnyQF