### PR TITLE
Document install_dotfiles.sh .tmp 0700 security rationale

### DIFF
--- a/doc/FEATURES.md
+++ b/doc/FEATURES.md
@@ -1150,6 +1150,8 @@ Targets include:
 
 It accounts for platform differences such as macOS and Linux and also normalizes required directories and permissions.
 
+For each target home directory, `install_dotfiles.sh` creates `.tmp` when it is missing and sets its mode to `0700`. This directory is the private per-user temporary area preferred by the companion `dot_zsh` configuration. The restrictive permission is intentional and is part of that temporary-directory security policy.
+
 
 ### install_dotvim.sh
 


### PR DESCRIPTION
## Summary
- `doc/FEATURES.md` (`### install_dotfiles.sh`): document that the `.tmp` directory created under each target home with mode `0700` is the private per-user temporary area preferred by the companion `dot_zsh` configuration, and that the restrictive permission is intentional as part of that security policy.

This is a documentation-only change describing existing, unchanged behavior. No source code, configuration, tests, or version metadata were modified.

## Test plan
- [x] `git diff --check -- doc/FEATURES.md` exits 0 with no output
- [x] Confirmed only an additive paragraph (no deletions/edits to existing lines, no heading renumbering)
- [x] `git status --short` shows only `doc/FEATURES.md` changed

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDacua5vha2k1arp5nqZ4w)_