### PR TITLE
Fix three isolated Shell Script portability defects without changing behavior

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -27,6 +27,8 @@ v2.0.1 (Release Date: TBD)
   handling.
 - Replace non-portable find and sort options with POSIX equivalents across
   shell utilities and installers.
+- Fix selected Shell Script portability defects without changing existing
+  workflows.
 - Modernize Python environment diagnostics.
 
 v2.0 (2026-07-31)

--- a/exif_drop.sh
+++ b/exif_drop.sh
@@ -22,6 +22,9 @@
 #  - Ensure that the exiftool and jhead utilities are installed before running this script.
 #
 #  Version History:
+#  v2.0 2026-08-22
+#       Replace read -d pathname processing with POSIX find -exec while
+#       preserving pathname safety.
 #  v1.9 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -94,15 +97,20 @@ process_images() {
         usage
     fi
 
-    $FIND "$dir" -type f -print0 | while IFS= read -r -d '' file
-    do
-        if [ -n "$($EXIFTOOL -gps:GPSLatitude "$file" 2>/dev/null)" ]; then
-            $JHEAD -purejpg "$file"
-            echo "[INFO] Processed: $file"
-        else
-            echo "[INFO] Skipped: $file"
-        fi
-    done
+    "$FIND" "$dir" -type f -exec sh -c '
+        exiftool=$1
+        jhead=$2
+        shift 2
+
+        for file do
+            if [ -n "$("$exiftool" -gps:GPSLatitude "$file" 2>/dev/null)" ]; then
+                "$jhead" -purejpg "$file"
+                echo "[INFO] Processed: $file"
+            else
+                echo "[INFO] Skipped: $file"
+            fi
+        done
+    ' sh "$EXIFTOOL" "$JHEAD" {} +
 }
 
 # Main entry point of the script

--- a/get_resources.sh
+++ b/get_resources.sh
@@ -26,6 +26,8 @@
 #      - Security-related logs and fail2ban status
 #
 #  Version History:
+#  v2.6 2026-08-22
+#       Use POSIX head -n syntax without changing resource report output.
 #  v2.5 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -196,7 +198,7 @@ gather_os_specific_info() {
         execute_command df -H
         execute_command top -l 1
         execute_command ps aux
-        execute_command ps -axo pid,rss,%mem,etime,comm -r | head -20
+        execute_command ps -axo pid,rss,%mem,etime,comm -r | head -n 20
         execute_command pmset -g batt
     else
         execute_command sh -c "grep -m1 'model name' /proc/cpuinfo | cut -d: -f2"
@@ -205,7 +207,7 @@ gather_os_specific_info() {
         execute_command df -P -T
         execute_command top -b -n 1
         execute_command ps aux
-        execute_command ps aux --sort=-rss | head -20
+        execute_command ps aux --sort=-rss | head -n 20
         display_power_summary
     fi
 }

--- a/installer/create_emergencyadmin.sh
+++ b/installer/create_emergencyadmin.sh
@@ -21,6 +21,8 @@
 #      ./create_emergencyadmin.sh
 #
 #  Version History:
+#  v1.3 2026-08-22
+#       Use POSIX tail -n syntax when selecting the highest existing UID.
 #  v1.2 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -113,7 +115,7 @@ prompt_passwords() {
 
 # Create a new admin user with a unique UID
 create_admin_user() {
-    MAX_UID=$(dscl . -list /Users UniqueID | awk '{print $2}' | sort -n | tail -1)
+    MAX_UID=$(dscl . -list /Users UniqueID | awk '{print $2}' | sort -n | tail -n 1)
     NEW_UID=$((MAX_UID + 1))
 
     echo "[INFO] Creating admin user '$USERNAME'..."


### PR DESCRIPTION
exif_drop.sh used find -print0 | while read -r -d '' to stay safe with
newline-containing pathnames, but read -d is not available in every
dash build. Replace it with find -exec sh -c '...' sh "$EXIFTOOL"
"$JHEAD" {} +, passing matched paths as positional parameters instead
of a re-parsed text stream, which keeps the same pathname safety
(including embedded newlines) using only POSIX find. The exiftool/jhead
invocation, GPS check, and [INFO] Processed/Skipped messages are
unchanged.

get_resources.sh and installer/create_emergencyadmin.sh used the
legacy `head -20` / `tail -1` numeric-option form, not guaranteed
portable; switch both call sites to `head -n 20` and `tail -n 1`. No
other line in either file is touched.