### PR TITLE
Align Python/Ruby bulk installers, pyck.py deps, and docs with the slimmed package sets

### DIFF
--- a/doc/FEATURES.md
+++ b/doc/FEATURES.md
@@ -1202,12 +1202,12 @@ It also supports user-local installation through `--no-sudo`.
 
 ### install_pip.sh
 
-Uses pip to install a predefined set of Python libraries for data analysis, machine learning, scientific computing, web development, and related tasks.
+Uses pip to install a compact predefined set of Python libraries for scientific computing, data analysis, machine learning, and Hugging Face work, plus the Python code-quality tools that pyck.py requires.
 
 
 ### install_conda.sh
 
-Installs a broad set of libraries and tools into a Conda environment for data analysis, machine learning, web development, and related tasks.
+Installs a compact, focused set of libraries and tools into a Conda environment for scientific computing, data analysis, machine learning, and Hugging Face work.
 
 
 ### setup_python_symlink.sh
@@ -1226,7 +1226,7 @@ By default, it uses a directory under `/opt/ruby/x.y`.
 
 ### install_gems.sh
 
-Updates RubyGems and installs a predefined set of gems for web development, data processing, and related tasks.
+Updates RubyGems and installs a compact, focused set of commonly used modern Ruby development gems.
 
 
 ### create_ubygems.sh

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -23,9 +23,8 @@ v2.0.1 (Release Date: TBD)
 - Prevent remove-repo.sh repository names from escaping the configured
   directories.
 - Reject invalid source directory paths in unzip_subdir.py.
-- Slim down the bulk package installers, take their package names from shell
-  word splitting instead of a non-portable sed expression, and stop treating
-  a failed update, installation, or listing as success.
+- Slim down the bulk package installers and improve package-manager failure
+  handling.
 - Replace non-portable find and sort options with POSIX equivalents across
   shell utilities and installers.
 - Modernize Python environment diagnostics.

--- a/installer/install_conda.sh
+++ b/installer/install_conda.sh
@@ -26,7 +26,9 @@
 #
 #  Exit Status:
 #  0: Success - All libraries were installed successfully.
-#  1: Error - A critical issue occurred (e.g., missing dependencies).
+#  1: Error - A general installation or update failure occurred.
+#  126: Error - A required command exists but is not executable.
+#  127: Error - A required command was not found.
 #
 #  Notes:
 #  - If no path is provided, the script assumes the default installation
@@ -36,14 +38,8 @@
 #
 #  Version History:
 #  v2.0 2026-08-22
-#       Reduce the broad historical package set to the established
-#       libraries for scientific computing, machine learning, and Hugging
-#       Face under their Conda names, leaving twelve direct installation
-#       targets, drop the additional packages installed through Easy
-#       Install, and let the package loop use install_lib().
-#       Take each package name from shell word splitting instead of a
-#       non-portable sed expression, and stop at the first failed Conda
-#       update or installation with a non-zero exit status.
+#       Slim the package set, remove Easy Install, and improve
+#       portability and Conda failure handling.
 #  v1.4 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.

--- a/installer/install_gems.sh
+++ b/installer/install_gems.sh
@@ -4,11 +4,11 @@
 # install_gems.sh: Bulk Ruby Gem Install Script
 #
 #  Description:
-#  This script automates the installation of a comprehensive set of Ruby
-#  gems required for web development, data processing, and other purposes.
-#  It updates the gem system to the latest version and installs frequently
-#  used gems. Proxy settings are supported via the HTTP_PROXY environment
-#  variable, ensuring compatibility with various network configurations.
+#  This script automates the installation of a compact, focused set of
+#  commonly used modern Ruby development gems. It updates the gem system
+#  to the latest version and installs these gems. Proxy settings are
+#  supported via the HTTP_PROXY environment variable, ensuring
+#  compatibility with various network configurations.
 #
 #  Author: id774 (More info: http://id774.net)
 #  Source Code: https://github.com/id774/scripts
@@ -27,7 +27,9 @@
 #
 #  Exit Status:
 #  0: Success - All gems were installed successfully.
-#  1: Error - A critical issue occurred (e.g., missing dependencies).
+#  1: Error - A general installation or update failure occurred.
+#  126: Error - A required command exists but is not executable.
+#  127: Error - A required command was not found.
 #
 #  Notes:
 #  - If no path is provided, the script assumes default tools in PATH.
@@ -35,9 +37,8 @@
 #
 #  Version History:
 #  v4.0 2026-08-22
-#       Narrow the bulk install list to twelve modern Ruby gems, drop the
-#       non-portable sed-based name trimming, and propagate RubyGems
-#       update/install/list failures instead of always exiting successfully.
+#       Slim the gem set and improve portability and RubyGems failure
+#       handling.
 #  v3.4 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.

--- a/installer/install_pip.sh
+++ b/installer/install_pip.sh
@@ -6,10 +6,11 @@
 #  Description:
 #  This script automates the installation of a compact set of Python
 #  libraries for scientific computing, data analysis, machine learning,
-#  and Hugging Face work. It ensures that these libraries are updated to
-#  their latest versions for optimal performance and compatibility.
-#  Additionally, the script supports environments with or without proxy
-#  settings, making it suitable for various network configurations.
+#  and Hugging Face work, plus the Python code-quality tools that pyck.py
+#  requires. It ensures that these libraries are updated to their latest
+#  versions for optimal performance and compatibility. Additionally, the
+#  script supports environments with or without proxy settings, making it
+#  suitable for various network configurations.
 #
 #  Author: id774 (More info: http://id774.net)
 #  Source Code: https://github.com/id774/scripts
@@ -28,7 +29,9 @@
 #
 #  Exit Status:
 #  0: Success - All libraries were installed successfully.
-#  1: Error - A critical issue occurred (e.g., missing dependencies).
+#  1: Error - A general installation or update failure occurred.
+#  126: Error - A required command exists but is not executable.
+#  127: Error - A required command was not found.
 #
 #  Notes:
 #  - If no path is provided, the script assumes default tools in PATH.
@@ -36,11 +39,9 @@
 #
 #  Version History:
 #  v2.0 2026-08-22
-#       Reduce the broad historical package set to the established
-#       libraries for scientific computing, machine learning, and Hugging
-#       Face, add standard Python code quality tools, and drop the
-#       additional packages installed through Easy Install. Exit with an
-#       error when pip fails.
+#       Slim the package set, retain the Python code-quality tools
+#       required by pyck.py, remove Easy Install, and propagate pip
+#       failures.
 #  v1.4 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.

--- a/show_version.py
+++ b/show_version.py
@@ -42,10 +42,11 @@
 #
 #  Version History:
 #  v3.0 2026-08-22
-#       Modernized the broad Python package catalog, added distribution
-#       metadata based version detection when available, retained actual
-#       module imports as an environment health check, and distinguished
-#       missing packages from import failures.
+#       Modernized the broad Python package catalog to track the current
+#       bulk installer targets, added distribution metadata based version
+#       detection when available, retained actual module imports as an
+#       environment health check, and distinguished missing packages from
+#       import failures.
 #  v2.7 2025-07-01
 #       Standardized termination behavior for consistent script execution.
 #  v2.6 2025-06-23
@@ -97,6 +98,7 @@ PACKAGES = [
     ('flake8', 'flake8'),
     ('pyflakes', 'pyflakes'),
     ('autopep8', 'autopep8'),
+    ('autoflake', 'autoflake'),
     ('isort', 'isort'),
     ('mypy', 'mypy'),
     ('Cython', 'Cython'),

--- a/test/show_version_test.py
+++ b/test/show_version_test.py
@@ -30,7 +30,8 @@
 #  Version History:
 #  v1.1 2026-08-22
 #       Added test coverage for the v3.0 metadata/import classification
-#       logic and the distribution-name to import-name mapping catalog.
+#       logic, the distribution-name to import-name mapping catalog, and
+#       the Python code-quality tools required by pyck.py.
 #  v1.0 2025-07-07
 #       Initial release.
 #
@@ -329,7 +330,8 @@ class TestShowVersion(unittest.TestCase):
                          'datasets', 'huggingface_hub', 'scikit-learn', 'xgboost',
                          'lightgbm', 'catboost', 'numpy', 'scipy', 'pandas', 'polars',
                          'pyarrow', 'Flask', 'Django', 'fastapi', 'requests', 'httpx',
-                         'spacy', 'mecab-python3'):
+                         'spacy', 'mecab-python3', 'autopep8', 'flake8', 'autoflake',
+                         'isort'):
             self.assertIn(expected, names)
 
     def test_catalog_excludes_removed_packages(self):


### PR DESCRIPTION
install_conda.sh was missing the autopep8/flake8/autoflake/isort tools
that pyck.py requires, even though install_pip.sh already installed
them; add them as regular Conda install targets. show_version.py's
diagnostic catalog was missing autoflake, so it could not report on
every package the bulk installers introduce; add it and extend
show_version_test.py's catalog coverage test to lock in all four
pyck.py tools.

Update install_pip.sh, install_conda.sh, and install_gems.sh headers
(Description, Exit Status, Version History) to match current behavior:
the Exit Status sections were missing the 126/127 codes check_commands()
already returns, and the Descriptions and Version History entries still
described the pre-slimdown package sets in more implementation detail
than the release-level scope warrants. Refresh the matching doc/FEATURES.md
entries, which still described install_pip.sh/install_conda.sh/install_gems.sh
by their old, broader package sets. Shorten the doc/VERSIONS bulk-installer
bullet to a release-level summary, consistent with the rest of that section.

No new Version History or doc/VERSIONS entries are added; all of the above
fold into the existing same-day 2026-08-22 entries per POLICY.