### PR TITLE
Clarify VERSIONS policy for pre-release repositories

### DIFF
--- a/doc/POLICY
+++ b/doc/POLICY
@@ -472,6 +472,13 @@ never asked to touch.
   what accumulated in it is known; which number it takes is decided then.
 - Replacing `TBD` with the actual release date is the release itself, not a
   change to record in the entry.
+- A repository that has not yet made its first release is in its initial
+  construction stage, and that stage takes no entry here. Typically this is the
+  state while `v1.0` is the first release and the repository still stands below
+  it, or `v1.0` itself is unreleased. The changes made while building up to that
+  release are not accumulated in `doc/VERSIONS` one by one: the file is the
+  record of released versions, not of the construction that precedes the first
+  of them, and its first entry is written when that release is made.
 - A documentation-only change takes no `doc/VERSIONS` entry, unless its scale
   makes it worth one line saying so.
 


### PR DESCRIPTION
This change clarifies the policy for how repositories handle version documentation during their initial construction phase, before the first release.

## Summary
Added guidance to `doc/POLICY` explaining that repositories in their initial construction stage (before the first release) do not require entries in `doc/VERSIONS`. This clarifies that version documentation is a record of released versions, not the development work leading up to the first release.

## Key Changes
- Added a new policy bullet point explaining that pre-release repositories take no entry in `doc/VERSIONS` during their initial construction stage
- Clarified that this typically applies when `v1.0` is the first unreleased version or the repository is still below it
- Established that the first `doc/VERSIONS` entry is written when the first release is actually made, not during the development leading up to it

## Details
This policy clarification helps maintainers understand that `doc/VERSIONS` serves as a changelog for released versions only, and that accumulating entries for unreleased work is not necessary or expected for new repositories that haven't yet reached their first stable release.

https://claude.ai/code/session_014Q4JqJ59yu41uBmxVngoVj