### PR TITLE
unzip_subdir: reject invalid source directory paths; add tests and update VERSIONS

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -19,6 +19,7 @@ v2.0.1 (Release Date: TBD)
 - Clarify the license exclusions for the bundled third-party software.
 - Prevent remove-repo.sh repository names from escaping the configured
   directories.
+- Reject invalid source directory paths in unzip_subdir.py.
 
 v2.0 (2026-07-31)
 -----------------

--- a/test/unzip_subdir_test.py
+++ b/test/unzip_subdir_test.py
@@ -23,8 +23,11 @@
 #    - Extracts .zip files discovered in nested subdirectories using the discovered archive path.
 #    - Continues after a failed archive and reports the failure count.
 #    - Exits with status 1 from the CLI when an extraction fails.
+#    - Exits with status 1 when the source path is not a directory.
 #
 #  Version History:
+#  v1.5 2026-08-19
+#       Add coverage for rejecting invalid source directory paths.
 #  v1.4 2026-07-26
 #       Add coverage for failure counting and non-zero CLI exit status,
 #       and switch the help test to sys.executable.
@@ -174,6 +177,32 @@ class TestUnzipSubdir(unittest.TestCase):
 
             self.assertEqual(process.returncode, 0)
             self.assertTrue(os.path.isfile(os.path.join(tmpdir, 'good', 'good.txt')))
+
+    def test_cli_rejects_source_path_that_is_not_a_directory(self):
+        script_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '../unzip_subdir.py'))
+        from subprocess import PIPE, Popen
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source_path = os.path.join(tmpdir, 'archive.zip')
+            with open(source_path, 'w') as f:
+                f.write('not a directory')
+
+            process = Popen([sys.executable, script_path, source_path], stdout=PIPE, stderr=PIPE)
+            _, stderr = process.communicate()
+
+            self.assertEqual(process.returncode, 1)
+            self.assertIn(source_path, stderr.decode('utf-8'))
+
+    def test_cli_rejects_missing_source_directory(self):
+        script_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '../unzip_subdir.py'))
+        from subprocess import PIPE, Popen
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source_path = os.path.join(tmpdir, 'missing')
+
+            process = Popen([sys.executable, script_path, source_path], stdout=PIPE, stderr=PIPE)
+            _, stderr = process.communicate()
+
+            self.assertEqual(process.returncode, 1)
+            self.assertIn(source_path, stderr.decode('utf-8'))
 
     def test_extracts_zip_files_from_nested_directories(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/unzip_subdir.py
+++ b/unzip_subdir.py
@@ -29,10 +29,13 @@
 #    files in the source directory.
 #  - The script does not overwrite existing directories.
 #  - Archive members containing unsafe paths are rejected before extraction.
+#  - The source path must name an existing directory.
 #  - Processing continues after a failed archive, and the exit status is 1
 #    when at least one archive failed to extract.
 #
 #  Version History:
+#  v2.1 2026-08-19
+#       Reject source paths that do not name an existing directory.
 #  v2.0 2026-07-26
 #       Return exit status 1 when any archive fails to extract.
 #  v1.8 2026-07-23
@@ -147,6 +150,10 @@ def main():
         parser.print_help()
         return 1
     else:
+        if not os.path.isdir(args[0]):
+            print("[ERROR] Source path is not a directory: {}".format(args[0]),
+                  file=sys.stderr)
+            return 1
         failures = unzip_files(args, options.dry_run)
         if failures > 0:
             print("[ERROR] Failed to extract {} archive(s).".format(failures), file=sys.stderr)


### PR DESCRIPTION
### Motivation
- Ensure `unzip_subdir.py` fails fast when the provided source path does not name an existing directory to avoid surprising behavior and improve error reporting.
- Document the behavior in the project `doc/VERSIONS` history entry.
- Add automated coverage for the new behavior to prevent regressions.

### Description
- Add an `os.path.isdir` check in `main()` of `unzip_subdir.py` that prints an error to `stderr` and returns exit status `1` when the supplied source path is not an existing directory.
- Add two CLI tests to `test/unzip_subdir_test.py`: `test_cli_rejects_source_path_that_is_not_a_directory` and `test_cli_rejects_missing_source_directory` which exercise non-directory and missing-path cases via subprocess invocation of the script.
- Update `doc/VERSIONS` to record the new behavior and the change in the script version history.

### Testing
- Ran the test suite with `python -m unittest discover` which executed `test/unzip_subdir_test.py` including the two new tests, and all tests passed.
- Existing tests that exercise dry-run behavior, nested extraction, unsafe-member rejection, failure counting, and CLI exit statuses were retained and ran successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a858887fda883229ba3d6dce0d5d6fc)