### PR TITLE
Resolve small POLICY inconsistencies in exit rules and Efficiency wording

### DIFF
--- a/doc/POLICY
+++ b/doc/POLICY
@@ -79,38 +79,43 @@ which, weigh competing concerns in this order:
    versions working.
 2. Safety: do not destroy, overwrite, or expose what the run was not asked to
    touch, and prefer state changes that remain safe when repeated.
-3. Efficiency: prefer the smaller, simpler, less dependent implementation.
-   Efficiency matters, but not at the cost of Compatibility or Safety.
+3. Efficiency: avoid unnecessary processing, unnecessary process creation,
+   unnecessary I/O, unnecessary network access, and unnecessary resource
+   cost; meet the required behavior at the smallest reasonable runtime and
+   operational cost. This includes preferring the smaller, simpler, less
+   dependent implementation. Efficiency matters, but not at the cost of
+   Compatibility or Safety.
 
-The nine items below are the concrete decision material that gives those
-three concerns substance in this repository. They stand alongside the
-ordering above, not apart from it:
+The items below are the concrete decision material that gives those three
+concerns substance in this repository. They stand alongside the ordering
+above, not as a second, separate priority order:
 
-1. Do not destroy or overwrite what the run was not asked to touch.
-2. Do not put a credential where another user of the host can read it, and do
-   not commit one.
-3. Prefer state changes that remain safe when the same operation is repeated.
-4. Preserve existing observable behavior, including control flow,
-   processing order, which later operations are attempted after a
-   failure, side effects, options, exit status, output, and
-   configuration file format, so that an unchanged invocation keeps
-   behaving as before.
-5. Stay portable: POSIX for a Shell Script, and the stated minimum version for
-   Python and Ruby.
-6. Branch on what the environment provides, not on what it is called.
-7. Stay fit for unattended execution: report a condition the operator can act
-   on, and do not repeat one they cannot.
-8. Prefer the standard library when it provides the required behavior without
-   unreasonable implementation or operational cost.
-9. Add no option, no configuration value, and no script that is not needed.
+- Do not destroy or overwrite what the run was not asked to touch.
+- Do not put a credential where another user of the host can read it, and do
+  not commit one.
+- Prefer state changes that remain safe when the same operation is repeated.
+- Preserve existing observable behavior, including control flow,
+  processing order, which later operations are attempted after a
+  failure, side effects, options, exit status, output, and
+  configuration file format, so that an unchanged invocation keeps
+  behaving as before.
+- Stay portable: POSIX for a Shell Script, and the stated minimum version for
+  Python and Ruby.
+- Branch on what the environment provides, not on what it is called.
+- Stay fit for unattended execution: report a condition the operator can act
+  on, and do not repeat one they cannot.
+- Prefer the standard library when it provides the required behavior without
+  unreasonable implementation or operational cost.
+- Add no option, no configuration value, and no script that is not needed.
 
 These priorities are decision guidance, not mechanical goals that justify
 breaking required functionality or established observable behavior.
 
-Item 4 preserves behavior that is intended and valid. A clear defect,
-regression, unintended side effect, or otherwise broken behavior is not
-preserved merely because it is what the code currently does, and correcting
-it is not treated as an incidental compatibility break. When the intended
+The observable-behavior item above preserves behavior that is intended and
+valid. A clear defect, regression, unintended side effect, or otherwise
+broken behavior is not preserved merely because it is what the code
+currently does, and correcting it is not treated as an incidental
+compatibility break. When the intended
 behavior is unclear, weigh the implementation, the documented interface, the
 history, and the maintenance intent together, as described in 1.6.1.
 
@@ -121,11 +126,19 @@ principle.
 ### 1.2 Implementation Fundamentals
 
 #### 1.2.1 Control Flow Rules
-- Use explicit termination (`exit`, `sys.exit`, `exit()`) **only for abnormal or
-  forced termination**.
-- Normal execution paths must return normally and propagate status explicitly.
+- Within a function or other internal control flow, use explicit termination
+  (`exit`, `sys.exit`, `exit()`) **only for abnormal or forced termination**.
+- Normal internal control flow must return normally and propagate status
+  explicitly rather than cutting execution short with a process-level `exit`.
+- The top-level program entry point converting the status that `main()` (or
+  `main`) returned into the OS process exit status, such as
+  `sys.exit(main())` in Python or `exit(main) if __FILE__ == $0` in Ruby, is
+  normal entry-point behavior, not the abnormal or forced termination this
+  rule constrains.
 - Do not rely on implicit termination or language-specific shortcuts
-  (e.g. `set -e` in a shell script, bare `except` in Python).
+  (e.g. `set -e` in a shell script, bare `except` in Python). For a Shell
+  Script, this rule constrains internal control-flow termination the same
+  way; it does not apply to the top-level process simply completing.
 - A change whose stated purpose is portability, diagnostics, error
   handling, cleanup, refactoring, modernization, or standards
   conformance must preserve existing observable behavior unless a
@@ -221,7 +234,11 @@ principle.
 - **1: General failure**
   The default failure code.
   Use for invalid arguments, missing resources, processing errors, or any
-  failure that does not require explicit classification.
+  failure that does not require explicit classification. For an invalid or
+  unsupported CLI option specifically, the exit status follows the
+  established usage behavior defined in Section 1.3.1 instead: both the
+  repository-standard `0` and the existing accepted `1` are valid, and this
+  entry does not override that Section 1.3.1 usage behavior.
 
 - **126: Command or script exists but is not executable**
   Reserved by the shell. Do not redefine.

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -5,9 +5,11 @@ v2.0.1 (Release Date: TBD)
 --------------------------
 - Large-scale documentation revision, recorded here as an exception.
 - Add .gitattributes, marking the Markdown documents for diff.
-- Expand and clarify doc/POLICY across decision priorities, rule wording
-  strength, documentation roles, portability, compatibility, execution
-  behavior, testing, pull request scope, and version history conventions.
+- Expand and clarify doc/POLICY across decision priorities, the Efficiency
+  definition, rule wording strength, control-flow and entry-point exit
+  rules, CLI exit status conventions, documentation roles, portability,
+  compatibility, execution behavior, testing, pull request scope, and
+  version history conventions.
 - Remove etc/pathext.txt, an obsolete list of Windows PATHEXT values.
 - Add the shared version history description guidelines to the end of this
   file.


### PR DESCRIPTION
Clarify that the Control Flow Rules abnormal-termination restriction
applies to internal control flow, not to a top-level entry point
converting main()'s returned status into the process exit status
(sys.exit(main()), exit(main) if __FILE__ == $0), which already matches
the Python and Ruby language sections. Note in the Exit Code Conventions
General failure entry that invalid/unsupported CLI options follow the
Section 1.3.1 usage behavior instead. Define Efficiency in terms of
avoiding unnecessary runtime cost rather than conflating it with
simplicity/dependency preference, and turn the second Decision Priorities
list into bullets so it no longer reads as a second priority order.
Fold these into the existing v2.0.1 POLICY summary in doc/VERSIONS.