### PR TITLE
Add --delete-remote-branches option to git-all-pull.sh

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -15,6 +15,7 @@ v2.0.1 (Release Date: TBD)
 - Prune stale remote-tracking branches when git-all-pull.sh pulls repositories.
 - Describe each main directory in the README Directory Structure section.
 - Enable automatic pruning on Git fetch with fetch.prune.
+- Add git-all-pull.sh --delete-remote-branches for origin branch cleanup.
 
 v2.0 (2026-07-31)
 -----------------

--- a/git-all-pull.sh
+++ b/git-all-pull.sh
@@ -14,7 +14,7 @@
 #  Contact: idnanashi@gmail.com
 #
 #  Usage:
-#      ./git-all-pull.sh [--hard] [--no-symlink] [--dry-run] [--github-only] [--git-only] [--www-only] [--all]
+#      ./git-all-pull.sh [--hard] [--no-symlink] [--dry-run] [--delete-remote-branches] [--github-only] [--git-only] [--www-only] [--all]
 #
 #  Default behavior is to show this help message. Use '--all' to pull from github, git, and www targets.
 #
@@ -24,11 +24,14 @@
 #      '--reset' can be used as an alias of '--hard'.
 #      Pulls prune remote-tracking branches deleted from remotes.
 #      Pruning does not delete local branches.
+#      '--delete-remote-branches' deletes origin branches except master and main.
 #
 #  WARNING: The '--hard' option performs 'git reset --hard' which can
 #  overwrite local changes. Use with caution.
 #
 #  Version History:
+#  v2.4 2026-08-15
+#       Add --delete-remote-branches to delete origin branches except master and main.
 #  v2.3 2026-08-07
 #       Prune stale remote-tracking branches during repository pulls.
 #  v2.2 2026-07-11
@@ -68,6 +71,7 @@
 HARD_MODE=false
 NO_SYMLINK=false
 DRY_RUN=false
+DELETE_REMOTE_BRANCHES=false
 GITHUB_ONLY=false
 GIT_ONLY=false
 ALL=false
@@ -106,12 +110,40 @@ parse_arguments() {
             --reset) HARD_MODE=true ;;
             --no-symlink) NO_SYMLINK=true ;;
             --dry-run) DRY_RUN=true ;;
+            --delete-remote-branches) DELETE_REMOTE_BRANCHES=true ;;
             --github-only) GITHUB_ONLY=true ;;
             --git-only) GIT_ONLY=true ;;
             --www-only) WWW_ONLY=true ;;
             --all) ALL=true ;;
             *) SHOW_HELP=true ;;
         esac
+    done
+}
+
+# Delete remote branches other than master and main from origin
+delete_remote_branches() {
+    repo="$1"
+
+    if ! remote_heads=$(git -C "$repo" ls-remote --heads origin); then
+        echo "[ERROR] Failed to list remote branches: origin ($repo)" >&2
+        return 1
+    fi
+
+    printf '%s\n' "$remote_heads" | awk '
+        $2 ~ /^refs\/heads\// {
+            branch = substr($2, 12)
+            if (branch != "master" && branch != "main") print branch
+        }
+    ' | while IFS= read -r branch; do
+        [ -n "$branch" ] || continue
+        if [ "$DRY_RUN" = true ]; then
+            echo "[INFO] DRY RUN: Delete remote branch: origin/$branch ($repo)"
+        else
+            echo "[INFO] Deleting remote branch: origin/$branch ($repo)"
+            if ! git -C "$repo" push origin --delete "$branch"; then
+                echo "[ERROR] Failed to delete remote branch: origin/$branch ($repo)" >&2
+            fi
+        fi
     done
 }
 
@@ -159,6 +191,10 @@ pull_repo() {
         git -C "$repo" pull --prune
     else
         echo "[INFO] DRY RUN: Pull repository: $repo"
+    fi
+
+    if [ "$DELETE_REMOTE_BRANCHES" = true ]; then
+        delete_remote_branches "$repo"
     fi
 }
 


### PR DESCRIPTION
### Motivation
- Provide an opt-in way to remove unnecessary remote branches on `origin` after a successful `git pull`, while always preserving `master` and `main`.
- Keep the behavior safe and discoverable by requiring an explicit `--delete-remote-branches` flag and honoring existing `--dry-run` and target-selection options.

### Description
- Add a global flag `DELETE_REMOTE_BRANCHES` and parse the `--delete-remote-branches` CLI option in `parse_arguments()`.
- Implement a new helper `delete_remote_branches()` that lists real remote branches using `git -C "$repo" ls-remote --heads origin`, excludes `master` and `main`, and deletes each remaining branch with `git -C "$repo" push origin --delete "$branch"` while continuing on individual failures and logging errors.
- Invoke `delete_remote_branches()` from `pull_repo()` immediately after the existing `git pull --prune` step only when the flag is enabled, and respect `--dry-run` by logging intended deletions without performing them.
- Update the script usage/notes to mention the new option and add a single-line entry to `doc/VERSIONS` describing the change.

### Testing
- Verified POSIX syntax with `/bin/sh -n git-all-pull.sh` (no syntax errors).
- Confirmed `doc/VERSIONS` line-length policy check passed (no lines over threshold) after update.
- Performed integration checks with a stubbed `git` in a temporary `HOME` that validated: `ls-remote` is used, `master`/`main` are excluded, three other branches are reported as deletion candidates, `--dry-run` logs deletion messages but does not call `push --delete`, and the deletion step runs after `pull --prune`.
- Ran the repository test harness via `./run_tests.sh`, which completed successfully for Python tests (all tests passed with some skipped) and overall test runner reported success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80360fcb7483229be14314b9871db6)