### PR TITLE
Fix repository removal path traversal

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -17,6 +17,8 @@ v2.0.1 (Release Date: TBD)
 - Enable automatic pruning on Git fetch with fetch.prune.
 - Add git-all-pull.sh --delete-remote-branches for origin branch cleanup.
 - Clarify the license exclusions for the bundled third-party software.
+- Prevent remove-repo.sh repository names from escaping the configured
+  directories.
 
 v2.0 (2026-07-31)
 -----------------

--- a/remove-repo.sh
+++ b/remove-repo.sh
@@ -27,6 +27,8 @@
 #      ./remove-repo.sh -x repo1 repo2     # remove multiple repositories
 #
 #  Version History:
+#  v1.8 2026-08-18
+#       Reject repository names that could escape the configured directories.
 #  v1.7 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -61,6 +63,17 @@ usage() {
 # Check if a directory is a Git repository.
 is_git_repo() {
     [ -d "$1/.git" ]
+}
+
+# Reject names that could resolve outside the repository directories.
+validate_repo_name() {
+    case "$1" in
+        ""|.|..|*/*)
+            echo "[ERROR] Invalid repository name: $1" >&2
+            return 1
+            ;;
+    esac
+    return 0
 }
 
 # Remove the Git repository from the github directory if it exists.
@@ -106,6 +119,10 @@ remove_symlink() {
 remove_repo() {
     repo_name="$1"
 
+    if ! validate_repo_name "$repo_name"; then
+        return 1
+    fi
+
     remove_from_github
     remove_from_git
     remove_symlink
@@ -113,10 +130,14 @@ remove_repo() {
 
 # Iterate through arguments and remove each specified repository.
 remove_repos() {
+    status=0
     while [ $# -gt 0 ]; do
-        [ "$1" != "-x" ] && remove_repo "$1"
+        if [ "$1" != "-x" ] && ! remove_repo "$1"; then
+            status=1
+        fi
         shift
     done
+    return "$status"
 }
 
 # Main entry point of the script
@@ -136,7 +157,9 @@ main() {
     done
 
     if [ -n "$1" ]; then
-        remove_repos "$@"
+        if ! remove_repos "$@"; then
+            return 1
+        fi
     else
         usage
     fi


### PR DESCRIPTION
### Motivation
- Prevent `remove-repo.sh` from accepting repository names that can escape the configured target directories (e.g. `..` or names containing `/`) and cause unintended removals.

### Description
- Add `validate_repo_name()` to reject empty names, `.`/`..`, and any name containing a path separator before attempting removal. 
- Propagate per-name failures by collecting a non-zero `status` in `remove_repos()` and returning failure from `main` when any name is invalid. 
- Update the script header with `v1.8` and record the behavioral fix in `doc/VERSIONS`.

### Testing
- Ran a syntax check with `sh -n remove-repo.sh` which succeeded. 
- Performed a path-traversal preservation check using a temporary `HOME` and `HOME="$tmp" sh ./remove-repo.sh -x ..` and observed a non-zero exit and no deletion of the target `.git` directory. 
- Executed `SCRIPTS=$PWD ./test/check_scripts.sh` which reported all scripts passing. 
- Ran the full test runner with `./run_tests.sh` which completed successfully for Python tests (RSpec was not available and Ruby tests were skipped as expected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a844d624ba48322b48d7a9634306c5a)