### PR TITLE
Fix pyck tests on pre-3.8 Python

### DIFF
--- a/test/pyck_test.py
+++ b/test/pyck_test.py
@@ -540,7 +540,7 @@ class TestPyck(unittest.TestCase):
             ['path/to/file.py'], 'E302,E402,E501', CONFIG_PATH)
 
         for command_call in mock_popen.call_args_list:
-            command = command_call.args[0]
+            command = command_call[0][0]
             self.assertNotIn('autoflake --config=/tmp/pyck.cfg --imports=django,requests,urllib3 -i', command)
             self.assertNotIn('autopep8 --global-config=/tmp/pyck.cfg --ignore-local-config --ignore=E302,E402,E501 -v -i', command)
             self.assertNotRegex(command, r'^isort --settings-path=/tmp/pyck\.cfg (?!--check-only)')
@@ -610,14 +610,14 @@ class TestPyck(unittest.TestCase):
         pyck.execute_formatting(
             ['path/to/directory'], 'E302,E402,E501', CONFIG_PATH)
         auto_fix_files = sorted(
-            c.args[0] for c in mock_format_file.call_args_list)
+            c[0][0] for c in mock_format_file.call_args_list)
 
         mock_popen.reset_mock()
 
         pyck.dry_run_formatting(
             ['path/to/directory'], 'E302,E402,E501', CONFIG_PATH)
         dry_run_files = sorted(set(
-            c.args[0].split()[-1] for c in mock_popen.call_args_list))
+            c[0][0].split()[-1] for c in mock_popen.call_args_list))
 
         expected_files = sorted([
             os.path.join('path/to/directory', 'file1.py'),


### PR DESCRIPTION
## Summary

Replace Python 3.8-only `unittest.mock.call.args` access in `test/pyck_test.py` with the tuple-based call argument access supported by Python 3.6 and Python 3.7.

This changes only how existing mock call arguments are read. Test semantics and production behavior are unchanged.

## Changes

- Replace `command_call.args[0]` with `command_call[0][0]`.
- Replace two `c.args[0]` accesses with `c[0][0]`.
- Make no production code, dependency, documentation, or version changes.

## Validation

- `python3.6 test/pyck_test.py`: not available in this session's environment
- `python3.7 test/pyck_test.py`: not available in this session's environment
- `python3.8 test/pyck_test.py`: not available in this session's environment
- `python3.10 test/pyck_test.py`: PASS (38 tests, exit status 0)
- `python3.11 test/pyck_test.py`: PASS (38 tests, exit status 0)
- `git diff --check`: PASS
- Confirmed that the final diff contains only the three compatibility substitutions in `test/pyck_test.py`.
- Note: Python 3.6/3.7/3.8 interpreters were not present in the execution environment used to prepare this PR, so the exact three version-pinned commands requested could not be run directly. The replacement (`call[0][0]`) is a tuple-index access valid on all CPython 3.x versions, unlike `call.args`, which was added in 3.8.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VibfaQXRAcH8J8inWFzZPz)_