### PR TITLE
Distinguish auto-fixable changes from lint findings in pyck

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -29,8 +29,8 @@ v2.0.1 (Release Date: TBD)
 - Fix selected Shell Script portability defects without changing existing
   workflows.
 - Modernize Python environment diagnostics.
-- Make pyck.py dry-run report only changes that auto-fix would apply,
-  separating lint diagnostics.
+- Make pyck.py distinguish auto-fixable changes from lint findings and
+  report unresolved lint issues after auto-fix.
 
 v2.0 (2026-07-31)
 -----------------

--- a/pyck.py
+++ b/pyck.py
@@ -4,18 +4,32 @@
 # pyck.py: Comprehensive Python Code Formatter and Linter
 #
 #  Description:
-#  This script performs code style checks, auto-formatting, and removal
-#  of unused imports for Python files. It uses flake8 for linting,
-#  autopep8 for auto-formatting, autoflake for removing unused
-#  imports, and isort for organizing imports. The script can operate in
-#  dry-run mode to display potential changes without modifying files,
-#  and in auto-fix mode to apply changes. It supports multiple files and
-#  directories, including wildcard usage.
-#  In dry-run mode, "Would clean:", "Would format:", and "Would sort
-#  imports in:" are reported only when autoflake, autopep8, or isort
-#  respectively would actually change a file under auto-fix; flake8
-#  lint diagnostics are reported separately as "Lint issue:" and never
-#  affect those change reports.
+#  This script performs Python code auto-fixing and lint checking. It uses
+#  autoflake to remove unused imports, autopep8 to apply formatting fixes,
+#  isort to organize imports, and flake8 to detect lint issues.
+#
+#  pyck deliberately separates changes that its automatic fixers can apply
+#  from lint findings that may require human judgment. "Would clean:",
+#  "Would format:", and "Would sort imports in:" are reserved for changes
+#  that pyck -i directly applies through autoflake, autopep8, and isort.
+#  flake8 findings are reported separately because flake8 can detect real
+#  defects that the configured automatic fixers cannot safely rewrite.
+#
+#  Without -i, pyck performs a non-destructive dry run. flake8 findings are
+#  reported as "Lint issue (manual review candidate):". They are described
+#  as candidates at this stage because a later autoflake, autopep8, or isort
+#  change may indirectly eliminate the condition.
+#
+#  With -i, pyck first runs autoflake, autopep8, and isort for each file,
+#  then runs flake8 against the resulting file. Any lint findings that remain
+#  are reported as "Manual fix required:". This means the configured
+#  automatic fixers have completed and the remaining finding requires human
+#  review.
+#
+#  Remaining lint findings are advisory diagnostics, not pyck execution
+#  failures. A normally completed pyck run returns status 0 even when
+#  "Manual fix required:" findings remain. Existing non-zero statuses for
+#  actual execution failures are unchanged.
 #
 #  Author: id774 (More info: http://id774.net)
 #  Source Code: https://github.com/id774/scripts
@@ -27,16 +41,20 @@
 #      pyck.py [file(s) or directory(ies)]
 #  Example:
 #      pyck.py ./my_python_project *.py
-#  This mode shows which files would be formatted, cleaned, and have imports organized
-#  by -i, without making changes. flake8 lint diagnostics are shown separately and do
-#  not affect these change reports.
+#  This mode never modifies files. "Would clean:", "Would format:", and
+#  "Would sort imports in:" identify changes that -i would directly apply.
+#  flake8 findings are shown separately as
+#  "Lint issue (manual review candidate):" because they are not guaranteed
+#  to require manual correction until auto-fix has been applied.
 #
 #  With -i (Actual formatting mode):
 #      pyck.py -i [file(s) or directory(ies)]
 #  Example:
 #      pyck.py -i ./my_python_project *.py
-#  This mode actually formats, cleans, and organizes imports in the Python files
-#  in the specified files or directories.
+#  For each file, this mode runs autoflake, autopep8, and isort, then runs
+#  flake8 on the resulting file. Remaining lint findings are reported as
+#  "Manual fix required:". These findings require human review but do not
+#  change the normal exit status from 0.
 #
 #  Requirements:
 #  - Python Version: 3.2 or later
@@ -44,8 +62,8 @@
 #
 #  Version History:
 #  v2.8 2026-08-22
-#       Make dry-run report only changes that auto-fix would apply,
-#       separating flake8 lint diagnostics from formatting changes.
+#       Distinguish auto-fixable changes from lint findings and report
+#       unresolved lint issues after auto-fix.
 #  v2.7 2026-07-15
 #       Quote file and directory paths before interpolating them into
 #       shell commands, to support paths containing spaces.
@@ -170,8 +188,10 @@ def dry_run_formatting(paths, ignore_errors):
     """ Perform a dry run to show which files auto-fix would change, without making actual changes. """
     print("[INFO] DRY RUN: No files will be modified. Use -i to auto-fix.")
     for file_path in resolve_target_files(paths):
-        run_command("flake8 --ignore={} {}".format(ignore_errors,
-                    shlex.quote(file_path)), show_files="Lint issue:")
+        run_command(
+            "flake8 --ignore={} {}".format(
+                ignore_errors, shlex.quote(file_path)),
+            show_files="Lint issue (manual review candidate):")
         run_command("autoflake --imports=django,requests,urllib3 --check {}".format(shlex.quote(file_path)),
                     show_files="Would clean: {}".format(file_path), literal_message=True)
         run_command("autopep8 --ignore={} --diff --exit-code {}".format(ignore_errors, shlex.quote(file_path)),
@@ -180,9 +200,13 @@ def dry_run_formatting(paths, ignore_errors):
                     show_files="Would sort imports in: {}".format(file_path), literal_message=True)
 
 def execute_formatting(paths, ignore_errors):
-    """ Execute auto-formatting and cleaning on specified Python files or directories. """
+    """ Execute auto-formatting and report lint issues that remain afterward. """
     for file_path in resolve_target_files(paths):
         format_file(file_path, ignore_errors)
+        run_command(
+            "flake8 --ignore={} {}".format(
+                ignore_errors, shlex.quote(file_path)),
+            show_files="Manual fix required:")
 
 def format_file(file_path, ignore_errors):
     """ Format a single Python file by cleaning up imports, and applying 'autopep8' and 'isort'. """

--- a/test/pyck_test.py
+++ b/test/pyck_test.py
@@ -38,6 +38,11 @@
 #      multiple directories.
 #    - Regression: a flake8-only lint issue (autoflake/autopep8/isort all report no changes)
 #      must not produce "Would format:".
+#    - Report dry-run flake8 findings as "Lint issue (manual review candidate):".
+#    - Run flake8 after autoflake, autopep8, and isort in auto-fix mode.
+#    - Report flake8 findings remaining after auto-fix as "Manual fix required:".
+#    - Keep exit status 0 when lint findings remain after a successful auto-fix run.
+#    - Quote paths containing spaces in the post-fix flake8 command.
 #    - Regression: an autopep8-only diff (autoflake/isort report no changes) must produce
 #      "Would format:" for the target file.
 #    - "Would clean:" is shown only when autoflake reports a change is needed.
@@ -62,9 +67,8 @@
 #
 #  Version History:
 #  v1.4 2026-08-22
-#       Add regression coverage for dry-run change detection: separate flake8 lint
-#       diagnostics from "Would format:", add the missing autopep8 diff check, and
-#       verify dry-run and auto-fix resolve the same target files.
+#       Cover auto-fix change detection, lint candidate reporting, and
+#       unresolved lint diagnostics after auto-fix.
 #  v1.3 2026-07-15
 #       Add test cases verifying that paths with spaces are quoted
 #       before being passed to format_file and dry_run_formatting.
@@ -396,7 +400,8 @@ class TestPyck(unittest.TestCase):
                               if 'Would format:' in str(c)]
         self.assertEqual(would_format_calls, [])
         mock_print.assert_any_call(
-            "Lint issue: path/to/file.py:1:1: F401 'os' imported but unused")
+            "Lint issue (manual review candidate): "
+            "path/to/file.py:1:1: F401 'os' imported but unused")
 
     @patch('pyck.subprocess.Popen')
     @patch('pyck.print')
@@ -555,9 +560,13 @@ class TestPyck(unittest.TestCase):
         mock_popen.return_value = mock_process
 
         pyck.execute_formatting(['path/to/directory'], 'E302,E402,E501')
-        auto_fix_files = sorted(c.args[0] for c in mock_format_file.call_args_list)
+        auto_fix_files = sorted(
+            c.args[0] for c in mock_format_file.call_args_list)
 
-        pyck.dry_run_formatting(['path/to/directory'], 'E302,E402,E501')
+        mock_popen.reset_mock()
+
+        pyck.dry_run_formatting(
+            ['path/to/directory'], 'E302,E402,E501')
         dry_run_files = sorted(set(
             c.args[0].split()[-1] for c in mock_popen.call_args_list))
 
@@ -568,11 +577,14 @@ class TestPyck(unittest.TestCase):
         self.assertEqual(auto_fix_files, expected_files)
         self.assertEqual(dry_run_files, expected_files)
 
+    @patch('pyck.run_command')
     @patch('pyck.format_file')
     @patch('pyck.print')
     @patch('pyck.os.path')
     @patch('pyck.os.walk')
-    def test_execute_formatting_single_file(self, mock_walk, mock_path, mock_print, mock_format_file):
+    def test_execute_formatting_single_file(
+            self, mock_walk, mock_path, mock_print,
+            mock_format_file, mock_run_command):
         # Mocking file existence
         mock_path.isfile.return_value = True
         mock_path.isdir.return_value = False
@@ -584,14 +596,22 @@ class TestPyck(unittest.TestCase):
         mock_format_file.assert_called_once_with(
             'path/to/single_file.py', 'E302,E402,E501')
 
+        mock_run_command.assert_called_once_with(
+            "flake8 --ignore=E302,E402,E501 path/to/single_file.py",
+            show_files="Manual fix required:")
+
+    @patch('pyck.run_command')
     @patch('pyck.format_file')
     @patch('pyck.print')
     @patch('pyck.os.path')
     @patch('pyck.os.walk')
-    def test_execute_formatting_with_multiple_files(self, mock_walk, mock_path, mock_print, mock_format_file):
+    def test_execute_formatting_with_multiple_files(
+            self, mock_walk, mock_path, mock_print,
+            mock_format_file, mock_run_command):
         # Mocking file and directory existence
         mock_path.isfile.side_effect = lambda p: p == 'path/to/file.py'
         mock_path.isdir.side_effect = lambda p: p == 'path/to/directory'
+        mock_path.join.side_effect = lambda *parts: '/'.join(parts)
         mock_walk.return_value = [
             ('path/to/directory', [], ['file1.py', 'file2.py'])]
 
@@ -608,19 +628,33 @@ class TestPyck(unittest.TestCase):
         # Verify format_file call for a single file
         mock_format_file.assert_any_call('path/to/file.py', 'E302,E402,E501')
 
+        mock_run_command.assert_any_call(
+            "flake8 --ignore=E302,E402,E501 path/to/directory/file1.py",
+            show_files="Manual fix required:")
+        mock_run_command.assert_any_call(
+            "flake8 --ignore=E302,E402,E501 path/to/directory/file2.py",
+            show_files="Manual fix required:")
+        mock_run_command.assert_any_call(
+            "flake8 --ignore=E302,E402,E501 path/to/file.py",
+            show_files="Manual fix required:")
+
         # Test behavior when path is neither a file nor a directory
         pyck.execute_formatting(['invalid/path'], 'E302,E402,E501')
         mock_print.assert_called_with(
             "[ERROR] The specified path 'invalid/path' is neither a file nor a directory.", file=sys.stderr)
 
+    @patch('pyck.run_command')
     @patch('pyck.format_file')
     @patch('pyck.print')
     @patch('pyck.os.path')
     @patch('pyck.os.walk')
-    def test_execute_formatting_single_directory(self, mock_walk, mock_path, mock_print, mock_format_file):
+    def test_execute_formatting_single_directory(
+            self, mock_walk, mock_path, mock_print,
+            mock_format_file, mock_run_command):
         # Mocking directory existence
         mock_path.isfile.return_value = False
         mock_path.isdir.return_value = True
+        mock_path.join.side_effect = lambda *parts: '/'.join(parts)
         mock_walk.return_value = [
             ('path/to/directory', [], ['file1.py', 'file2.py'])]
 
@@ -633,15 +667,26 @@ class TestPyck(unittest.TestCase):
         mock_format_file.assert_any_call(expected_file1_path, 'E302,E402,E501')
         mock_format_file.assert_any_call(expected_file2_path, 'E302,E402,E501')
 
+        mock_run_command.assert_any_call(
+            "flake8 --ignore=E302,E402,E501 path/to/directory/file1.py",
+            show_files="Manual fix required:")
+        mock_run_command.assert_any_call(
+            "flake8 --ignore=E302,E402,E501 path/to/directory/file2.py",
+            show_files="Manual fix required:")
+
+    @patch('pyck.run_command')
     @patch('pyck.format_file')
     @patch('pyck.print')
     @patch('pyck.os.path')
     @patch('pyck.os.walk')
-    def test_execute_formatting_multiple_directories(self, mock_walk, mock_path, mock_print, mock_format_file):
+    def test_execute_formatting_multiple_directories(
+            self, mock_walk, mock_path, mock_print,
+            mock_format_file, mock_run_command):
         # Mocking multiple directories
         mock_path.isfile.return_value = False
         mock_path.isdir.side_effect = lambda p: p in [
             'path/to/dir1', 'path/to/dir2']
+        mock_path.join.side_effect = lambda *parts: '/'.join(parts)
         mock_walk.side_effect = [
             [('path/to/dir1', [], ['file1.py', 'file2.py'])],
             [('path/to/dir2', [], ['file3.py', 'file4.py'])]
@@ -659,6 +704,120 @@ class TestPyck(unittest.TestCase):
         ]
         for call in expected_calls:
             mock_format_file.assert_any_call(call, 'E302,E402,E501')
+
+        mock_run_command.assert_any_call(
+            "flake8 --ignore=E302,E402,E501 path/to/dir1/file1.py",
+            show_files="Manual fix required:")
+        mock_run_command.assert_any_call(
+            "flake8 --ignore=E302,E402,E501 path/to/dir1/file2.py",
+            show_files="Manual fix required:")
+        mock_run_command.assert_any_call(
+            "flake8 --ignore=E302,E402,E501 path/to/dir2/file3.py",
+            show_files="Manual fix required:")
+        mock_run_command.assert_any_call(
+            "flake8 --ignore=E302,E402,E501 path/to/dir2/file4.py",
+            show_files="Manual fix required:")
+
+    @patch('pyck.run_command')
+    @patch('pyck.format_file')
+    @patch('pyck.resolve_target_files')
+    def test_execute_formatting_runs_flake8_after_format_file(
+            self, mock_resolve_target_files,
+            mock_format_file, mock_run_command):
+        mock_resolve_target_files.return_value = ['path/to/file.py']
+
+        calls = MagicMock()
+        calls.attach_mock(mock_format_file, 'format_file')
+        calls.attach_mock(mock_run_command, 'run_command')
+
+        pyck.execute_formatting(
+            ['path/to/file.py'], 'E302,E402,E501')
+
+        self.assertEqual(calls.mock_calls, [
+            call.format_file(
+                'path/to/file.py', 'E302,E402,E501'),
+            call.run_command(
+                'flake8 --ignore=E302,E402,E501 path/to/file.py',
+                show_files='Manual fix required:'),
+        ])
+
+    @patch('pyck.subprocess.Popen')
+    @patch('pyck.print')
+    def test_run_command_reports_manual_fix_required(
+            self, mock_print, mock_popen):
+        mock_process = MagicMock()
+        mock_process.communicate.return_value = (
+            "path/to/file.py:10:5: F811 redefinition of unused 'test_case'",
+            '')
+        mock_process.returncode = 1
+        mock_popen.return_value = mock_process
+
+        pyck.run_command(
+            'flake8 --ignore=E302,E402,E501 path/to/file.py',
+            show_files='Manual fix required:')
+
+        mock_print.assert_called_once_with(
+            "Manual fix required: "
+            "path/to/file.py:10:5: F811 "
+            "redefinition of unused 'test_case'")
+
+    @patch('pyck.run_command')
+    @patch('pyck.format_file')
+    @patch('pyck.resolve_target_files')
+    def test_execute_formatting_quotes_path_for_post_fix_flake8(
+            self, mock_resolve_target_files,
+            mock_format_file, mock_run_command):
+        mock_resolve_target_files.return_value = [
+            'path/to/my file.py']
+
+        pyck.execute_formatting(
+            ['path/to/my file.py'], 'E302,E402,E501')
+
+        mock_run_command.assert_called_once_with(
+            "flake8 --ignore=E302,E402,E501 "
+            "'path/to/my file.py'",
+            show_files='Manual fix required:')
+
+    @patch('pyck.print')
+    @patch('pyck.subprocess.Popen')
+    @patch('pyck.format_file')
+    @patch('pyck.resolve_target_files')
+    @patch('pyck.check_command')
+    @patch('pyck.setup_argument_parser')
+    def test_main_returns_zero_when_lint_remains_after_auto_fix(
+            self, mock_setup_argument_parser, mock_check_command,
+            mock_resolve_target_files, mock_format_file,
+            mock_popen, mock_print):
+        mock_parser = MagicMock()
+        mock_args = MagicMock()
+        mock_args.paths = ['path/to/file.py']
+        mock_args.auto_fix = True
+        mock_parser.parse_args.return_value = mock_args
+        mock_setup_argument_parser.return_value = mock_parser
+
+        mock_resolve_target_files.return_value = ['path/to/file.py']
+
+        mock_process = MagicMock()
+        mock_process.communicate.return_value = (
+            "path/to/file.py:10:5: F811 redefinition of unused 'test_case'",
+            '')
+        mock_process.returncode = 1
+        mock_popen.return_value = mock_process
+
+        result = pyck.main()
+
+        self.assertEqual(result, 0)
+        mock_print.assert_any_call(
+            "Manual fix required: "
+            "path/to/file.py:10:5: F811 "
+            "redefinition of unused 'test_case'")
+
+        mock_check_command.assert_has_calls([
+            call('autopep8'),
+            call('flake8'),
+            call('autoflake'),
+            call('isort'),
+        ])
 
     @patch('pyck.os.path.isfile')
     @patch.dict('pyck.os.environ', {'PATH': '/usr/bin:/bin'})


### PR DESCRIPTION
## Summary
This PR refactors pyck to clearly separate automatic code fixes from lint findings that require manual review. In dry-run mode, flake8 findings are now reported as "Lint issue (manual review candidate):" to indicate they may be resolved by subsequent auto-fixes. In auto-fix mode, flake8 is run after formatting changes and remaining findings are reported as "Manual fix required:", with the exit status remaining 0 to indicate normal completion despite unresolved lint issues.

## Key Changes

- **Dry-run mode**: Changed flake8 reporting from "Lint issue:" to "Lint issue (manual review candidate):" to clarify that findings may be resolved by auto-fix changes
- **Auto-fix mode**: Added post-fix flake8 execution in `execute_formatting()` that runs after `format_file()` for each target file
- **Lint reporting**: Introduced `run_command()` calls with `show_files="Manual fix required:"` parameter to report unresolved lint issues after auto-fix
- **Path quoting**: Ensured file paths are properly quoted in post-fix flake8 commands to support paths containing spaces
- **Exit status**: Maintained exit status 0 on normal completion even when "Manual fix required:" findings remain, distinguishing advisory diagnostics from execution failures
- **Documentation**: Updated module docstring and comments to explain the separation between auto-fixable changes and lint findings, and clarified the behavior in both dry-run and auto-fix modes

## Implementation Details

- The `execute_formatting()` function now calls `run_command()` with flake8 after each `format_file()` call
- File paths in flake8 commands are quoted using `shlex.quote()` to handle spaces
- Test coverage expanded to verify flake8 execution order, path quoting, and exit status behavior
- Version history updated to reflect the distinction between auto-fixable changes and lint findings

https://claude.ai/code/session_013Dww6t3JW5XzDJnNTBD7Pa