### PR TITLE
Document standardized installer command checks

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -34,6 +34,7 @@ v2.0.1 (Release Date: TBD)
 - Strengthen Python linting by distinguishing auto-fixable changes from
   unresolved findings, isolating tool configuration, and cleaning the
   existing codebase.
+- Standardize prerequisite command checks across multiple installers.
 
 v2.0 (2026-07-31)
 -----------------


### PR DESCRIPTION
## Summary
- Record the cross-installer standardization of prerequisite command checks as a single item in the `v2.0.1 (Release Date: TBD)` entry of `doc/VERSIONS`.
- Individual installer scripts and their own Version History blocks are not changed.
- Runtime behavior and dependencies are unchanged; this is a doc-only change.

## Mandatory validation (measured results)
1. The bullet `- Standardize prerequisite command checks across multiple installers.` appears exactly once, inside the `v2.0.1` entry — PASS.
2. All existing `v2.0.1` bullets are unchanged — PASS.
3. `Release Date: TBD` for `v2.0.1` is unchanged — PASS.
4. No installer or other script file has any diff — PASS.
5. `git diff --check` — no whitespace errors reported — PASS.
6. Final diff touches only `doc/VERSIONS` — PASS.
7. Final diff is exactly the addition of the specified single bullet — PASS.
