### PR TITLE
Replace non-portable find/sort options with POSIX equivalents

### DIFF
--- a/cltmp.sh
+++ b/cltmp.sh
@@ -59,6 +59,7 @@
 #  - Linux/macOS POSIX sh
 #
 #  Version History:
+#  20260822 - Use POSIX find for direct Trash entries.
 #  20260711 - Replace the awk {n,} interval expression in usage() with a portable
 #             equivalent, since mawk on some systems matches it incorrectly.
 #  20260508 - Normalize cleanup retention periods to 0, 1, 7, and 30 days.
@@ -202,7 +203,9 @@ perform_cleanup() {
     rm -vf "$HOME/.xsession-errors"
 
     if [ -d "$HOME/.local/share/Trash" ]; then
-        find "$HOME/.local/share/Trash" -mindepth 1 -exec rm -rf {} +
+        find "$HOME/.local/share/Trash" \
+            ! -path "$HOME/.local/share/Trash" \
+            -prune -exec rm -rf {} +
     fi
 
     rm -vf "$HOME"/.ssh/known_hosts.old

--- a/doc/POLICY
+++ b/doc/POLICY
@@ -670,6 +670,10 @@ Before a change is proposed, it answers these:
 
 ### 2.1 Basic Principles
 - Comply strictly with POSIX (`#!/bin/sh`).
+- POSIX compliance also covers the options, regular expressions, and escape
+  sequences of the standard utilities a script invokes, not just shell
+  grammar. Do not rely on a GNU or BSD extension in a portable code path
+  (e.g. `find -maxdepth`, `sort -V`, non-standard `sed` escapes).
 - Avoid Bash-specific syntax and extensions.
 - Do not use `local`.
 - `/bin/sh` is dash on Debian and Ubuntu. A construct that works because

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -26,6 +26,8 @@ v2.0.1 (Release Date: TBD)
 - Slim down the bulk package installers, take their package names from shell
   word splitting instead of a non-portable sed expression, and stop treating
   a failed update, installation, or listing as success.
+- Replace non-portable find and sort options with POSIX equivalents across
+  shell utilities and installers.
 - Modernize Python environment diagnostics.
 
 v2.0 (2026-07-31)

--- a/git-symlink.sh
+++ b/git-symlink.sh
@@ -43,6 +43,8 @@
 #      -u, --uninstall Remove matching symlinks in $HOME (do not recreate).
 #
 #  Version History:
+#  v1.2 2026-08-22
+#       Use POSIX find for first-level repository and symlink discovery.
 #  v1.1 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -170,7 +172,7 @@ recreate_links_for_bases() {
             continue
         fi
         # List only first-level directories
-        find "$base" -mindepth 1 -maxdepth 1 -type d -print | while IFS= read -r d; do
+        find "$base" ! -path "$base" -prune -type d -print | while IFS= read -r d; do
             create_or_replace_link "$d"
         done
     done
@@ -181,7 +183,7 @@ purge_broken_symlinks_in_home() {
     # Finds symlinks in $HOME whose targets no longer exist and removes them
     echo "[INFO] Purging broken symlinks in $HOME"
     # Only depth=1 (directly under $HOME) to avoid unintended recursion
-    find "$HOME" -mindepth 1 -maxdepth 1 -type l -print | while IFS= read -r l; do
+    find "$HOME" ! -path "$HOME" -prune -type l -print | while IFS= read -r l; do
         if [ ! -e "$l" ]; then
             if [ "$DRY_RUN" = true ]; then
                 echo "[INFO] DRY RUN: rm -f \"$l\""
@@ -202,7 +204,7 @@ uninstall_matching_symlinks() {
             echo "[WARN] Base not found: $base" >&2
             continue
         fi
-        find "$base" -mindepth 1 -maxdepth 1 -type d -print | while IFS= read -r d; do
+        find "$base" ! -path "$base" -prune -type d -print | while IFS= read -r d; do
             name=$(basename "$d")
             path="$HOME/$name"
             if [ -L "$path" ]; then

--- a/gpx_sync.sh
+++ b/gpx_sync.sh
@@ -53,6 +53,8 @@
 #  127. Required command(s) not installed.
 #
 #  Version History:
+#  v3.1 2026-08-22
+#       Use POSIX find for first-level GPX file operations.
 #  v3.0 2026-07-12
 #       Create the destination yearly directory before copying files so that
 #       the first run of a new year no longer fails with a missing directory.
@@ -138,7 +140,7 @@ check_commands() {
 # Check if GPX files exist in a directory
 check_gpx_files() {
     dir="$1"
-    if ! find "$dir" -maxdepth 1 -name '*.gpx' -type f | grep -q .; then
+    if ! find "$dir" ! -path "$dir" -prune -name '*.gpx' -type f | grep -q .; then
         echo "[ERROR] No GPX files found in $dir. Exiting." >&2
         return 1
     fi
@@ -208,7 +210,8 @@ copy_files_to_user_storage() {
         fi
     fi
     echo "[INFO] Copying files from $source_dir to user storage: $destination"
-    find "$source_dir" -maxdepth 1 -name '*.gpx' -type f -exec cp {} "$destination" \;
+    find "$source_dir" ! -path "$source_dir" -prune \
+        -name '*.gpx' -type f -exec cp {} "$destination" \;
 }
 
 # Set permissions for copied GPX files
@@ -220,7 +223,8 @@ set_file_permissions() {
         return 2
     fi
     echo "[INFO] Setting GPX file permissions in $destination to $permissions"
-    find "$destination" -maxdepth 1 -name '*.gpx' -type f -exec chmod "$permissions" {} \;
+    find "$destination" ! -path "$destination" -prune \
+        -name '*.gpx' -type f -exec chmod "$permissions" {} \;
 }
 
 # Sync to all configured hosts

--- a/installer/create_ubygems.sh
+++ b/installer/create_ubygems.sh
@@ -36,6 +36,8 @@
 #    for a `x.y.z` version directory under `lib/ruby/`.
 #
 #  Version History:
+#  v1.7 2026-08-22
+#       Select custom Ruby versions with POSIX find and awk.
 #  v1.6 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -90,8 +92,29 @@ get_custom_ruby_path() {
         exit 1
     fi
 
-    # Find the latest x.y.z format directory under lib/ruby
-    RUBY_VERSION=$(find "$BASE_DIR/lib/ruby" -maxdepth 1 -type d | grep -E '/[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1)
+    # Find the highest x.y.z format directory directly under lib/ruby
+    RUBY_VERSION=$(find "$BASE_DIR/lib/ruby" \
+        ! -path "$BASE_DIR/lib/ruby" -prune -type d -print |
+        awk -F/ '
+            {
+                name = $NF
+                if (name !~ /^[0-9]+\.[0-9]+\.[0-9]+$/) next
+                split(name, v, ".")
+                major = v[1] + 0
+                minor = v[2] + 0
+                patch = v[3] + 0
+                if (!found || major > bmajor ||
+                    (major == bmajor && minor > bminor) ||
+                    (major == bmajor && minor == bminor && patch > bpatch)) {
+                    found = 1
+                    bmajor = major
+                    bminor = minor
+                    bpatch = patch
+                    best = name
+                }
+            }
+            END { if (found) print best }
+        ')
 
     # Ensure a valid directory was found
     if [ -z "$RUBY_VERSION" ]; then
@@ -99,8 +122,6 @@ get_custom_ruby_path() {
         exit 1
     fi
 
-    # Extract only the x.y.z part and set target directory
-    RUBY_VERSION=$(basename "$RUBY_VERSION")
     TARGET_DIR="$BASE_DIR/lib/ruby/$RUBY_VERSION"
 }
 
@@ -156,7 +177,7 @@ main() {
     esac
 
     # Ensure required commands are available before proceeding
-    check_commands find grep sort tail basename ls cat
+    check_commands find awk ls cat
 
     # Determine target directory
     if [ -n "$1" ]; then

--- a/installer/install_dotfiles.sh
+++ b/installer/install_dotfiles.sh
@@ -30,6 +30,8 @@
 #  - Run with appropriate permissions if modifying system-wide settings.
 #
 #  Version History:
+#  v3.4 2026-08-22
+#       Use POSIX find for first-level home directory operations.
 #  v3.3 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -242,7 +244,7 @@ deploy_dotfiles_to_mac() {
             copy_ssh_file_if_exists "$user_home" "$user" config
             copy_ssh_file_if_exists "$user_home" "$user" known_hosts
             sudo chown "$user:$(id -gn "$user")" "$user_home"
-            sudo find "$user_home" -maxdepth 1 -mindepth 1 -exec chown "$user:$(id -gn "$user")" {} +
+            sudo find "$user_home" ! -path "$user_home" -prune -exec chown "$user:$(id -gn "$user")" {} +
         fi
         shift
     done
@@ -258,7 +260,7 @@ deploy_dotfiles_to_linux() {
             copy_ssh_file_if_exists "/home/$1" "$1" config
             copy_ssh_file_if_exists "/home/$1" "$1" known_hosts
             sudo chown "$1:$(id -gn "$1")" "/home/$1"
-            sudo find "/home/$1" -maxdepth 1 -mindepth 1 -exec chown "$1:$(id -gn "$1")" {} +
+            sudo find "/home/$1" ! -path "/home/$1" -prune -exec chown "$1:$(id -gn "$1")" {} +
         fi
         shift
     done
@@ -266,7 +268,7 @@ deploy_dotfiles_to_linux() {
 
 # Deploy dotfiles to multiple users across different OS environments
 bulk_deploy() {
-    test -d "/home" && test -d "/home/$USER" && find /home -mindepth 1 -maxdepth 1 -type d -exec sudo chmod 0750 {} +
+    test -d "/home" && test -d "/home/$USER" && find /home ! -path /home -prune -type d -exec sudo chmod 0750 {} +
     test -d /home/opt && sudo chmod 0755 /home/opt
 
     # Harden local SSH source permissions if present

--- a/installer/setup_rsyslog_cron.sh
+++ b/installer/setup_rsyslog_cron.sh
@@ -42,6 +42,8 @@
 #  - Commands: sudo, awk, find, grep, cmp, chown, chmod, cp, mktemp, rsyslogd, uname
 #
 #  Version History:
+#  v1.2 2026-08-22
+#       Use POSIX find for rsyslog drop-in discovery.
 #  v1.1 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -122,7 +124,21 @@ check_target_dir() {
 # Detect existing split logging (cron.none) in main or drop-in configs
 has_cron_none() {
     # Collect candidate config files from common include dirs
-    files=$(find /etc/rsyslog.conf.d "$TARGET_DIR" -maxdepth 1 -type f -name '*.conf' 2>/dev/null)
+    files=$(
+        {
+            if [ -d /etc/rsyslog.conf.d ]; then
+                find /etc/rsyslog.conf.d \
+                    ! -path /etc/rsyslog.conf.d \
+                    -prune -type f -name '*.conf' -print
+            fi
+
+            if [ -d "$TARGET_DIR" ]; then
+                find "$TARGET_DIR" \
+                    ! -path "$TARGET_DIR" \
+                    -prune -type f -name '*.conf' -print
+            fi
+        } 2>/dev/null
+    )
     # Match only non-comment lines that actually contain cron.none in a selector
     grep -hE '^[[:space:]]*[^#].*cron\.none' /etc/rsyslog.conf $files 2>/dev/null | grep -q .
 }

--- a/installer/setup_rsyslog_postfix.sh
+++ b/installer/setup_rsyslog_postfix.sh
@@ -46,6 +46,8 @@
 #  - Commands: sudo, awk, find, grep, cmp, chown, chmod, cp, mktemp, mv, rsyslogd, uname, test
 #
 #  Version History:
+#  v1.3 2026-08-22
+#       Use POSIX find for rsyslog drop-in discovery.
 #  v1.2 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -130,7 +132,21 @@ check_target_dir() {
 has_postfix_split() {
     # Consider both main file and common include directories
     files_main="/etc/rsyslog.conf"
-    files_dropin=$(find /etc/rsyslog.conf.d "$TARGET_DIR" -maxdepth 1 -type f -name '*.conf' 2>/dev/null)
+    files_dropin=$(
+        {
+            if [ -d /etc/rsyslog.conf.d ]; then
+                find /etc/rsyslog.conf.d \
+                    ! -path /etc/rsyslog.conf.d \
+                    -prune -type f -name '*.conf' -print
+            fi
+
+            if [ -d "$TARGET_DIR" ]; then
+                find "$TARGET_DIR" \
+                    ! -path "$TARGET_DIR" \
+                    -prune -type f -name '*.conf' -print
+            fi
+        } 2>/dev/null
+    )
 
     # Heuristics:
     #  - Any rule that routes postfix to a dedicated file (e.g., /var/log/postfix.log)

--- a/setup_scripts.sh
+++ b/setup_scripts.sh
@@ -31,6 +31,8 @@
 #      - To all files under scripts/cron/bin (no extension filter)
 #
 #  Version History:
+#  v2.5 2026-08-22
+#       Use POSIX find for current-directory script selection.
 #  v2.4 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -114,7 +116,7 @@ set_permissions() {
 
     echo "[INFO] Granting execute permissions to script files (*.sh, *.py, *.rb) including current directory."
     find "$SCRIPTS" -type f \( -name "*.sh" -o -name "*.py" -o -name "*.rb" \) -exec chmod u+x,g+x,o+x {} \;
-    find . -maxdepth 1 -type f \( -name "*.sh" -o -name "*.py" -o -name "*.rb" \) -exec chmod u+x,g+x,o+x {} \;
+    find . ! -path . -prune -type f \( -name "*.sh" -o -name "*.py" -o -name "*.rb" \) -exec chmod u+x,g+x,o+x {} \;
     RC2=$?
 
     echo "[INFO] Granting execute permissions to installer scripts (*.sh, *.py, *.rb)."

--- a/tree.sh
+++ b/tree.sh
@@ -22,6 +22,8 @@
 #  or with '-a' option to include hidden directories.
 #
 #  Version History:
+#  v2.0 2026-08-22
+#       Use POSIX find negation when excluding hidden paths.
 #  v1.9 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -104,7 +106,7 @@ display_tree() {
     if [ "$show_hidden" = true ]; then
         find . -print | sort | sed '1d;s/^\.//;s/\/\([^/]*\)$/|--\1/;s/\/[^/|]*/|  /g'
     else
-        find . -not -path '*/\.*' -print | sort | sed '1d;s/^\.//;s/\/\([^/]*\)$/|--\1/;s/\/[^/|]*/|  /g'
+        find . ! -path '*/\.*' -print | sort | sed '1d;s/^\.//;s/\/\([^/]*\)$/|--\1/;s/\/[^/|]*/|  /g'
     fi
 }
 


### PR DESCRIPTION
## Summary
- Replace `find -maxdepth`, `find -mindepth`, and `find -not` (none guaranteed by POSIX, and BSD/macOS `find` can behave differently) with the POSIX `! -path "$dir" -prune` direct-child pattern and the `!` negation, across `tree.sh`, `cltmp.sh`, `git-symlink.sh`, `gpx_sync.sh`, `setup_scripts.sh`, `installer/install_dotfiles.sh`, `installer/setup_rsyslog_cron.sh`, and `installer/setup_rsyslog_postfix.sh`. Root-exclusion, direct-entries-only, and no-recursion semantics are preserved everywhere.
- Replace `installer/create_ubygems.sh`'s `find -maxdepth | grep | sort -V | tail | basename` version-directory pipeline with POSIX `find`/`-prune` enumeration and an `awk` numeric major/minor/patch comparison, so `3.10.1` correctly outranks `3.9.9` instead of losing to it under lexical sort. `check_commands` no longer requires `grep`/`sort`/`tail`/`basename` and now requires `awk`.
- Note in `doc/POLICY` that the strict-POSIX principle covers standard-utility options/regexes/escapes, not just shell grammar, and record the change in `doc/VERSIONS`.

This is split out from #68, which covers the unrelated `install_gems.sh` failure-propagation fix.

## Test plan
- [x] `sh -n` on all 9 changed shell scripts
- [x] Functional check in a temp dir: `tree.sh` default vs `-a` hidden-path behavior
- [x] Functional check in a temp dir: the `! -path/-prune` pattern lists only direct children, not nested entries
- [x] Functional check in a temp dir: `create_ubygems.sh` selects `4.0.1` from a mixed version set, and `3.10.1` over `3.9.9` (numeric, not lexical)
- [x] `SCRIPTS="$PWD" sh test/check_scripts.sh` (140/140 succeeded)
- [x] `python check_header_doc.py -a` (clean)
- [x] `git diff --check` against `master`


---
_Generated by [Claude Code](https://claude.ai/code/session_01SefjLoQ9SBz9XqGktZyXnF)_