### PR TITLE
Refactor dry-run to report only auto-fix changes, add autopep8 check

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -29,6 +29,8 @@ v2.0.1 (Release Date: TBD)
 - Fix selected Shell Script portability defects without changing existing
   workflows.
 - Modernize Python environment diagnostics.
+- Make pyck.py dry-run report only changes that auto-fix would apply,
+  separating lint diagnostics.
 
 v2.0 (2026-07-31)
 -----------------

--- a/pyck.py
+++ b/pyck.py
@@ -11,6 +11,11 @@
 #  dry-run mode to display potential changes without modifying files,
 #  and in auto-fix mode to apply changes. It supports multiple files and
 #  directories, including wildcard usage.
+#  In dry-run mode, "Would clean:", "Would format:", and "Would sort
+#  imports in:" are reported only when autoflake, autopep8, or isort
+#  respectively would actually change a file under auto-fix; flake8
+#  lint diagnostics are reported separately as "Lint issue:" and never
+#  affect those change reports.
 #
 #  Author: id774 (More info: http://id774.net)
 #  Source Code: https://github.com/id774/scripts
@@ -22,8 +27,9 @@
 #      pyck.py [file(s) or directory(ies)]
 #  Example:
 #      pyck.py ./my_python_project *.py
-#  This mode shows which files would be formatted, cleaned, and have imports organized,
-#  without making changes.
+#  This mode shows which files would be formatted, cleaned, and have imports organized
+#  by -i, without making changes. flake8 lint diagnostics are shown separately and do
+#  not affect these change reports.
 #
 #  With -i (Actual formatting mode):
 #      pyck.py -i [file(s) or directory(ies)]
@@ -37,6 +43,9 @@
 #  - Dependencies: autopep8, flake8, autoflake, isort
 #
 #  Version History:
+#  v2.8 2026-08-22
+#       Make dry-run report only changes that auto-fix would apply,
+#       separating flake8 lint diagnostics from formatting changes.
 #  v2.7 2026-07-15
 #       Quote file and directory paths before interpolating them into
 #       shell commands, to support paths containing spaces.
@@ -139,20 +148,9 @@ def format_imports(file_path):
     command = "isort {}".format(shlex.quote(file_path))
     subprocess.Popen(command, shell=True).wait()
 
-def dry_run_formatting(paths, ignore_errors):
-    """ Perform a dry run to show which files would be formatted and cleaned without making actual changes. """
-    for path in paths:
-        print(
-            "[INFO] DRY RUN: No files will be modified for '{}'. Use -i to auto-fix.".format(path))
-        run_command("flake8 --ignore={} {}".format(ignore_errors,
-                    shlex.quote(path)), show_files="Would format:")
-        run_command("autoflake --imports=django,requests,urllib3 --check {}".format(shlex.quote(path)),
-                    show_files="Would clean:")
-        run_command("isort --check-only {}".format(shlex.quote(path)),
-                    show_files="Would sort imports in:")
-
-def execute_formatting(paths, ignore_errors):
-    """ Execute auto-formatting and cleaning on specified Python files or directories. """
+def resolve_target_files(paths):
+    """ Resolve the given files/directories into the concrete list of .py files to process. """
+    target_files = []
     for path in paths:
         actual_path = path[0] if isinstance(path, list) else path
 
@@ -160,13 +158,31 @@ def execute_formatting(paths, ignore_errors):
             for root, dirs, files in os.walk(actual_path):
                 for name in files:
                     if name.endswith('.py'):
-                        file_path = os.path.join(root, name)
-                        format_file(file_path, ignore_errors)
+                        target_files.append(os.path.join(root, name))
         elif os.path.isfile(actual_path):
-            format_file(actual_path, ignore_errors)
+            target_files.append(actual_path)
         else:
             print("[ERROR] The specified path '{}' is neither a file nor a directory.".format(
                 actual_path), file=sys.stderr)
+    return target_files
+
+def dry_run_formatting(paths, ignore_errors):
+    """ Perform a dry run to show which files auto-fix would change, without making actual changes. """
+    print("[INFO] DRY RUN: No files will be modified. Use -i to auto-fix.")
+    for file_path in resolve_target_files(paths):
+        run_command("flake8 --ignore={} {}".format(ignore_errors,
+                    shlex.quote(file_path)), show_files="Lint issue:")
+        run_command("autoflake --imports=django,requests,urllib3 --check {}".format(shlex.quote(file_path)),
+                    show_files="Would clean: {}".format(file_path), literal_message=True)
+        run_command("autopep8 --ignore={} --diff --exit-code {}".format(ignore_errors, shlex.quote(file_path)),
+                    show_files="Would format: {}".format(file_path), literal_message=True)
+        run_command("isort --check-only {}".format(shlex.quote(file_path)),
+                    show_files="Would sort imports in: {}".format(file_path), literal_message=True)
+
+def execute_formatting(paths, ignore_errors):
+    """ Execute auto-formatting and cleaning on specified Python files or directories. """
+    for file_path in resolve_target_files(paths):
+        format_file(file_path, ignore_errors)
 
 def format_file(file_path, ignore_errors):
     """ Format a single Python file by cleaning up imports, and applying 'autopep8' and 'isort'. """
@@ -177,16 +193,19 @@ def format_file(file_path, ignore_errors):
     subprocess.Popen(command, shell=True).wait()
     format_imports(file_path)
 
-def run_command(command, show_files=None):
-    """ Execute a shell command and optionally display formatted files. """
+def run_command(command, show_files=None, literal_message=False):
+    """ Execute a shell command and optionally display a message when it reports a non-zero exit status. """
     process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
     stdout, _ = process.communicate()
     if isinstance(stdout, bytes):
         stdout = stdout.decode('utf-8')
     if process.returncode != 0 and show_files:
-        for line in stdout.split('\n'):
-            if line:
-                print("{} {}".format(show_files, line))
+        if literal_message:
+            print(show_files)
+        else:
+            for line in stdout.split('\n'):
+                if line:
+                    print("{} {}".format(show_files, line))
 
 def main():
     """ Parse command-line arguments and perform formatting or dry-run based on the input. """

--- a/test/pyck_test.py
+++ b/test/pyck_test.py
@@ -27,11 +27,29 @@
 #    - Verify format_file() quotes a file path containing spaces before passing it to the shell.
 #    - Suppress output on successful run_command() execution.
 #    - Print the provided error prefix and command output when run_command() returns a non-zero status.
-#    - In dry-run mode, run flake8/autoflake/isort checks for a single Python file.
-#    - In dry-run mode, verify a path containing spaces is quoted before being passed to the shell.
-#    - In dry-run mode, run flake8/autoflake/isort checks for multiple Python files.
-#    - In dry-run mode, run flake8/autoflake/isort checks for a single directory path.
-#    - In dry-run mode, run flake8/autoflake/isort checks for multiple directory paths.
+#    - Print a single literal message when run_command() is called with literal_message=True.
+#    - In dry-run mode, run flake8/autoflake/autopep8/isort checks for a single Python file.
+#    - In dry-run mode, verify a path containing spaces is quoted before being passed to flake8,
+#      autoflake, autopep8, and isort, including the new autopep8 --diff --exit-code command.
+#    - In dry-run mode, run flake8/autoflake/autopep8/isort checks for multiple Python files.
+#    - In dry-run mode, run flake8/autoflake/autopep8/isort checks for each .py file under a
+#      single directory.
+#    - In dry-run mode, run flake8/autoflake/autopep8/isort checks for each .py file under
+#      multiple directories.
+#    - Regression: a flake8-only lint issue (autoflake/autopep8/isort all report no changes)
+#      must not produce "Would format:".
+#    - Regression: an autopep8-only diff (autoflake/isort report no changes) must produce
+#      "Would format:" for the target file.
+#    - "Would clean:" is shown only when autoflake reports a change is needed.
+#    - "Would sort imports in:" is shown only when isort reports a change is needed.
+#    - When autoflake, autopep8, and isort all report no changes, none of "Would clean:",
+#      "Would format:", or "Would sort imports in:" is shown.
+#    - Dry-run never invokes autoflake -i, autopep8 -i, or a plain (non-check) isort command,
+#      and only runs check/diff commands against the target file.
+#    - resolve_target_files() resolves a single file, a directory (recursively, .py files
+#      only), and reports the existing invalid-path error.
+#    - dry_run_formatting() and execute_formatting() resolve and operate on the same set of
+#      .py files for the same input paths.
 #    - In execute (auto-fix) mode, format a single Python file via format_file().
 #    - In execute (auto-fix) mode, format a mix of directory and file paths and report an error for invalid paths.
 #    - In execute (auto-fix) mode, format a single directory by formatting each .py file under it.
@@ -43,6 +61,10 @@
 #    - Verify check_command behavior via alternate patching for non-executable commands.
 #
 #  Version History:
+#  v1.4 2026-08-22
+#       Add regression coverage for dry-run change detection: separate flake8 lint
+#       diagnostics from "Would format:", add the missing autopep8 diff check, and
+#       verify dry-run and auto-fix resolve the same target files.
 #  v1.3 2026-07-15
 #       Add test cases verifying that paths with spaces are quoted
 #       before being passed to format_file and dry_run_formatting.
@@ -65,6 +87,21 @@ from unittest.mock import MagicMock, call, patch
 # Adjust the path to import script from the parent directory
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import pyck
+
+
+def _popen_side_effect(rules):
+    """ Build a subprocess.Popen side_effect returning canned results keyed by command substring. """
+    def side_effect(command, shell=True, stdout=None):
+        mock_process = MagicMock()
+        for key, (returncode, out) in rules.items():
+            if key in command:
+                mock_process.communicate.return_value = (out, '')
+                mock_process.returncode = returncode
+                return mock_process
+        mock_process.communicate.return_value = ('', '')
+        mock_process.returncode = 0
+        return mock_process
+    return side_effect
 
 
 class TestPyck(unittest.TestCase):
@@ -175,7 +212,24 @@ class TestPyck(unittest.TestCase):
 
     @patch('pyck.subprocess.Popen')
     @patch('pyck.print')
-    def test_dry_run_formatting_single_file(self, mock_print, mock_popen):
+    def test_run_command_literal_message(self, mock_print, mock_popen):
+        # literal_message=True prints show_files verbatim, ignoring command output
+        mock_process = MagicMock()
+        mock_process.communicate.return_value = ('--- a\n+++ b\n', '')
+        mock_process.returncode = 2
+        mock_popen.return_value = mock_process
+
+        pyck.run_command('autopep8 --diff --exit-code test.py',
+                          show_files="Would format: test.py", literal_message=True)
+        mock_print.assert_called_once_with("Would format: test.py")
+
+    @patch('pyck.subprocess.Popen')
+    @patch('pyck.print')
+    @patch('pyck.os.path.isdir')
+    @patch('pyck.os.path.isfile')
+    def test_dry_run_formatting_single_file(self, mock_isfile, mock_isdir, mock_print, mock_popen):
+        mock_isdir.return_value = False
+        mock_isfile.return_value = True
         mock_process = MagicMock()
         mock_process.communicate.return_value = ('output', 'error')
         mock_process.returncode = 0
@@ -190,11 +244,17 @@ class TestPyck(unittest.TestCase):
         mock_popen.assert_any_call(
             "autoflake --imports=django,requests,urllib3 --check path/to/single_file.py", shell=True, stdout=-1)
         mock_popen.assert_any_call(
+            "autopep8 --ignore=E302,E402,E501 --diff --exit-code path/to/single_file.py", shell=True, stdout=-1)
+        mock_popen.assert_any_call(
             "isort --check-only path/to/single_file.py", shell=True, stdout=-1)
 
     @patch('pyck.subprocess.Popen')
     @patch('pyck.print')
-    def test_dry_run_formatting_with_multiple_files(self, mock_print, mock_popen):
+    @patch('pyck.os.path.isdir')
+    @patch('pyck.os.path.isfile')
+    def test_dry_run_formatting_with_multiple_files(self, mock_isfile, mock_isdir, mock_print, mock_popen):
+        mock_isdir.return_value = False
+        mock_isfile.return_value = True
         mock_process = MagicMock()
         mock_process.communicate.return_value = ('output', 'error')
         mock_process.returncode = 0
@@ -208,11 +268,15 @@ class TestPyck(unittest.TestCase):
                  shell=True, stdout=-1),
             call("autoflake --imports=django,requests,urllib3 --check path/to/file1.py",
                  shell=True, stdout=-1),
+            call("autopep8 --ignore=E302,E402,E501 --diff --exit-code path/to/file1.py",
+                 shell=True, stdout=-1),
             call("isort --check-only path/to/file1.py",
                  shell=True, stdout=-1),
             call("flake8 --ignore=E302,E402,E501 path/to/file2.py",
                  shell=True, stdout=-1),
             call("autoflake --imports=django,requests,urllib3 --check path/to/file2.py",
+                 shell=True, stdout=-1),
+            call("autopep8 --ignore=E302,E402,E501 --diff --exit-code path/to/file2.py",
                  shell=True, stdout=-1),
             call("isort --check-only path/to/file2.py",
                  shell=True, stdout=-1)
@@ -221,7 +285,11 @@ class TestPyck(unittest.TestCase):
 
     @patch('pyck.subprocess.Popen')
     @patch('pyck.print')
-    def test_dry_run_formatting_quotes_path_with_spaces(self, mock_print, mock_popen):
+    @patch('pyck.os.path.isdir')
+    @patch('pyck.os.path.isfile')
+    def test_dry_run_formatting_quotes_path_with_spaces(self, mock_isfile, mock_isdir, mock_print, mock_popen):
+        mock_isdir.return_value = False
+        mock_isfile.return_value = True
         mock_process = MagicMock()
         mock_process.communicate.return_value = ('output', 'error')
         mock_process.returncode = 0
@@ -235,64 +303,270 @@ class TestPyck(unittest.TestCase):
         mock_popen.assert_any_call(
             "autoflake --imports=django,requests,urllib3 --check 'path/to/my file.py'", shell=True, stdout=-1)
         mock_popen.assert_any_call(
+            "autopep8 --ignore=E302,E402,E501 --diff --exit-code 'path/to/my file.py'", shell=True, stdout=-1)
+        mock_popen.assert_any_call(
             "isort --check-only 'path/to/my file.py'", shell=True, stdout=-1)
 
     @patch('pyck.subprocess.Popen')
     @patch('pyck.print')
-    def test_dry_run_formatting_single_directory(self, mock_print, mock_popen):
+    @patch('pyck.os.path.isdir')
+    @patch('pyck.os.path.isfile')
+    @patch('pyck.os.walk')
+    def test_dry_run_formatting_single_directory(self, mock_walk, mock_isfile, mock_isdir, mock_print, mock_popen):
+        mock_isdir.return_value = True
+        mock_isfile.return_value = False
+        mock_walk.return_value = [
+            ('path/to/directory', [], ['file1.py', 'file2.py'])]
         mock_process = MagicMock()
         mock_process.communicate.return_value = ('output', 'error')
         mock_process.returncode = 0
         mock_popen.return_value = mock_process
 
-        with patch('pyck.os.walk') as mock_walk:
-            mock_walk.return_value = [
-                ('path/to/directory', [], ['file1.py', 'file2.py'])]
+        pyck.dry_run_formatting(['path/to/directory'], 'E302,E402,E501')
 
-            pyck.dry_run_formatting(['path/to/directory'], 'E302,E402,E501')
-
-            expected_calls = [
-                call("flake8 --ignore=E302,E402,E501 path/to/directory",
+        expected_calls = []
+        for name in ('file1.py', 'file2.py'):
+            target = os.path.join('path/to/directory', name)
+            expected_calls.extend([
+                call("flake8 --ignore=E302,E402,E501 {}".format(target),
                      shell=True, stdout=-1),
-                call("autoflake --imports=django,requests,urllib3 --check path/to/directory",
+                call("autoflake --imports=django,requests,urllib3 --check {}".format(target),
                      shell=True, stdout=-1),
-                call("isort --check-only path/to/directory",
-                     shell=True, stdout=-1)
-            ]
-            mock_popen.assert_has_calls(expected_calls, any_order=True)
+                call("autopep8 --ignore=E302,E402,E501 --diff --exit-code {}".format(target),
+                     shell=True, stdout=-1),
+                call("isort --check-only {}".format(target),
+                     shell=True, stdout=-1),
+            ])
+        mock_popen.assert_has_calls(expected_calls, any_order=True)
 
     @patch('pyck.subprocess.Popen')
     @patch('pyck.print')
-    def test_dry_run_formatting_multiple_directories(self, mock_print, mock_popen):
+    @patch('pyck.os.path.isdir')
+    @patch('pyck.os.path.isfile')
+    @patch('pyck.os.walk')
+    def test_dry_run_formatting_multiple_directories(self, mock_walk, mock_isfile, mock_isdir, mock_print, mock_popen):
+        mock_isdir.return_value = True
+        mock_isfile.return_value = False
+        mock_walk.side_effect = [
+            [('path/to/dir1', [], ['file1.py', 'file2.py'])],
+            [('path/to/dir2', [], ['file3.py', 'file4.py'])]
+        ]
         mock_process = MagicMock()
         mock_process.communicate.return_value = ('output', 'error')
         mock_process.returncode = 0
         mock_popen.return_value = mock_process
 
-        with patch('pyck.os.walk') as mock_walk:
-            mock_walk.side_effect = [
-                [('path/to/dir1', [], ['file1.py', 'file2.py'])],
-                [('path/to/dir2', [], ['file3.py', 'file4.py'])]
-            ]
+        pyck.dry_run_formatting(
+            ['path/to/dir1', 'path/to/dir2'], 'E302,E402,E501')
 
-            pyck.dry_run_formatting(
-                ['path/to/dir1', 'path/to/dir2'], 'E302,E402,E501')
+        expected_calls = []
+        for root, name in (('path/to/dir1', 'file1.py'), ('path/to/dir1', 'file2.py'),
+                            ('path/to/dir2', 'file3.py'), ('path/to/dir2', 'file4.py')):
+            target = os.path.join(root, name)
+            expected_calls.extend([
+                call("flake8 --ignore=E302,E402,E501 {}".format(target),
+                     shell=True, stdout=-1),
+                call("autoflake --imports=django,requests,urllib3 --check {}".format(target),
+                     shell=True, stdout=-1),
+                call("autopep8 --ignore=E302,E402,E501 --diff --exit-code {}".format(target),
+                     shell=True, stdout=-1),
+                call("isort --check-only {}".format(target),
+                     shell=True, stdout=-1),
+            ])
+        mock_popen.assert_has_calls(expected_calls, any_order=True)
 
-            expected_calls = [
-                call("flake8 --ignore=E302,E402,E501 path/to/dir1",
-                     shell=True, stdout=-1),
-                call("autoflake --imports=django,requests,urllib3 --check path/to/dir1",
-                     shell=True, stdout=-1),
-                call("isort --check-only path/to/dir1",
-                     shell=True, stdout=-1),
-                call("flake8 --ignore=E302,E402,E501 path/to/dir2",
-                     shell=True, stdout=-1),
-                call("autoflake --imports=django,requests,urllib3 --check path/to/dir2",
-                     shell=True, stdout=-1),
-                call("isort --check-only path/to/dir2",
-                     shell=True, stdout=-1)
-            ]
-            mock_popen.assert_has_calls(expected_calls, any_order=True)
+    @patch('pyck.subprocess.Popen')
+    @patch('pyck.print')
+    @patch('pyck.os.path.isdir')
+    @patch('pyck.os.path.isfile')
+    def test_dry_run_formatting_flake8_only_does_not_report_would_format(self, mock_isfile, mock_isdir, mock_print, mock_popen):
+        # Regression: a flake8-only lint issue must never surface as "Would format:".
+        mock_isdir.return_value = False
+        mock_isfile.return_value = True
+        mock_popen.side_effect = _popen_side_effect({
+            'flake8': (1, "path/to/file.py:1:1: F401 'os' imported but unused"),
+            'autoflake': (0, ''),
+            'autopep8': (0, ''),
+            'isort': (0, ''),
+        })
+
+        pyck.dry_run_formatting(['path/to/file.py'], 'E302,E402,E501')
+
+        would_format_calls = [c for c in mock_print.call_args_list
+                              if 'Would format:' in str(c)]
+        self.assertEqual(would_format_calls, [])
+        mock_print.assert_any_call(
+            "Lint issue: path/to/file.py:1:1: F401 'os' imported but unused")
+
+    @patch('pyck.subprocess.Popen')
+    @patch('pyck.print')
+    @patch('pyck.os.path.isdir')
+    @patch('pyck.os.path.isfile')
+    def test_dry_run_formatting_autopep8_only_reports_would_format(self, mock_isfile, mock_isdir, mock_print, mock_popen):
+        # Regression: autopep8 alone reporting a diff must produce "Would format:".
+        mock_isdir.return_value = False
+        mock_isfile.return_value = True
+        mock_popen.side_effect = _popen_side_effect({
+            'flake8': (0, ''),
+            'autoflake': (0, ''),
+            'autopep8': (2, '--- original\n+++ fixed\n'),
+            'isort': (0, ''),
+        })
+
+        pyck.dry_run_formatting(['path/to/file.py'], 'E302,E402,E501')
+
+        mock_print.assert_any_call("Would format: path/to/file.py")
+
+    @patch('pyck.subprocess.Popen')
+    @patch('pyck.print')
+    @patch('pyck.os.path.isdir')
+    @patch('pyck.os.path.isfile')
+    def test_dry_run_formatting_reports_would_clean_only_when_autoflake_changes(self, mock_isfile, mock_isdir, mock_print, mock_popen):
+        mock_isdir.return_value = False
+        mock_isfile.return_value = True
+        mock_popen.side_effect = _popen_side_effect({
+            'flake8': (0, ''),
+            'autoflake': (1, ''),
+            'autopep8': (0, ''),
+            'isort': (0, ''),
+        })
+
+        pyck.dry_run_formatting(['path/to/file.py'], 'E302,E402,E501')
+
+        mock_print.assert_any_call("Would clean: path/to/file.py")
+
+    @patch('pyck.subprocess.Popen')
+    @patch('pyck.print')
+    @patch('pyck.os.path.isdir')
+    @patch('pyck.os.path.isfile')
+    def test_dry_run_formatting_reports_would_sort_only_when_isort_changes(self, mock_isfile, mock_isdir, mock_print, mock_popen):
+        mock_isdir.return_value = False
+        mock_isfile.return_value = True
+        mock_popen.side_effect = _popen_side_effect({
+            'flake8': (0, ''),
+            'autoflake': (0, ''),
+            'autopep8': (0, ''),
+            'isort': (1, ''),
+        })
+
+        pyck.dry_run_formatting(['path/to/file.py'], 'E302,E402,E501')
+
+        mock_print.assert_any_call("Would sort imports in: path/to/file.py")
+
+    @patch('pyck.subprocess.Popen')
+    @patch('pyck.print')
+    @patch('pyck.os.path.isdir')
+    @patch('pyck.os.path.isfile')
+    def test_dry_run_formatting_no_change_reports_nothing(self, mock_isfile, mock_isdir, mock_print, mock_popen):
+        mock_isdir.return_value = False
+        mock_isfile.return_value = True
+        mock_process = MagicMock()
+        mock_process.communicate.return_value = ('', '')
+        mock_process.returncode = 0
+        mock_popen.return_value = mock_process
+
+        pyck.dry_run_formatting(['path/to/file.py'], 'E302,E402,E501')
+
+        for label in ('Would clean:', 'Would format:', 'Would sort imports in:'):
+            matching_calls = [c for c in mock_print.call_args_list if label in str(c)]
+            self.assertEqual(matching_calls, [])
+
+    @patch('pyck.subprocess.Popen')
+    @patch('pyck.print')
+    @patch('pyck.os.path.isdir')
+    @patch('pyck.os.path.isfile')
+    def test_dry_run_formatting_never_uses_write_mode_commands(self, mock_isfile, mock_isdir, mock_print, mock_popen):
+        # Safety: dry-run must only invoke check/diff commands, never the mutating ones.
+        mock_isdir.return_value = False
+        mock_isfile.return_value = True
+        mock_process = MagicMock()
+        mock_process.communicate.return_value = ('', '')
+        mock_process.returncode = 0
+        mock_popen.return_value = mock_process
+
+        pyck.dry_run_formatting(['path/to/file.py'], 'E302,E402,E501')
+
+        for command_call in mock_popen.call_args_list:
+            command = command_call.args[0]
+            self.assertNotIn('autoflake --imports=django,requests,urllib3 -i', command)
+            self.assertNotIn('autopep8 --ignore=E302,E402,E501 -v -i', command)
+            self.assertNotRegex(command, r'^isort (?!--check-only)')
+        mock_popen.assert_any_call(
+            "autoflake --imports=django,requests,urllib3 --check path/to/file.py", shell=True, stdout=-1)
+        mock_popen.assert_any_call(
+            "autopep8 --ignore=E302,E402,E501 --diff --exit-code path/to/file.py", shell=True, stdout=-1)
+        mock_popen.assert_any_call(
+            "isort --check-only path/to/file.py", shell=True, stdout=-1)
+
+    @patch('pyck.os.path.isdir')
+    @patch('pyck.os.path.isfile')
+    def test_resolve_target_files_single_file(self, mock_isfile, mock_isdir):
+        mock_isdir.return_value = False
+        mock_isfile.return_value = True
+
+        result = pyck.resolve_target_files(['path/to/file.py'])
+
+        self.assertEqual(result, ['path/to/file.py'])
+
+    @patch('pyck.os.walk')
+    @patch('pyck.os.path.isdir')
+    @patch('pyck.os.path.isfile')
+    def test_resolve_target_files_directory(self, mock_isfile, mock_isdir, mock_walk):
+        mock_isdir.return_value = True
+        mock_isfile.return_value = False
+        mock_walk.return_value = [
+            ('path/to/directory', [], ['file1.py', 'file2.py', 'notes.txt'])]
+
+        result = pyck.resolve_target_files(['path/to/directory'])
+
+        self.assertEqual(result, [
+            os.path.join('path/to/directory', 'file1.py'),
+            os.path.join('path/to/directory', 'file2.py'),
+        ])
+
+    @patch('pyck.print')
+    @patch('pyck.os.path.isdir')
+    @patch('pyck.os.path.isfile')
+    def test_resolve_target_files_invalid_path(self, mock_isfile, mock_isdir, mock_print):
+        mock_isdir.return_value = False
+        mock_isfile.return_value = False
+
+        result = pyck.resolve_target_files(['invalid/path'])
+
+        self.assertEqual(result, [])
+        mock_print.assert_called_with(
+            "[ERROR] The specified path 'invalid/path' is neither a file nor a directory.", file=sys.stderr)
+
+    @patch('pyck.subprocess.Popen')
+    @patch('pyck.format_file')
+    @patch('pyck.print')
+    @patch('pyck.os.path.isdir')
+    @patch('pyck.os.path.isfile')
+    @patch('pyck.os.walk')
+    def test_dry_run_and_execute_formatting_target_same_files(self, mock_walk, mock_isfile, mock_isdir, mock_print, mock_format_file, mock_popen):
+        # dry-run and auto-fix must resolve and act on the exact same set of .py files.
+        mock_isdir.return_value = True
+        mock_isfile.return_value = False
+        mock_walk.return_value = [
+            ('path/to/directory', [], ['file1.py', 'file2.py'])]
+        mock_process = MagicMock()
+        mock_process.communicate.return_value = ('', '')
+        mock_process.returncode = 0
+        mock_popen.return_value = mock_process
+
+        pyck.execute_formatting(['path/to/directory'], 'E302,E402,E501')
+        auto_fix_files = sorted(c.args[0] for c in mock_format_file.call_args_list)
+
+        pyck.dry_run_formatting(['path/to/directory'], 'E302,E402,E501')
+        dry_run_files = sorted(set(
+            c.args[0].split()[-1] for c in mock_popen.call_args_list))
+
+        expected_files = sorted([
+            os.path.join('path/to/directory', 'file1.py'),
+            os.path.join('path/to/directory', 'file2.py'),
+        ])
+        self.assertEqual(auto_fix_files, expected_files)
+        self.assertEqual(dry_run_files, expected_files)
 
     @patch('pyck.format_file')
     @patch('pyck.print')


### PR DESCRIPTION
## Summary
This PR refactors the dry-run mode to accurately report only the changes that auto-fix would apply, while separating flake8 lint diagnostics from formatting change reports. It also adds the missing autopep8 diff check to dry-run mode.

## Key Changes

- **Added autopep8 check to dry-run**: Introduced `autopep8 --diff --exit-code` command in dry-run mode to detect formatting changes that autopep8 would apply, matching the auto-fix behavior.

- **Separated lint diagnostics from formatting reports**: Flake8 output is now reported as "Lint issue:" and does not trigger "Would format:" messages. Only actual formatting tools (autoflake, autopep8, isort) trigger their respective "Would clean:", "Would format:", and "Would sort imports in:" messages.

- **Extracted file resolution logic**: Created new `resolve_target_files()` function that converts file/directory paths into a concrete list of .py files. This ensures dry-run and auto-fix operate on the exact same set of files.

- **Refactored dry-run implementation**: 
  - Now processes individual files instead of passing directories directly to tools
  - Uses `literal_message=True` parameter to print exact messages only when tools report changes
  - Moved per-path info message to a single message at the start

- **Enhanced `run_command()` function**: Added `literal_message` parameter to support printing exact messages (e.g., "Would format: file.py") instead of appending tool output to a prefix.

- **Updated documentation**: Clarified that dry-run shows changes that auto-fix would apply, with flake8 diagnostics reported separately.

## Implementation Details

- The `_popen_side_effect()` helper function in tests enables flexible mocking of different tool outputs based on command substrings.
- Comprehensive test coverage added for regression scenarios: flake8-only issues, autopep8-only changes, and combinations of tool outputs.
- Safety test ensures dry-run never invokes mutating commands (`autoflake -i`, `autopep8 -i`, plain `isort`).

https://claude.ai/code/session_01UoyHRRzzQ9LHmnCQ2qcWDp