### PR TITLE
Fix mount helpers and Python command lookup

### DIFF
--- a/cal.py
+++ b/cal.py
@@ -27,6 +27,10 @@
 #  - Python Version: 3.1 or later
 #
 #  Version History:
+#  v1.6 2026-09-03
+#       Replaced 'command -v' based lookup with a manual PATH search in
+#       command_exists() and get_command_path(), matching the shell script
+#       helper's PATH lookup and exit semantics.
 #  v1.5 2025-07-01
 #       Standardized termination behavior for consistent script execution.
 #  v1.4 2025-06-23
@@ -99,23 +103,28 @@ def print_cal_month(year, month):
     """
     subprocess.call(['cal', str(month), str(year)])
 
+def find_command(command):
+    """
+    Search PATH for command's executable path, using a manual PATH search.
+    Return the full path when found, or None when not found.
+    """
+    for directory in os.environ.get("PATH", "").split(os.pathsep):
+        candidate = os.path.join(directory if directory else ".", command)
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
 def command_exists(command):
     """
-    Checks if a given command exists in the system path using 'command -v'.
+    Checks if a given command exists in the system path using a manual PATH search.
     """
-    with open(os.devnull, 'w') as devnull:
-        return subprocess.call('command -v {}'.format(command), shell=True, stdout=devnull, stderr=devnull) == 0
+    return find_command(command) is not None
 
 def get_command_path(command):
     """
-    Gets the full path of a command using 'command -v'.
+    Gets the full path of a command using a manual PATH search.
     """
-    try:
-        with open(os.devnull, 'w') as devnull:
-            output = subprocess.check_output('command -v {}'.format(command), shell=True, stderr=devnull)
-        return output.decode().strip()
-    except subprocess.CalledProcessError:
-        return None
+    return find_command(command)
 
 def run_system_cal(args):
     """

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -3,8 +3,9 @@ scripts Repository Version History
 
 v2.0.2 (Release Date: TBD)
 --------------------------
-- Add luksmount.py to open and mount a LUKS device after confirmation, and
-  install it as luksmount with the system administration scripts.
+- Add luksmount.py to open and mount a LUKS device after confirmation, and fix its sudo check and PATH lookup.
+- Fix tcmount.py to run mount and unmount without a shell, propagating command failures to the exit status.
+- Replace shell-based command lookup with a manual PATH search in tcmount.py, cal.py, du.py, and wp_cachectl.py.
 
 v2.0.1 (2026-08-26)
 -------------------

--- a/du.py
+++ b/du.py
@@ -31,6 +31,10 @@
 #  directory as the total.
 #
 #  Version History:
+#  v1.8 2026-09-03
+#       Replaced 'command -v' based lookup with a manual PATH search in
+#       command_exists(), matching the shell script helper's PATH lookup and
+#       exit semantics.
 #  v1.7 2025-07-01
 #       Standardized termination behavior for consistent script execution.
 #  v1.6 2025-06-23
@@ -84,12 +88,22 @@ def usage():
         sys.exit(1)
     sys.exit(0)
 
+def locate_command(command):
+    """
+    Search PATH for command's executable path, using a manual PATH search.
+    Return the full path when found, or None when not found.
+    """
+    for directory in os.environ.get("PATH", "").split(os.pathsep):
+        candidate = os.path.join(directory if directory else ".", command)
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
 def command_exists(command):
     """
-    Checks if a given command exists in the system path using 'command -v'.
+    Checks if a given command exists in the system path using a manual PATH search.
     """
-    with open(os.devnull, 'w') as devnull:
-        return subprocess.call('command -v {}'.format(command), shell=True, stdout=devnull, stderr=devnull) == 0
+    return locate_command(command) is not None
 
 def error_message(message, exit_code=1):
     """

--- a/luksmount.py
+++ b/luksmount.py
@@ -60,7 +60,9 @@
 #
 #  Version History:
 #  v1.0 2026-09-03
-#       Initial release.
+#       Initial release. Suppress sudo -v output while keeping the interactive
+#       password prompt, and fix find_command() to search the current directory
+#       for an empty PATH component instead of skipping it.
 #
 ########################################################################
 
@@ -125,9 +127,7 @@ def find_command(command):
     """
     found_non_executable = False
     for directory in os.environ.get("PATH", "").split(os.pathsep):
-        if not directory:
-            continue
-        candidate = os.path.join(directory, command)
+        candidate = os.path.join(directory if directory else ".", command)
         if not os.path.isfile(candidate):
             continue
         if os.access(candidate, os.X_OK):
@@ -217,9 +217,15 @@ def confirm(source, serial, mapper, target):
 def check_sudo():
     """ Return True when the user has sudo privileges (password may be required). """
     try:
-        return subprocess.call(["sudo", "-v"]) == 0
-    except OSError:
+        with open(os.devnull, 'w') as devnull:
+            status = subprocess.call(["sudo", "-v"], stdout=devnull, stderr=devnull)
+    except OSError as e:
+        print("[ERROR] Failed to execute sudo: %s" % e, file=sys.stderr)
         return False
+    if status != 0:
+        print("[ERROR] This script requires sudo privileges. Please run as a user with sudo access.", file=sys.stderr)
+        return False
+    return True
 
 
 def build_open_command(source, name):
@@ -259,7 +265,6 @@ def process_mount(device, name):
         return 0
 
     if not check_sudo():
-        print("[ERROR] This script requires sudo privileges. Please run as a user with sudo access.", file=sys.stderr)
         return 1
 
     print("[INFO] Opening %s as %s." % (source, name))

--- a/tcmount.py
+++ b/tcmount.py
@@ -70,6 +70,10 @@
 #
 #  Requirements:
 #  - Python Version: 3.1 or later
+#  - TrueCrypt or VeraCrypt
+#  - sudo
+#  - get-device
+#  - get-mountpoint
 #
 #  Notes on Unmounting:
 #  From v5.1 onward, unmount operations always resolve the *real mountpoint*
@@ -94,6 +98,13 @@
 #  on mount options and device specifications.
 #
 #  Version History:
+#  v5.2 2026-09-03
+#       Eliminated shell=True and shell-string command construction from mount
+#       and unmount execution; commands now run as argument lists. Propagated
+#       external command failure status to the script's exit status. Unmount
+#       now aborts without running the detach command when get-device or
+#       get-mountpoint resolution fails. Replaced 'command -v' based lookup
+#       with a manual PATH search in command_exists().
 #  v5.1 2025-09-01
 #       Fix external mount to honor explicit target and preserve legacy container path.
 #       Change unmount logic to always resolve real mountpoint via get-device/get-mountpoint.
@@ -136,6 +147,7 @@
 
 import os
 import re
+import stat
 import subprocess
 import sys
 from optparse import OptionParser
@@ -211,18 +223,33 @@ def check_sudo():
         print("[ERROR] Failed to check sudo privileges: {}".format(e), file=sys.stderr)
         sys.exit(1)
 
-def os_exec(cmd):
+def os_exec(argv):
     """
-    Executes a system command using subprocess.
+    Executes an argument list without a shell and returns its exit status.
+    Returns 1 when the command cannot be executed.
     """
-    subprocess.call(cmd, shell=True)
+    try:
+        return subprocess.call(argv)
+    except OSError as e:
+        print("[ERROR] Failed to execute %s: %s" % (argv[0], e), file=sys.stderr)
+        return 1
+
+def find_command(command):
+    """
+    Search PATH for command's executable path, using a manual PATH search.
+    Return the full path when found, or None when not found.
+    """
+    for directory in os.environ.get("PATH", "").split(os.pathsep):
+        candidate = os.path.join(directory if directory else ".", command)
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return None
 
 def command_exists(command):
     """
-    Checks if a given command exists in the system path using 'command -v'.
+    Checks if a given command exists in the system path using a manual PATH search.
     """
-    with open(os.devnull, 'w') as devnull:
-        return subprocess.call('command -v {}'.format(command), shell=True, stdout=devnull, stderr=devnull) == 0
+    return find_command(command) is not None
 
 def is_truecrypt_installed():
     """
@@ -258,60 +285,124 @@ def get_veracrypt_version():
     except subprocess.CalledProcessError:
         return "Unknown"
 
-def build_mount_command(device, mount_options, target=None):
+def is_block_device(path):
+    """ Return True when the path refers to a block device. """
+    try:
+        return stat.S_ISBLK(os.stat(path).st_mode)
+    except OSError:
+        return False
+
+def build_mount_argv(tool_argv, device, mount_options, target=None):
     """
-    Build command to mount /dev/<device> to ~/mnt/<target or device>
+    Build the argument list to mount /dev/<device> to ~/mnt/<target or device>.
+    tool_argv is the encryption tool invocation, e.g. ['truecrypt'] or
+    ['veracrypt', '-tc'].
     """
     if not target:
         target = device
-    return 'test -b /dev/{0} && sudo truecrypt -t -k "" --protect-hidden=no --fs-options={1} /dev/{0} ~/mnt/{2}'.format(device, mount_options, target)
+    source = '/dev/' + device
+    mount_point = os.path.expanduser(os.path.join('~', 'mnt', target))
+    return (['sudo'] + tool_argv +
+            ['-t', '-k', '', '--protect-hidden=no', '--fs-options=%s' % mount_options,
+             source, mount_point])
 
-def build_unmount_command(target):
+def build_mount_external_argv(tool_argv, mount_options, target):
     """
-    Build command to unmount by resolving the real mountpoint
-    using get-device and get-mountpoint.
-    This replaces the legacy behavior (sudo truecrypt -d ~/mnt/<target>).
+    Build the argument list to mount the legacy external container file to
+    ~/mnt/<target>.
     """
-    return (
-        'dev=$(get-device ~/mnt/{0}) && '
-        'mp=$(get-mountpoint "$dev") && '
-        'sudo truecrypt -d "$mp"'
-    ).format(target)
+    external_file = os.path.expanduser(os.path.join('~', 'mnt', 'external', 'container.tc'))
+    mount_point = os.path.expanduser(os.path.join('~', 'mnt', target))
+    return (['sudo'] + tool_argv +
+            ['-t', '-k', '', '--protect-hidden=no', '--fs-options=%s' % mount_options,
+             external_file, mount_point])
 
-def build_unmount_external_command():
+def build_detach_argv(tool_argv, mountpoint):
     """
-    Build command to unmount the legacy external container by its file path.
+    Build the argument list to detach the given mountpoint.
+    tool_argv is the encryption tool invocation used for unmounting.
     """
-    return 'sudo truecrypt -d ~/mnt/external/container.tc'
+    return ['sudo'] + tool_argv + ['-d', mountpoint]
 
-def build_mount_all_command(mount_options):
+def build_unmount_external_argv(tool_argv):
     """
-    Build commands to mount all devices from sdc to sdz
+    Build the argument list to unmount the legacy external container by its
+    file path.
     """
-    commands = []
-    for device_suffix in range(ord('c'), ord('z') + 1):
-        commands.append(build_mount_command('sd' + chr(device_suffix), mount_options))
-    return commands
+    external_file = os.path.expanduser(os.path.join('~', 'mnt', 'external', 'container.tc'))
+    return build_detach_argv(tool_argv, external_file)
 
-def build_mount_external_command(external_device, mount_options, target=None):
+def list_all_devices():
+    """ Return the device names covered by --all (sdc..sdz). """
+    return ['sd' + chr(c) for c in range(ord('c'), ord('z') + 1)]
+
+def resolve_real_mountpoint(target):
     """
-    Build command to mount legacy external container file to ~/mnt/<target or external_device>.
-    - external_device: device name given to -e (e.g., 'sde')
-    - target: explicit mountpoint name under ~/mnt (e.g., 'disk3')
+    Resolve the real mountpoint of ~/mnt/<target> via get-device and
+    get-mountpoint. Return the mountpoint, or None when resolution fails.
+    Neither helper is invoked past the first failure.
     """
-    # Default mountpoint to the external device name if not specified
+    mount_point = os.path.expanduser(os.path.join('~', 'mnt', target))
+    try:
+        device = subprocess.check_output(['get-device', mount_point]).decode('utf-8').strip()
+    except (subprocess.CalledProcessError, OSError):
+        return None
+    try:
+        real_mountpoint = subprocess.check_output(['get-mountpoint', device]).decode('utf-8').strip()
+    except (subprocess.CalledProcessError, OSError):
+        return None
+    return real_mountpoint
+
+def run_single_mount(device, mount_options, tool_argv, target=None):
+    """ Mount /dev/<device> after verifying it is a block device. """
+    source = '/dev/' + device
+    if not is_block_device(source):
+        print("[ERROR] Not a block device: %s" % source, file=sys.stderr)
+        return 1
+    return os_exec(build_mount_argv(tool_argv, device, mount_options, target))
+
+def run_single_unmount(target, unmount_tool_argv):
+    """
+    Unmount by resolving the real mountpoint via get-device/get-mountpoint.
+    Does not run the detach command when resolution fails.
+    """
+    mountpoint = resolve_real_mountpoint(target)
+    if mountpoint is None:
+        print("[ERROR] Failed to resolve the real mountpoint for %s." % target, file=sys.stderr)
+        return 1
+    return os_exec(build_detach_argv(unmount_tool_argv, mountpoint))
+
+def run_external_mount(external_device, mount_options, tool_argv, target=None):
+    """
+    Mount the legacy external container file to ~/mnt/<target or external_device>.
+    """
     if target is None or str(target).strip() == "":
         target = external_device
-    # Legacy fixed path expected by existing tests and prior behavior
-    external_file = os.path.join('~', 'mnt', 'external', 'container.tc')
-    mount_point = os.path.join('~', 'mnt', target)
-    return 'test -f {0} && sudo truecrypt -t -k "" --protect-hidden=no --fs-options={1} {0} {2}'.format(
-        external_file, mount_options, mount_point
-    )
+    external_file = os.path.expanduser(os.path.join('~', 'mnt', 'external', 'container.tc'))
+    if not os.path.isfile(external_file):
+        print("[ERROR] External container file not found: %s" % external_file, file=sys.stderr)
+        return 1
+    return os_exec(build_mount_external_argv(tool_argv, mount_options, target))
+
+def run_external_unmount(unmount_tool_argv):
+    """ Unmount the legacy external container by its file path. """
+    return os_exec(build_unmount_external_argv(unmount_tool_argv))
+
+def run_mount_all(mount_options, tool_argv):
+    """
+    Mount every device from sdc to sdz, continuing past individual failures.
+    Returns 1 if any device failed, 0 only when all succeeded.
+    """
+    any_failed = False
+    for device in list_all_devices():
+        if run_single_mount(device, mount_options, tool_argv) != 0:
+            any_failed = True
+    return 1 if any_failed else 0
 
 def process_mounting(options, args):
     """
-    Process mounting and unmounting based on CLI options and arguments
+    Process mounting and unmounting based on CLI options and arguments.
+    Returns the resulting exit status.
     """
     mount_options = []
     if not options.no_utf8:
@@ -321,7 +412,26 @@ def process_mounting(options, args):
 
     mount_options_str = ','.join(mount_options)
 
-    commands = []
+    # Select encryption tool according to options.
+    if options.tc_compat:
+        if not is_veracrypt_installed():
+            print("[ERROR] VeraCrypt is not installed, but '-t' option was specified. Please use TrueCrypt or install VeraCrypt and try again.", file=sys.stderr)
+            sys.exit(13)
+        mount_tool_argv = ['veracrypt', '-tc']
+        unmount_tool_argv = ['veracrypt']
+    elif options.veracrypt:
+        if not is_veracrypt_installed():
+            print("[ERROR] VeraCrypt is not installed, but '-v' option was specified. Please use TrueCrypt or install VeraCrypt and try again.", file=sys.stderr)
+            sys.exit(12)
+        mount_tool_argv = ['veracrypt']
+        unmount_tool_argv = ['veracrypt']
+    else:
+        if not is_truecrypt_installed():
+            print("[ERROR] TrueCrypt is not installed. Please use VeraCrypt or install TrueCrypt and try again.", file=sys.stderr)
+            sys.exit(11)
+        mount_tool_argv = ['truecrypt']
+        unmount_tool_argv = ['truecrypt']
+
     if options.external:
         # Syntax:
         #   Mount   : -e <external_device> [<target>]
@@ -335,74 +445,40 @@ def process_mounting(options, args):
         #       unless it looks like a device name 'sd[a-z]'; otherwise default to <external_device>.
         is_unmount = any(t in ['unmount', 'umount'] for t in args)
         if is_unmount:
-            commands.append(build_unmount_external_command())
+            return run_external_unmount(unmount_tool_argv)
+        tokens = [t for t in args if t not in ['unmount', 'umount']]
+        if len(tokens) >= 2:
+            explicit_target = tokens[-1]
+        elif len(tokens) == 1:
+            explicit_target = tokens[0] if not re.match(r'^sd[a-z]$', tokens[0]) else None
         else:
-            tokens = [t for t in args if t not in ['unmount', 'umount']]
-            if len(tokens) >= 2:
-                explicit_target = tokens[-1]
-            elif len(tokens) == 1:
-                explicit_target = tokens[0] if not re.match(r'^sd[a-z]$', tokens[0]) else None
-            else:
-                explicit_target = None  # builder will fallback to external_device
-            commands.append(
-                build_mount_external_command(options.external, mount_options_str, explicit_target)
-            )
-    else:
-        if args:
-            device = args[0]
-            if len(args) > 1 and args[1] in ['unmount', 'umount']:
-                # Unmount: second token is action, target defaults to device
-                commands.append(build_unmount_command(device))
-            elif len(args) > 2 and args[2] in ['unmount', 'umount']:
-                # Explicit target unmount: third token is action, second token is target
-                target = args[1]
-                commands.append(build_unmount_command(target))
-            else:
-                # Mount: optional explicit target as second token
-                target = args[1] if len(args) > 1 else None
-                if target is None:
-                    commands.append(build_mount_command(device, mount_options_str))
-                else:
-                    commands.append(build_mount_command(device, mount_options_str, target))
-        else:
-            # No positional args: keep --all behavior; otherwise show version and exit
-            if options.all:
-                commands.extend(build_mount_all_command(mount_options_str))
-            else:
-                # Ensure version_message is available (e.g., when called with only flags like -v)
-                global version_message
-                if not version_message:
-                    version_message = build_version_message()
-                print(version_message)
-                sys.exit(0)
+            explicit_target = None  # falls back to external_device
+        return run_external_mount(options.external, mount_options_str, mount_tool_argv, explicit_target)
 
-    # Select encryption tool according to options
-    if options.tc_compat:
-        if not is_veracrypt_installed():
-            print("[ERROR] VeraCrypt is not installed, but '-t' option was specified. Please use TrueCrypt or install VeraCrypt and try again.", file=sys.stderr)
-            sys.exit(13)
-        encryption_tool = "veracrypt -tc"
-        unmount_cmd = "veracrypt"
-    elif options.veracrypt:
-        if not is_veracrypt_installed():
-            print("[ERROR] VeraCrypt is not installed, but '-v' option was specified. Please use TrueCrypt or install VeraCrypt and try again.", file=sys.stderr)
-            sys.exit(12)
-        encryption_tool = "veracrypt"
-        unmount_cmd = "veracrypt"
-    else:
-        if not is_truecrypt_installed():
-            print("[ERROR] TrueCrypt is not installed. Please use VeraCrypt or install TrueCrypt and try again.", file=sys.stderr)
-            sys.exit(11)
-        encryption_tool = "truecrypt"
-        unmount_cmd = "truecrypt"
-
-    # Execute built commands after replacing the encryption tool
-    for cmd in commands:
-        if ' -d ' in cmd:
-            cmd = cmd.replace('truecrypt', unmount_cmd)
+    if args:
+        device = args[0]
+        if len(args) > 1 and args[1] in ['unmount', 'umount']:
+            # Unmount: second token is action, target defaults to device
+            return run_single_unmount(device, unmount_tool_argv)
+        elif len(args) > 2 and args[2] in ['unmount', 'umount']:
+            # Explicit target unmount: third token is action, second token is target
+            target = args[1]
+            return run_single_unmount(target, unmount_tool_argv)
         else:
-            cmd = cmd.replace('truecrypt', encryption_tool)
-        os_exec(cmd)
+            # Mount: optional explicit target as second token
+            target = args[1] if len(args) > 1 else None
+            return run_single_mount(device, mount_options_str, mount_tool_argv, target)
+
+    # No positional args: keep --all behavior; otherwise show version and return.
+    if options.all:
+        return run_mount_all(mount_options_str, mount_tool_argv)
+
+    # Ensure version_message is available (e.g., when called with only flags like -v)
+    global version_message
+    if not version_message:
+        version_message = build_version_message()
+    print(version_message)
+    return 0
 
 def main():
     """
@@ -455,9 +531,7 @@ def main():
 
     check_sudo()
 
-    process_mounting(options, args)
-
-    return 0
+    return process_mounting(options, args)
 
 
 if __name__ == "__main__":

--- a/test/cal_test.py
+++ b/test/cal_test.py
@@ -17,8 +17,15 @@
 #    - Shows usage and exits with code 0 when invoked with -h option
 #    - Falls back to Python calendar module if 'cal' does not exist
 #    - Invokes system cal with arguments if available
+#    - find_command() resolves an executable command found on PATH
+#    - find_command() returns None when the command is not found on PATH
+#    - find_command() resolves an empty PATH component to the current directory
+#    - command_exists() and get_command_path() are consistent with find_command()
 #
 #  Version History:
+#  v1.1 2026-09-03
+#       Add tests for the manual PATH search in find_command(), replacing the
+#       previous 'command -v' based lookup.
 #  v1.0 2025-07-07
 #       Initial release.
 #
@@ -26,8 +33,10 @@
 
 import io
 import os
+import shutil
 import subprocess
 import sys
+import tempfile
 import unittest
 from contextlib import redirect_stdout
 from unittest.mock import patch
@@ -79,6 +88,51 @@ class TestCal(unittest.TestCase):
         with patch.object(sys, 'argv', ['cal.py', '3', '2024']):
             cal.main()
         mock_call.assert_called_with(['cal', '3', '2024'])
+
+    def make_fake_path(self, commands, non_executable):
+        """ Create a temporary PATH directory containing the given commands; return its path. """
+        directory = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, directory)
+        for command in commands:
+            path = os.path.join(directory, command)
+            with open(path, 'w', encoding='utf-8') as f:
+                f.write('#!/bin/sh\n')
+            if command not in non_executable:
+                os.chmod(path, 0o755)
+            else:
+                os.chmod(path, 0o644)
+        return directory
+
+    def test_find_command_resolves_executable_on_path(self):
+        directory = self.make_fake_path(['fake_cal'], [])
+        with patch.dict(os.environ, {'PATH': directory}):
+            found = cal.find_command('fake_cal')
+            self.assertTrue(cal.command_exists('fake_cal'))
+            self.assertEqual(cal.get_command_path('fake_cal'), found)
+        self.assertEqual(os.path.realpath(found),
+                         os.path.realpath(os.path.join(directory, 'fake_cal')))
+
+    def test_find_command_missing_returns_none(self):
+        directory = self.make_fake_path([], [])
+        with patch.dict(os.environ, {'PATH': directory}):
+            self.assertIsNone(cal.find_command('nonexistent_command'))
+            self.assertFalse(cal.command_exists('nonexistent_command'))
+            self.assertIsNone(cal.get_command_path('nonexistent_command'))
+
+    def test_find_command_empty_path_component_is_cwd(self):
+        directory = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, directory)
+        command_name = 'fake_command_for_cwd_test'
+        path = os.path.join(directory, command_name)
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write('#!/bin/sh\n')
+        os.chmod(path, 0o755)
+        original_cwd = os.getcwd()
+        self.addCleanup(os.chdir, original_cwd)
+        os.chdir(directory)
+        with patch.dict(os.environ, {'PATH': ''}):
+            found = cal.find_command(command_name)
+        self.assertEqual(os.path.realpath(found), os.path.realpath(path))
 
 
 if __name__ == '__main__':

--- a/test/du_test.py
+++ b/test/du_test.py
@@ -20,8 +20,16 @@
 #    - Parse du output and return the size for the requested directory path.
 #    - run_custom_du includes hidden directories when include_hidden is True.
 #    - run_custom_du excludes hidden directories when include_hidden is False.
+#    - locate_command() resolves an executable command found on PATH.
+#    - locate_command() returns None when the command is not found on PATH.
+#    - locate_command() resolves an empty PATH component to the current directory.
+#    - command_exists() is consistent with locate_command().
 #
 #  Version History:
+#  v1.1 2026-09-03
+#       Add tests for the manual PATH search in locate_command(), replacing
+#       the previous 'command -v' based lookup. These run on any platform,
+#       unlike the macOS-only disk usage tests above.
 #  v1.0 2025-06-24
 #      Initial release.
 #
@@ -29,6 +37,7 @@
 
 import os
 import platform
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -39,7 +48,7 @@ from unittest.mock import patch
 # Adjust the path to import script from the parent directory
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from du import check_directory, parse_du_output, run_custom_du
+from du import check_directory, command_exists, locate_command, parse_du_output, run_custom_du
 
 
 class TestDuScript(unittest.TestCase):
@@ -111,6 +120,53 @@ class TestDuScript(unittest.TestCase):
             output = "".join(call.args[0] for call in mock_print.call_args_list)
             self.assertNotIn('.hidden', output)
             self.assertIn('visible', output)
+
+
+class TestDuCommandLookup(unittest.TestCase):
+    """ Tests for the manual PATH search; these are not macOS-specific. """
+
+    def make_fake_path(self, commands, non_executable):
+        """ Create a temporary PATH directory containing the given commands; return its path. """
+        directory = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, directory)
+        for command in commands:
+            path = os.path.join(directory, command)
+            with open(path, 'w', encoding='utf-8') as f:
+                f.write('#!/bin/sh\n')
+            if command not in non_executable:
+                os.chmod(path, 0o755)
+            else:
+                os.chmod(path, 0o644)
+        return directory
+
+    def test_locate_command_resolves_executable_on_path(self):
+        directory = self.make_fake_path(['fake_du'], [])
+        with patch.dict(os.environ, {'PATH': directory}):
+            found = locate_command('fake_du')
+            self.assertTrue(command_exists('fake_du'))
+        self.assertEqual(os.path.realpath(found),
+                         os.path.realpath(os.path.join(directory, 'fake_du')))
+
+    def test_locate_command_missing_returns_none(self):
+        directory = self.make_fake_path([], [])
+        with patch.dict(os.environ, {'PATH': directory}):
+            self.assertIsNone(locate_command('nonexistent_command'))
+            self.assertFalse(command_exists('nonexistent_command'))
+
+    def test_locate_command_empty_path_component_is_cwd(self):
+        directory = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, directory)
+        command_name = 'fake_command_for_cwd_test'
+        path = os.path.join(directory, command_name)
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write('#!/bin/sh\n')
+        os.chmod(path, 0o755)
+        original_cwd = os.getcwd()
+        self.addCleanup(os.chdir, original_cwd)
+        os.chdir(directory)
+        with patch.dict(os.environ, {'PATH': ''}):
+            found = locate_command(command_name)
+        self.assertEqual(os.path.realpath(found), os.path.realpath(path))
 
 
 if __name__ == '__main__':

--- a/test/luksmount_test.py
+++ b/test/luksmount_test.py
@@ -35,6 +35,11 @@
 #    - A missing mount point is rejected before serial, sudo, cryptsetup, and mount.
 #    - A missing required command returns 127 before main processing.
 #    - A non-executable required command returns 126 before main processing.
+#    - check_sudo() returns True and suppresses sudo output on success.
+#    - check_sudo() returns False and prints one diagnostic on a non-zero exit.
+#    - check_sudo() returns False and prints one diagnostic when sudo cannot be executed.
+#    - A sudo failure inside process_mount() prints exactly one [ERROR] line.
+#    - find_command() resolves an empty PATH component to the current directory.
 #
 #  Version History:
 #  v1.0 2026-09-03
@@ -238,6 +243,62 @@ class TestLuksMount(unittest.TestCase):
             with patch.object(sys, 'argv', ['luksmount.py', 'sdb', 'disk3']):
                 self.assertEqual(luksmount.main(), 126)
         mock_process.assert_not_called()
+
+    @patch('luksmount.subprocess.call', return_value=0)
+    def test_check_sudo_success(self, mock_call):
+        self.assertTrue(luksmount.check_sudo())
+        args, kwargs = mock_call.call_args
+        self.assertEqual(args[0], ['sudo', '-v'])
+
+    @patch('luksmount.subprocess.call', return_value=0)
+    def test_check_sudo_suppresses_command_output(self, mock_call):
+        luksmount.check_sudo()
+        args, kwargs = mock_call.call_args
+        self.assertIn('stdout', kwargs)
+        self.assertIn('stderr', kwargs)
+        self.assertIsNotNone(kwargs['stdout'])
+        self.assertIsNotNone(kwargs['stderr'])
+
+    @patch('luksmount.subprocess.call', return_value=1)
+    def test_check_sudo_failure_nonzero_prints_one_error(self, mock_call):
+        self.assertFalse(luksmount.check_sudo())
+        error_lines = [line for line in sys.stderr.getvalue().splitlines() if '[ERROR]' in line]
+        self.assertEqual(len(error_lines), 1)
+
+    @patch('luksmount.subprocess.call', side_effect=OSError('sudo not found'))
+    def test_check_sudo_failure_exec_error_prints_one_error(self, mock_call):
+        self.assertFalse(luksmount.check_sudo())
+        error_lines = [line for line in sys.stderr.getvalue().splitlines() if '[ERROR]' in line]
+        self.assertEqual(len(error_lines), 1)
+        self.assertIn('Failed to execute sudo', sys.stderr.getvalue())
+
+    @patch('luksmount.run_command')
+    @patch('luksmount.subprocess.call', return_value=1)
+    @patch('luksmount.confirm', return_value=True)
+    @patch('luksmount.get_serial', return_value='SERIAL123')
+    @patch('luksmount.validate_paths', return_value=0)
+    def test_process_mount_sudo_failure_prints_single_error_line(self, mock_validate, mock_serial,
+                                                                  mock_confirm, mock_call, mock_run):
+        self.assertEqual(luksmount.process_mount('sdb', 'disk3'), 1)
+        mock_run.assert_not_called()
+        error_lines = [line for line in sys.stderr.getvalue().splitlines() if '[ERROR]' in line]
+        self.assertEqual(len(error_lines), 1)
+
+    def test_find_command_empty_path_component_is_cwd(self):
+        directory = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, directory)
+        command_name = 'fake_command_for_cwd_test'
+        path = os.path.join(directory, command_name)
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write('#!/bin/sh\n')
+        os.chmod(path, 0o755)
+        original_cwd = os.getcwd()
+        self.addCleanup(os.chdir, original_cwd)
+        os.chdir(directory)
+        with patch.dict(os.environ, {'PATH': ''}):
+            found_path, status = luksmount.find_command(command_name)
+        self.assertEqual(status, 0)
+        self.assertEqual(os.path.realpath(found_path), os.path.realpath(path))
 
 
 if __name__ == '__main__':

--- a/test/tcmount_test.py
+++ b/test/tcmount_test.py
@@ -5,9 +5,11 @@
 #
 #  Description:
 #  This test suite is designed to test the tcmount.py script, focusing on
-#  the functionality of building commands for mounting and unmounting
-#  TrueCrypt and VeraCrypt encrypted devices. It tests various combinations
-#  of options, including TrueCrypt and VeraCrypt compatibility modes.
+#  the functionality of building argument lists for mounting and unmounting
+#  TrueCrypt and VeraCrypt encrypted devices, and on the orchestration
+#  functions that run them without a shell. It tests various combinations
+#  of options, including TrueCrypt and VeraCrypt compatibility modes, and
+#  verifies that command failures propagate to the script's exit status.
 #
 #  Author: id774 (More info: http://id774.net)
 #  Source Code: https://github.com/id774/scripts
@@ -20,39 +22,61 @@
 #
 #  Test Cases:
 #    - Verifies that the script prints usage and exits with code 0 when invoked with -h option.
-#    - Build a default TrueCrypt mount command for a block device with UTF-8 filesystem options.
-#    - Build a default TrueCrypt unmount command for a device mountpoint resolved via get-device/get-mountpoint.
-#    - Build mount-all command list and include the last device (sdz) in the generated commands.
-#    - Build an external container mount command using the default mount target (device name).
-#    - Build a mount command with read-only filesystem option.
-#    - Build a mount command without UTF-8 filesystem option.
-#    - Build a mount command with an explicit target mount directory.
-#    - Build an unmount command with an explicit target mount directory.
+#    - Build a default TrueCrypt mount argument list for a block device with UTF-8 filesystem options.
+#    - Build a mount argument list with read-only filesystem option.
+#    - Build a mount argument list without UTF-8 filesystem option.
+#    - Build a mount argument list with an explicit target mount directory.
+#    - Build a mount argument list for VeraCrypt TC-compat mode with the correct tool tokens.
+#    - Build a detach argument list for a resolved mountpoint.
+#    - Build an external container mount argument list using the default mount target (device name).
+#    - Build an external container mount argument list honoring an explicit target mount directory.
+#    - Build an external container unmount argument list by its fixed file path.
+#    - list_all_devices() includes the first (sdc) and last (sdz) devices.
 #    - Detect TrueCrypt installation when the truecrypt command is available.
 #    - Detect VeraCrypt installation when the veracrypt command is available.
-#    - Return True from command_exists() when the command is found.
-#    - Return False from command_exists() when the command is not found.
-#    - Execute a shell command via os_exec() using subprocess.call with shell=True.
-#    - In process_mounting(), mount and unmount using mocked builders and os_exec (TrueCrypt path).
-#    - In process_mounting(), mount and unmount using mocked builders and os_exec (VeraCrypt path).
-#    - In process_mounting(), mount and unmount using mocked builders and os_exec (VeraCrypt TC-compat path).
-#    - In process_mounting(), pass an explicit target to build_mount_command and build_unmount_command.
-#    - In process_mounting(), build read-only/no-UTF8 mount command for TrueCrypt.
-#    - In process_mounting(), build read-only mount command for VeraCrypt (utf8,ro).
-#    - In process_mounting(), build no-UTF8 mount command for VeraCrypt TC-compat mode.
-#    - In process_mounting(), mount with explicit target using VeraCrypt when TrueCrypt is unavailable.
-#    - In process_mounting(), mount with explicit target using VeraCrypt TC-compat when TrueCrypt is unavailable.
-#    - In process_mounting(), mount and unmount multiple device names via mocked builders.
-#    - In process_mounting(), build read-only/no-UTF8 mount commands for multiple device names.
-#    - In process_mounting(), generate expected mount commands across option combinations (veracrypt/tc_compat/no_utf8/readonly/all/external).
-#    - In process_mounting(), generate expected mount commands for representative option combinations.
-#    - Build an external container mount command using the default target when explicit target is not provided.
-#    - Build an external container mount command honoring an explicit target mount directory.
-#    - In process_mounting(), delegate external mount (-e) to build_mount_external_command with an explicit target.
+#    - find_command() resolves an executable command found on PATH.
+#    - find_command() returns None when the command is not found on PATH.
+#    - find_command() resolves an empty PATH component to the current directory.
+#    - command_exists() is consistent with find_command().
+#    - os_exec() runs an argument list via subprocess.call without a shell and returns its status.
+#    - os_exec() returns 1 and prints a diagnostic when the command cannot be executed.
+#    - is_block_device() returns True only for a path whose mode is a block device.
+#    - resolve_real_mountpoint() returns the resolved path when get-device and get-mountpoint both succeed.
+#    - resolve_real_mountpoint() returns None and does not call get-mountpoint when get-device fails.
+#    - resolve_real_mountpoint() returns None when get-mountpoint fails after get-device succeeds.
+#    - run_single_mount() rejects a non-block-device source without executing a command.
+#    - run_single_mount() returns the propagated status of a successful mount.
+#    - run_single_mount() returns the propagated status of a failed mount.
+#    - run_single_unmount() returns 1 and does not execute a detach command when resolution fails.
+#    - run_single_unmount() returns the propagated status of the detach command on success.
+#    - run_external_mount() rejects a missing container file without executing a command.
+#    - run_external_unmount() always detaches by the container file path.
+#    - run_mount_all() continues past a mid-sequence failure and aggregates status 1.
+#    - run_mount_all() returns 0 only when every device mounts successfully.
+#    - In process_mounting(), no shell metacharacter in a device/target value is interpreted as a second command.
+#    - In process_mounting(), mount and unmount using mocked orchestration (TrueCrypt path).
+#    - In process_mounting(), mount and unmount using mocked orchestration (VeraCrypt path).
+#    - In process_mounting(), mount and unmount using mocked orchestration (VeraCrypt TC-compat path).
+#    - In process_mounting(), pass an explicit target to run_single_mount and run_single_unmount.
+#    - In process_mounting(), a failed single mount propagates status 1 to the caller.
+#    - In process_mounting(), a failed single unmount propagates status 1 to the caller.
+#    - In process_mounting(), custom exit code 11 when TrueCrypt is required but missing.
+#    - In process_mounting(), custom exit code 12 when VeraCrypt is required but missing (-v).
+#    - In process_mounting(), custom exit code 13 when VeraCrypt is required but missing (-t).
+#    - In process_mounting(), generate expected mount argument lists across option combinations
+#      (veracrypt/tc_compat/no_utf8/readonly/all/external).
+#    - In process_mounting(), delegate external mount (-e) to run_external_mount with an explicit target.
 #    - In process_mounting(), unmount an external container with default arguments.
 #    - In process_mounting(), unmount an external container even when an explicit target is provided.
+#    - In process_mounting(), --all continues through every device and aggregates a failure.
 #
 #  Version History:
+#  v1.4 2026-09-03
+#       Rewrote the suite for the argv-based mount/unmount execution: no
+#       shell=True anywhere, command failures propagate to process_mounting()'s
+#       return value, --all continues past failures and aggregates status, and
+#       get-device/get-mountpoint failures block the detach command. Added
+#       tests for the manual PATH search in find_command().
 #  v1.3 2025-08-31
 #       Add 5 tests for external container (-e): mount default/explicit target,
 #       process_mounting explicit target, and unmount default/explicit target.
@@ -67,14 +91,31 @@
 ########################################################################
 
 import os
+import shutil
+import stat
 import subprocess
 import sys
+import tempfile
 import unittest
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 # Adjust the path to import script from the parent directory
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import tcmount
+
+
+def make_options(veracrypt=False, tc_compat=False, no_utf8=False, readonly=False,
+                 all_devices=False, external=None):
+    """ Build a minimal stand-in for optparse's Values object. """
+    def options():
+        return None
+    options.veracrypt = veracrypt
+    options.tc_compat = tc_compat
+    options.no_utf8 = no_utf8
+    options.readonly = readonly
+    options.all = all_devices
+    options.external = external
+    return options
 
 
 class TestTcMount(unittest.TestCase):
@@ -108,102 +149,288 @@ class TestTcMount(unittest.TestCase):
             self.skipTest(
                 "Neither TrueCrypt nor VeraCrypt is installed, skipping this test.")
 
-    def test_build_mount_command(self):
-        expected = 'test -b /dev/sdb && sudo truecrypt -t -k "" --protect-hidden=no --fs-options=utf8 /dev/sdb ~/mnt/sdb'
-        result = tcmount.build_mount_command('sdb', 'utf8')
+    # -- argument-list builders -----------------------------------------
+
+    def test_build_mount_argv(self):
+        expected = ['sudo', 'truecrypt', '-t', '-k', '', '--protect-hidden=no',
+                    '--fs-options=utf8', '/dev/sdb', os.path.expanduser('~/mnt/sdb')]
+        result = tcmount.build_mount_argv(['truecrypt'], 'sdb', 'utf8')
         self.assertEqual(result, expected)
 
-    def test_build_unmount_command(self):
-        expected = 'dev=$(get-device ~/mnt/sdb) && mp=$(get-mountpoint "$dev") && sudo truecrypt -d "$mp"'
-        result = tcmount.build_unmount_command('sdb')
+    def test_build_mount_argv_with_readonly(self):
+        expected = ['sudo', 'truecrypt', '-t', '-k', '', '--protect-hidden=no',
+                    '--fs-options=ro', '/dev/sdb', os.path.expanduser('~/mnt/sdb')]
+        result = tcmount.build_mount_argv(['truecrypt'], 'sdb', 'ro')
         self.assertEqual(result, expected)
 
-    def test_build_mount_all_command(self):
-        result = tcmount.build_mount_all_command('utf8')
-        self.assertTrue('sdz' in result[-1])
-
-    def test_build_mount_external_command(self):
-        expected = 'test -f ~/mnt/external/container.tc && sudo truecrypt -t -k "" --protect-hidden=no --fs-options=utf8 ~/mnt/external/container.tc ~/mnt/sdb'
-        result = tcmount.build_mount_external_command('sdb', 'utf8')
+    def test_build_mount_argv_without_utf8(self):
+        expected = ['sudo', 'truecrypt', '-t', '-k', '', '--protect-hidden=no',
+                    '--fs-options=', '/dev/sdb', os.path.expanduser('~/mnt/sdb')]
+        result = tcmount.build_mount_argv(['truecrypt'], 'sdb', '')
         self.assertEqual(result, expected)
 
-    def test_build_mount_command_with_readonly(self):
-        expected = 'test -b /dev/sdb && sudo truecrypt -t -k "" --protect-hidden=no --fs-options=ro /dev/sdb ~/mnt/sdb'
-        result = tcmount.build_mount_command('sdb', 'ro')
+    def test_build_mount_argv_with_explicit_target(self):
+        expected = ['sudo', 'truecrypt', '-t', '-k', '', '--protect-hidden=no',
+                    '--fs-options=utf8', '/dev/sdb', os.path.expanduser('~/mnt/disk1')]
+        result = tcmount.build_mount_argv(['truecrypt'], 'sdb', 'utf8', 'disk1')
         self.assertEqual(result, expected)
 
-    def test_build_mount_command_without_utf8(self):
-        expected = 'test -b /dev/sdb && sudo truecrypt -t -k "" --protect-hidden=no --fs-options= /dev/sdb ~/mnt/sdb'
-        result = tcmount.build_mount_command('sdb', '')
+    def test_build_mount_argv_tc_compat_tool_tokens(self):
+        # tc-compat mounts as two argv words: 'veracrypt', '-tc'.
+        expected = ['sudo', 'veracrypt', '-tc', '-t', '-k', '', '--protect-hidden=no',
+                    '--fs-options=utf8', '/dev/sdb', os.path.expanduser('~/mnt/sdb')]
+        result = tcmount.build_mount_argv(['veracrypt', '-tc'], 'sdb', 'utf8')
         self.assertEqual(result, expected)
 
-    def test_build_mount_command_with_explicit_target(self):
-        expected = 'test -b /dev/sdb && sudo truecrypt -t -k "" --protect-hidden=no --fs-options=utf8 /dev/sdb ~/mnt/disk1'
-        result = tcmount.build_mount_command('sdb', 'utf8', 'disk1')
+    def test_build_detach_argv(self):
+        expected = ['sudo', 'truecrypt', '-d', '/mnt/real']
+        result = tcmount.build_detach_argv(['truecrypt'], '/mnt/real')
         self.assertEqual(result, expected)
 
-    def test_build_unmount_command_with_explicit_target(self):
-        expected = 'dev=$(get-device ~/mnt/disk1) && mp=$(get-mountpoint "$dev") && sudo truecrypt -d "$mp"'
-        result = tcmount.build_unmount_command('disk1')
+    def test_build_detach_argv_tc_compat_uses_bare_veracrypt(self):
+        # Unmount in TC-compat mode uses plain 'veracrypt', not '-tc'.
+        expected = ['sudo', 'veracrypt', '-d', '/mnt/real']
+        result = tcmount.build_detach_argv(['veracrypt'], '/mnt/real')
         self.assertEqual(result, expected)
 
-    @patch('tcmount.subprocess.call')
-    def test_is_truecrypt_installed(self, mock_call):
-        mock_call.return_value = 0
+    def test_build_mount_external_argv_default_target(self):
+        expected = ['sudo', 'truecrypt', '-t', '-k', '', '--protect-hidden=no',
+                    '--fs-options=utf8',
+                    os.path.expanduser('~/mnt/external/container.tc'),
+                    os.path.expanduser('~/mnt/sde')]
+        result = tcmount.build_mount_external_argv(['truecrypt'], 'utf8', 'sde')
+        self.assertEqual(result, expected)
+
+    def test_build_mount_external_argv_explicit_target(self):
+        expected = ['sudo', 'truecrypt', '-t', '-k', '', '--protect-hidden=no',
+                    '--fs-options=utf8',
+                    os.path.expanduser('~/mnt/external/container.tc'),
+                    os.path.expanduser('~/mnt/disk3')]
+        result = tcmount.build_mount_external_argv(['truecrypt'], 'utf8', 'disk3')
+        self.assertEqual(result, expected)
+
+    def test_build_unmount_external_argv(self):
+        expected = ['sudo', 'truecrypt', '-d', os.path.expanduser('~/mnt/external/container.tc')]
+        result = tcmount.build_unmount_external_argv(['truecrypt'])
+        self.assertEqual(result, expected)
+
+    def test_list_all_devices(self):
+        result = tcmount.list_all_devices()
+        self.assertEqual(result[0], 'sdc')
+        self.assertEqual(result[-1], 'sdz')
+
+    # -- detection and PATH lookup ---------------------------------------
+
+    @patch('tcmount.find_command', return_value='/usr/bin/truecrypt')
+    def test_is_truecrypt_installed(self, mock_find):
         self.assertTrue(tcmount.is_truecrypt_installed())
+        mock_find.assert_called_with('truecrypt')
 
-    @patch('tcmount.subprocess.call')
-    def test_is_veracrypt_installed(self, mock_call):
-        mock_call.return_value = 0
+    @patch('tcmount.find_command', return_value='/usr/bin/veracrypt')
+    def test_is_veracrypt_installed(self, mock_find):
         self.assertTrue(tcmount.is_veracrypt_installed())
+        mock_find.assert_called_with('veracrypt')
+
+    def make_fake_path(self, commands, non_executable):
+        """ Create a temporary PATH directory containing the given commands; return its path. """
+        directory = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, directory)
+        for command in commands:
+            path = os.path.join(directory, command)
+            with open(path, 'w', encoding='utf-8') as f:
+                f.write('#!/bin/sh\n')
+            if command not in non_executable:
+                os.chmod(path, 0o755)
+            else:
+                os.chmod(path, 0o644)
+        return directory
+
+    def test_find_command_resolves_executable_on_path(self):
+        directory = self.make_fake_path(['truecrypt'], [])
+        with patch.dict(os.environ, {'PATH': directory}):
+            found = tcmount.find_command('truecrypt')
+            self.assertTrue(tcmount.command_exists('truecrypt'))
+        self.assertEqual(os.path.realpath(found),
+                         os.path.realpath(os.path.join(directory, 'truecrypt')))
+
+    def test_find_command_missing_returns_none(self):
+        directory = self.make_fake_path([], [])
+        with patch.dict(os.environ, {'PATH': directory}):
+            self.assertIsNone(tcmount.find_command('nonexistent_command'))
+            self.assertFalse(tcmount.command_exists('nonexistent_command'))
+
+    def test_find_command_empty_path_component_is_cwd(self):
+        directory = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, directory)
+        command_name = 'fake_command_for_cwd_test'
+        path = os.path.join(directory, command_name)
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write('#!/bin/sh\n')
+        os.chmod(path, 0o755)
+        original_cwd = os.getcwd()
+        self.addCleanup(os.chdir, original_cwd)
+        os.chdir(directory)
+        with patch.dict(os.environ, {'PATH': ''}):
+            found = tcmount.find_command(command_name)
+        self.assertEqual(os.path.realpath(found), os.path.realpath(path))
+
+    # -- os_exec / is_block_device ----------------------------------------
 
     @patch('tcmount.subprocess.call')
-    def test_command_exists_true(self, mock_call):
-        """
-        Tests that command_exists returns True when the command is found.
-        """
+    def test_os_exec_runs_argv_without_shell(self, mock_call):
         mock_call.return_value = 0
-        self.assertTrue(tcmount.command_exists('truecrypt'))
+        argv = ['echo', 'Test Command']
+        status = tcmount.os_exec(argv)
+        mock_call.assert_called_with(argv)
+        self.assertEqual(status, 0)
 
     @patch('tcmount.subprocess.call')
-    def test_command_exists_false(self, mock_call):
-        """
-        Tests that command_exists returns False when the command is not found.
-        """
-        mock_call.return_value = 1
-        self.assertFalse(tcmount.command_exists('nonexistent'))
+    def test_os_exec_propagates_nonzero_status(self, mock_call):
+        mock_call.return_value = 7
+        self.assertEqual(tcmount.os_exec(['false']), 7)
+
+    @patch('tcmount.subprocess.call', side_effect=OSError('not found'))
+    def test_os_exec_exec_failure_returns_1(self, mock_call):
+        self.assertEqual(tcmount.os_exec(['nonexistent-binary']), 1)
+
+    def test_is_block_device_true_for_block_device(self):
+        fake_stat = type('FakeStat', (), {'st_mode': stat.S_IFBLK | 0o600})()
+        with patch('tcmount.os.stat', return_value=fake_stat):
+            self.assertTrue(tcmount.is_block_device('/dev/sdb'))
+
+    def test_is_block_device_false_for_regular_file(self):
+        fake_stat = type('FakeStat', (), {'st_mode': stat.S_IFREG | 0o600})()
+        with patch('tcmount.os.stat', return_value=fake_stat):
+            self.assertFalse(tcmount.is_block_device('/tmp/not-a-device'))
+
+    def test_is_block_device_false_when_missing(self):
+        with patch('tcmount.os.stat', side_effect=OSError()):
+            self.assertFalse(tcmount.is_block_device('/dev/does-not-exist'))
+
+    # -- resolve_real_mountpoint -------------------------------------------
+
+    @patch('tcmount.subprocess.check_output')
+    def test_resolve_real_mountpoint_success(self, mock_check_output):
+        mock_check_output.side_effect = [b'/dev/sdb1\n', b'/mnt/real\n']
+        result = tcmount.resolve_real_mountpoint('disk1')
+        self.assertEqual(result, '/mnt/real')
+        self.assertEqual(mock_check_output.call_args_list[0],
+                         call(['get-device', os.path.expanduser('~/mnt/disk1')]))
+        self.assertEqual(mock_check_output.call_args_list[1],
+                         call(['get-mountpoint', '/dev/sdb1']))
+
+    @patch('tcmount.subprocess.check_output')
+    def test_resolve_real_mountpoint_get_device_failure_skips_get_mountpoint(self, mock_check_output):
+        mock_check_output.side_effect = subprocess.CalledProcessError(1, 'get-device')
+        result = tcmount.resolve_real_mountpoint('disk1')
+        self.assertIsNone(result)
+        self.assertEqual(mock_check_output.call_count, 1)
+
+    @patch('tcmount.subprocess.check_output')
+    def test_resolve_real_mountpoint_get_mountpoint_failure(self, mock_check_output):
+        mock_check_output.side_effect = [b'/dev/sdb1\n', subprocess.CalledProcessError(1, 'get-mountpoint')]
+        result = tcmount.resolve_real_mountpoint('disk1')
+        self.assertIsNone(result)
+        self.assertEqual(mock_check_output.call_count, 2)
+
+    # -- run_single_mount / run_single_unmount ------------------------------
+
+    @patch('tcmount.os_exec')
+    @patch('tcmount.is_block_device', return_value=False)
+    def test_run_single_mount_rejects_non_block_device(self, mock_is_blk, mock_os_exec):
+        status = tcmount.run_single_mount('sdb', 'utf8', ['truecrypt'])
+        self.assertEqual(status, 1)
+        mock_os_exec.assert_not_called()
+
+    @patch('tcmount.os_exec', return_value=0)
+    @patch('tcmount.is_block_device', return_value=True)
+    def test_run_single_mount_success_status(self, mock_is_blk, mock_os_exec):
+        self.assertEqual(tcmount.run_single_mount('sdb', 'utf8', ['truecrypt']), 0)
+
+    @patch('tcmount.os_exec', return_value=1)
+    @patch('tcmount.is_block_device', return_value=True)
+    def test_run_single_mount_failure_status(self, mock_is_blk, mock_os_exec):
+        self.assertEqual(tcmount.run_single_mount('sdb', 'utf8', ['truecrypt']), 1)
+
+    @patch('tcmount.os_exec')
+    @patch('tcmount.resolve_real_mountpoint', return_value=None)
+    def test_run_single_unmount_resolution_failure_skips_detach(self, mock_resolve, mock_os_exec):
+        status = tcmount.run_single_unmount('disk1', ['truecrypt'])
+        self.assertEqual(status, 1)
+        mock_os_exec.assert_not_called()
+
+    @patch('tcmount.os_exec', return_value=0)
+    @patch('tcmount.resolve_real_mountpoint', return_value='/mnt/real')
+    def test_run_single_unmount_success_status(self, mock_resolve, mock_os_exec):
+        self.assertEqual(tcmount.run_single_unmount('disk1', ['truecrypt']), 0)
+        mock_os_exec.assert_called_with(['sudo', 'truecrypt', '-d', '/mnt/real'])
+
+    # -- run_external_mount / run_external_unmount ---------------------------
+
+    @patch('tcmount.os_exec')
+    @patch('tcmount.os.path.isfile', return_value=False)
+    def test_run_external_mount_missing_container_rejected(self, mock_isfile, mock_os_exec):
+        status = tcmount.run_external_mount('sde', 'utf8', ['truecrypt'])
+        self.assertEqual(status, 1)
+        mock_os_exec.assert_not_called()
+
+    @patch('tcmount.os_exec', return_value=0)
+    def test_run_external_unmount_detaches_by_container_path(self, mock_os_exec):
+        tcmount.run_external_unmount(['truecrypt'])
+        mock_os_exec.assert_called_with(
+            ['sudo', 'truecrypt', '-d', os.path.expanduser('~/mnt/external/container.tc')])
+
+    # -- run_mount_all -------------------------------------------------------
+
+    @patch('tcmount.run_single_mount')
+    def test_run_mount_all_continues_past_failure_and_aggregates(self, mock_run_single):
+        devices = tcmount.list_all_devices()
+
+        def side_effect(device, mount_options, tool_argv, target=None):
+            return 1 if device == devices[1] else 0
+
+        mock_run_single.side_effect = side_effect
+        status = tcmount.run_mount_all('utf8', ['truecrypt'])
+        self.assertEqual(status, 1)
+        self.assertEqual(mock_run_single.call_count, len(devices))
+
+    @patch('tcmount.run_single_mount', return_value=0)
+    def test_run_mount_all_all_succeed_returns_0(self, mock_run_single):
+        self.assertEqual(tcmount.run_mount_all('utf8', ['truecrypt']), 0)
+        self.assertEqual(mock_run_single.call_count, len(tcmount.list_all_devices()))
+
+    # -- process_mounting: no-shell / injection safety -----------------------
 
     @patch('tcmount.subprocess.call')
-    def test_os_exec(self, mock_call):
-        command = 'echo "Test Command"'
-        tcmount.os_exec(command)
-        mock_call.assert_called_with(command, shell=True)
+    @patch('tcmount.is_block_device', return_value=True)
+    @patch('tcmount.is_truecrypt_installed', return_value=True)
+    def test_process_mounting_does_not_interpret_shell_metacharacters(self, mock_tc, mock_is_blk, mock_call):
+        mock_call.return_value = 0
+        options = make_options()
+        # A target containing shell metacharacters must reach subprocess.call
+        # as a single literal argv element, never as shell text.
+        malicious_target = 'disk1; touch /tmp/pwned'
+        tcmount.process_mounting(options, ['sdb', malicious_target])
+        argv = mock_call.call_args[0][0]
+        self.assertIsInstance(argv, list)
+        self.assertIn(os.path.expanduser('~/mnt/' + malicious_target), argv)
+        for token in argv:
+            self.assertNotIn(';', token.replace(malicious_target, ''))
+
+    # -- process_mounting: orchestration dispatch ----------------------------
 
     def process_mounting_test_helper(self, veracrypt=False, tc_compat=False):
-        # Set up mock responses
-        with patch('tcmount.build_mount_command') as mock_build_mount, \
-                patch('tcmount.build_unmount_command') as mock_build_unmount, \
-                patch('tcmount.os_exec') as mock_os_exec:
-            mock_build_mount.return_value = 'mocked mount command'
-            mock_build_unmount.return_value = 'mocked unmount command'
+        with patch('tcmount.run_single_mount', return_value=0) as mock_run_mount, \
+                patch('tcmount.run_single_unmount', return_value=0) as mock_run_unmount:
+            options = make_options(veracrypt=veracrypt, tc_compat=tc_compat)
 
-            # Test mounting
-            def options():
-                return None
-            options.veracrypt = veracrypt
-            options.tc_compat = tc_compat
-            options.no_utf8 = False
-            options.readonly = False
-            options.all = False
-            options.external = None
-            tcmount.process_mounting(options, ['sdb'])
-            mock_build_mount.assert_called_with('sdb', 'utf8')
-            mock_os_exec.assert_called_with('mocked mount command')
+            status = tcmount.process_mounting(options, ['sdb'])
+            self.assertEqual(status, 0)
+            mock_run_mount.assert_called_with('sdb', 'utf8', mock_run_mount.call_args[0][2], None)
 
-            # Test unmounting
-            tcmount.process_mounting(options, ['sdb', 'unmount'])
-            mock_build_unmount.assert_called_with('sdb')
-            mock_os_exec.assert_called_with('mocked unmount command')
+            status = tcmount.process_mounting(options, ['sdb', 'unmount'])
+            self.assertEqual(status, 0)
+            mock_run_unmount.assert_called_with('sdb', mock_run_unmount.call_args[0][1])
 
     def test_process_mounting_truecrypt(self):
         self.check_truecrypt_installed()
@@ -218,411 +445,139 @@ class TestTcMount(unittest.TestCase):
         self.process_mounting_test_helper(veracrypt=False, tc_compat=True)
 
     def test_process_mounting_with_explicit_target_calls(self):
-        # Verify that explicit target is passed to builders
-        with patch('tcmount.build_mount_command') as mock_build_mount, \
-                patch('tcmount.build_unmount_command') as mock_build_unmount, \
-                patch('tcmount.os_exec') as mock_os_exec, \
+        with patch('tcmount.run_single_mount', return_value=0) as mock_run_mount, \
+                patch('tcmount.run_single_unmount', return_value=0) as mock_run_unmount, \
                 patch('tcmount.is_truecrypt_installed', return_value=True), \
                 patch('tcmount.is_veracrypt_installed', return_value=False):
-            mock_build_mount.return_value = 'mocked mount command'
-            mock_build_unmount.return_value = 'mocked unmount command'
+            options = make_options()
 
-            def options():
-                return None
-            options.veracrypt = False
-            options.tc_compat = False
-            options.no_utf8 = False
-            options.readonly = False
-            options.all = False
-            options.external = None
-
-            # Mount with explicit target
             tcmount.process_mounting(options, ['sdb', 'disk1'])
-            mock_build_mount.assert_called_with('sdb', 'utf8', 'disk1')
-            mock_os_exec.assert_called_with('mocked mount command')
-            mock_os_exec.reset_mock()
+            mock_run_mount.assert_called_with('sdb', 'utf8', ['truecrypt'], 'disk1')
 
-            # Unmount with explicit target (uses build_unmount_command which resolves real mountpoint)
-            with patch('tcmount.build_unmount_command') as mock_build_unmount:
-                mock_build_unmount.return_value = 'mocked unmount command'
-                tcmount.process_mounting(options, ['sdb', 'disk1', 'unmount'])
-                mock_build_unmount.assert_called_with('disk1')
-                mock_os_exec.assert_called_with('mocked unmount command')
+            tcmount.process_mounting(options, ['sdb', 'disk1', 'unmount'])
+            mock_run_unmount.assert_called_with('disk1', ['truecrypt'])
 
-    @patch('tcmount.os_exec')
-    def test_process_mounting_readonly_no_utf8_with_truecrypt(self, mock_os_exec):
-        self.check_truecrypt_installed()
+    def test_process_mounting_mount_failure_propagates_status(self):
+        with patch('tcmount.run_single_mount', return_value=1), \
+                patch('tcmount.is_truecrypt_installed', return_value=True), \
+                patch('tcmount.is_veracrypt_installed', return_value=False):
+            options = make_options()
+            self.assertEqual(tcmount.process_mounting(options, ['sdb']), 1)
 
-        def options():
-            return None
-        options.veracrypt = False
-        options.tc_compat = False
-        options.no_utf8 = True
-        options.readonly = True
-        options.all = False
-        options.external = None
-        tcmount.process_mounting(options, ['sdb'])
-        expected_command = 'test -b /dev/sdb && sudo truecrypt -t -k "" --protect-hidden=no --fs-options=ro /dev/sdb ~/mnt/sdb'
-        mock_os_exec.assert_called_with(expected_command)
+    def test_process_mounting_unmount_failure_propagates_status(self):
+        with patch('tcmount.run_single_unmount', return_value=1), \
+                patch('tcmount.is_truecrypt_installed', return_value=True), \
+                patch('tcmount.is_veracrypt_installed', return_value=False):
+            options = make_options()
+            self.assertEqual(tcmount.process_mounting(options, ['sdb', 'unmount']), 1)
 
-    @patch('tcmount.os_exec')
-    def test_process_mounting_readonly_with_veracrypt(self, mock_os_exec):
-        self.check_veracrypt_installed()
-
-        def options():
-            return None
-        options.veracrypt = True
-        options.tc_compat = False
-        options.no_utf8 = False
-        options.readonly = True
-        options.all = False
-        options.external = None
-        tcmount.process_mounting(options, ['sdb'])
-        expected_command = 'test -b /dev/sdb && sudo veracrypt -t -k "" --protect-hidden=no --fs-options=utf8,ro /dev/sdb ~/mnt/sdb'
-        mock_os_exec.assert_called_with(expected_command)
-
-    @patch('tcmount.os_exec')
-    def test_process_mounting_no_utf8_with_tc_compat(self, mock_os_exec):
-        self.check_veracrypt_installed()
-
-        def options():
-            return None
-        options.veracrypt = False
-        options.tc_compat = True
-        options.no_utf8 = True
-        options.readonly = False
-        options.all = False
-        options.external = None
-        tcmount.process_mounting(options, ['sdb'])
-        expected_command = 'test -b /dev/sdb && sudo veracrypt -tc -t -k "" --protect-hidden=no --fs-options= /dev/sdb ~/mnt/sdb'
-        mock_os_exec.assert_called_with(expected_command)
-
-    @patch('tcmount.os_exec')
     @patch('tcmount.is_truecrypt_installed', return_value=False)
-    @patch('tcmount.is_veracrypt_installed', return_value=True)
-    def test_process_mounting_with_explicit_target_veracrypt(self, mock_vc, mock_tc, mock_os_exec):
-        # Mount with explicit target using veracrypt
-        def options():
-            return None
-        options.veracrypt = True
-        options.tc_compat = False
-        options.no_utf8 = False
-        options.readonly = False
-        options.all = False
-        options.external = None
-        tcmount.process_mounting(options, ['sdb', 'disk1'])
-        expected_command = 'test -b /dev/sdb && sudo veracrypt -t -k "" --protect-hidden=no --fs-options=utf8 /dev/sdb ~/mnt/disk1'
-        mock_os_exec.assert_called_with(expected_command)
+    def test_process_mounting_exit_11_when_truecrypt_missing(self, mock_tc):
+        options = make_options()
+        with self.assertRaises(SystemExit) as cm:
+            tcmount.process_mounting(options, ['sdb'])
+        self.assertEqual(cm.exception.code, 11)
 
-    @patch('tcmount.os_exec')
-    @patch('tcmount.is_truecrypt_installed', return_value=False)
-    @patch('tcmount.is_veracrypt_installed', return_value=True)
-    def test_process_mounting_with_explicit_target_tc_compat(self, mock_vc, mock_tc, mock_os_exec):
-        # Mount with explicit target using veracrypt in TC-compat mode
-        def options():
-            return None
-        options.veracrypt = False
-        options.tc_compat = True
-        options.no_utf8 = False
-        options.readonly = False
-        options.all = False
-        options.external = None
-        tcmount.process_mounting(options, ['sdb', 'disk1'])
-        expected_command = 'test -b /dev/sdb && sudo veracrypt -tc -t -k "" --protect-hidden=no --fs-options=utf8 /dev/sdb ~/mnt/disk1'
-        mock_os_exec.assert_called_with(expected_command)
+    @patch('tcmount.is_veracrypt_installed', return_value=False)
+    def test_process_mounting_exit_12_when_veracrypt_missing(self, mock_vc):
+        options = make_options(veracrypt=True)
+        with self.assertRaises(SystemExit) as cm:
+            tcmount.process_mounting(options, ['sdb'])
+        self.assertEqual(cm.exception.code, 12)
 
-    @patch('tcmount.build_mount_command')
-    @patch('tcmount.build_unmount_command')
-    @patch('tcmount.os_exec')
-    def test_process_mounting_different_devices(self, mock_os_exec, mock_build_unmount, mock_build_mount):
-        self.check_truecrypt_installed()
-
-        # Set up mock responses
-        mock_build_mount.return_value = 'mocked mount command'
-        mock_build_unmount.return_value = 'mocked unmount command'
-
-        for device in ['sdb', 'sdc', 'sde', 'sdz']:
-            with self.subTest(device=device):
-                # Test mounting
-                def options():
-                    return None
-                options.veracrypt = False
-                options.tc_compat = False
-                options.no_utf8 = False
-                options.readonly = False
-                options.all = False
-                options.external = None
-                tcmount.process_mounting(options, [device])
-                mock_build_mount.assert_called_with(device, 'utf8')
-                mock_os_exec.assert_called_with('mocked mount command')
-
-                # Test unmounting
-                tcmount.process_mounting(options, [device, 'unmount'])
-                mock_build_unmount.assert_called_with(device)
-                mock_os_exec.assert_called_with('mocked unmount command')
-
-    @patch('tcmount.os_exec')
-    def test_process_mounting_readonly_no_utf8_different_devices(self, mock_os_exec):
-        self.check_truecrypt_installed()
-
-        for device in ['sdb', 'sdc', 'sde', 'sdz']:
-            with self.subTest(device=device):
-                def options():
-                    return None
-                options.veracrypt = False
-                options.tc_compat = False
-                options.no_utf8 = True
-                options.readonly = True
-                options.all = False
-                options.external = None
-                tcmount.process_mounting(options, [device])
-                expected_command = 'test -b /dev/{} && sudo truecrypt -t -k "" --protect-hidden=no --fs-options=ro /dev/{} ~/mnt/{}'.format(
-                    device, device, device)
-                mock_os_exec.assert_called_with(expected_command)
+    @patch('tcmount.is_veracrypt_installed', return_value=False)
+    def test_process_mounting_exit_13_when_veracrypt_missing_for_tc_compat(self, mock_vc):
+        options = make_options(tc_compat=True)
+        with self.assertRaises(SystemExit) as cm:
+            tcmount.process_mounting(options, ['sdb'])
+        self.assertEqual(cm.exception.code, 13)
 
     @patch('tcmount.os_exec')
     def test_process_mounting_combinations(self, mock_os_exec):
         self.check_both_installed()
+        mock_os_exec.return_value = 0
 
         test_cases = [
-            (False, False, False, False, False, None, 'utf8'),
-            (False, False, True, False, False, None, ''),
-            (False, False, False, True, False, None, 'utf8,ro'),
-            (False, False, True, True, False, None, 'ro'),
-            (False, False, False, False, True, None, 'utf8'),
-            (False, False, True, False, True, None, ''),
-            (False, False, False, True, True, None, 'utf8,ro'),
-            (False, False, True, True, True, None, 'ro'),
-            (False, False, False, False, False, 'sdb', 'utf8'),
-            (False, False, True, False, False, 'sdb', ''),
-            (False, False, False, True, False, 'sdb', 'utf8,ro'),
-            (False, False, True, True, False, 'sdb', 'ro'),
-            (False, False, False, False, True, 'sdb', 'utf8'),
-            (False, False, True, False, True, 'sdb', ''),
-            (False, False, False, True, True, 'sdb', 'utf8,ro'),
-            (False, False, True, True, True, 'sdb', 'ro'),
-            (False, False, False, False, False, 'sdc', 'utf8'),
-            (False, False, True, False, False, 'sdc', ''),
-            (False, False, False, True, False, 'sdc', 'utf8,ro'),
-            (False, False, True, True, False, 'sdc', 'ro'),
-            (False, False, False, False, True, 'sdc', 'utf8'),
-            (False, False, True, False, True, 'sdc', ''),
-            (False, False, False, True, True, 'sdc', 'utf8,ro'),
-            (False, False, True, True, True, 'sdc', 'ro'),
-            (True, False, False, False, False, None, 'utf8'),
-            (True, False, True, False, False, None, ''),
-            (True, False, False, True, False, None, 'utf8,ro'),
-            (True, False, True, True, False, None, 'ro'),
-            (True, False, False, False, True, None, 'utf8'),
-            (True, False, True, False, True, None, ''),
-            (True, False, False, True, True, None, 'utf8,ro'),
-            (True, False, True, True, True, None, 'ro'),
-            (True, False, False, False, False, 'sdb', 'utf8'),
-            (True, False, True, False, False, 'sdb', ''),
-            (True, False, False, True, False, 'sdb', 'utf8,ro'),
-            (True, False, True, True, False, 'sdb', 'ro'),
-            (True, False, False, False, True, 'sdb', 'utf8'),
-            (True, False, True, False, True, 'sdb', ''),
-            (True, False, False, True, True, 'sdb', 'utf8,ro'),
-            (True, False, True, True, True, 'sdb', 'ro'),
-            (True, False, False, False, False, 'sdc', 'utf8'),
-            (True, False, True, False, False, 'sdc', ''),
-            (True, False, False, True, False, 'sdc', 'utf8,ro'),
-            (True, False, True, True, False, 'sdc', 'ro'),
-            (True, False, False, False, True, 'sdc', 'utf8'),
-            (True, False, True, False, True, 'sdc', ''),
-            (True, False, False, True, True, 'sdc', 'utf8,ro'),
-            (True, False, True, True, True, 'sdc', 'ro'),
-            (False, True, False, False, False, None, 'utf8'),
-            (False, True, True, False, False, None, ''),
-            (False, True, False, True, False, None, 'utf8,ro'),
-            (False, True, True, True, False, None, 'ro'),
-            (False, True, False, False, True, None, 'utf8'),
-            (False, True, True, False, True, None, ''),
-            (False, True, False, True, True, None, 'utf8,ro'),
-            (False, True, True, True, True, None, 'ro'),
-            (False, True, False, False, False, 'sdb', 'utf8'),
-            (False, True, True, False, False, 'sdb', ''),
-            (False, True, False, True, False, 'sdb', 'utf8,ro'),
-            (False, True, True, True, False, 'sdb', 'ro'),
-            (False, True, False, False, True, 'sdb', 'utf8'),
-            (False, True, True, False, True, 'sdb', ''),
-            (False, True, False, True, True, 'sdb', 'utf8,ro'),
-            (False, True, True, True, True, 'sdb', 'ro'),
-            (False, True, False, False, False, 'sdc', 'utf8'),
-            (False, True, True, False, False, 'sdc', ''),
-            (False, True, False, True, False, 'sdc', 'utf8,ro'),
-            (False, True, True, True, False, 'sdc', 'ro'),
-            (False, True, False, False, True, 'sdc', 'utf8'),
-            (False, True, True, False, True, 'sdc', ''),
-            (False, True, False, True, True, 'sdc', 'utf8,ro'),
-            (False, True, True, True, True, 'sdc', 'ro'),
+            (False, False, False, False, None, 'utf8'),
+            (False, False, True, False, None, ''),
+            (False, False, False, True, None, 'utf8,ro'),
+            (False, False, True, True, None, 'ro'),
+            (False, False, False, False, 'sdb', 'utf8'),
+            (False, False, True, False, 'sdb', ''),
+            (True, False, False, False, None, 'utf8'),
+            (True, False, True, True, None, 'ro'),
+            (False, True, False, False, None, 'utf8'),
+            (False, True, True, True, None, 'ro'),
         ]
 
-        for veracrypt, tc_compat, no_utf8, readonly, all_devices, external, expected_options in test_cases:
-            with self.subTest(veracrypt=veracrypt, tc_compat=tc_compat, no_utf8=no_utf8, readonly=readonly, all_devices=all_devices, external=external):
-                def options():
-                    return None
-                options.veracrypt = veracrypt
-                options.tc_compat = tc_compat
-                options.no_utf8 = no_utf8
-                options.readonly = readonly
-                options.all = all_devices
-                options.external = external
+        for veracrypt, tc_compat, no_utf8, readonly, external, expected_options in test_cases:
+            with self.subTest(veracrypt=veracrypt, tc_compat=tc_compat, no_utf8=no_utf8,
+                              readonly=readonly, external=external):
+                options = make_options(veracrypt=veracrypt, tc_compat=tc_compat,
+                                       no_utf8=no_utf8, readonly=readonly, external=external)
                 tcmount.process_mounting(options, ['sdb'])
 
                 if tc_compat:
-                    cmd_prefix = 'veracrypt -tc'
+                    tool_argv = ['veracrypt', '-tc']
                 elif veracrypt:
-                    cmd_prefix = 'veracrypt'
+                    tool_argv = ['veracrypt']
                 else:
-                    cmd_prefix = 'truecrypt'
+                    tool_argv = ['truecrypt']
 
                 if external:
-                    expected_command = 'test -f ~/mnt/external/container.tc && sudo {} -t -k "" --protect-hidden=no --fs-options={} ~/mnt/external/container.tc ~/mnt/{}'.format(
-                        cmd_prefix, expected_options, external)
+                    expected_argv = (['sudo'] + tool_argv +
+                                     ['-t', '-k', '', '--protect-hidden=no',
+                                      '--fs-options=%s' % expected_options,
+                                      os.path.expanduser('~/mnt/external/container.tc'),
+                                      os.path.expanduser('~/mnt/' + external)])
                 else:
-                    expected_command = 'test -b /dev/sdb && sudo {} -t -k "" --protect-hidden=no --fs-options={} /dev/sdb ~/mnt/sdb'.format(
-                        cmd_prefix, expected_options)
+                    expected_argv = (['sudo'] + tool_argv +
+                                     ['-t', '-k', '', '--protect-hidden=no',
+                                      '--fs-options=%s' % expected_options,
+                                      '/dev/sdb', os.path.expanduser('~/mnt/sdb')])
 
-                mock_os_exec.assert_called_with(expected_command)
+                mock_os_exec.assert_called_with(expected_argv)
                 mock_os_exec.reset_mock()
-
-    @patch('tcmount.os_exec')
-    def test_mounting_various_options(self, mock_os_exec):
-        self.check_both_installed()
-
-        # Define various option combinations for testing
-        options_combinations = [
-            {'veracrypt': False, 'tc_compat': False,
-                'no_utf8': False, 'readonly': False},
-            {'veracrypt': True, 'tc_compat': False,
-                'no_utf8': False, 'readonly': False},
-            {'veracrypt': False, 'tc_compat': True,
-                'no_utf8': False, 'readonly': False},
-            {'veracrypt': False, 'tc_compat': False,
-                'no_utf8': True, 'readonly': False},
-            {'veracrypt': True, 'tc_compat': False,
-                'no_utf8': True, 'readonly': False},
-            {'veracrypt': False, 'tc_compat': True,
-                'no_utf8': True, 'readonly': False},
-            {'veracrypt': False, 'tc_compat': False,
-                'no_utf8': False, 'readonly': True},
-            {'veracrypt': True, 'tc_compat': False,
-                'no_utf8': False, 'readonly': True},
-            {'veracrypt': False, 'tc_compat': True,
-                'no_utf8': False, 'readonly': True},
-        ]
-
-        for options_dict in options_combinations:
-            with self.subTest(**options_dict):
-                # Setup options based on the current combination
-                def options():
-                    return None
-                options.veracrypt = options_dict['veracrypt']
-                options.tc_compat = options_dict['tc_compat']
-                options.no_utf8 = options_dict['no_utf8']
-                options.readonly = options_dict['readonly']
-                options.all = False
-                options.external = None
-
-                # Call process_mounting with the current options
-                tcmount.process_mounting(options, ['sdb'])
-
-                # Construct the expected command based on options
-                if options.tc_compat:
-                    cmd_prefix = 'veracrypt -tc'
-                elif options.veracrypt:
-                    cmd_prefix = 'veracrypt'
-                else:
-                    cmd_prefix = 'truecrypt'
-
-                fs_options = 'utf8' if not options.no_utf8 else ''
-                fs_options += ',ro' if options.readonly else ''
-                expected_command = 'test -b /dev/sdb && sudo {} -t -k "" --protect-hidden=no --fs-options={} /dev/sdb ~/mnt/sdb'.format(
-                    cmd_prefix, fs_options)
-
-                mock_os_exec.assert_called_with(expected_command)
-                mock_os_exec.reset_mock()
-
-    def test_build_mount_external_command_default_target(self):
-        # Use external_device when target is not specified
-        expected = 'test -f ~/mnt/external/container.tc && sudo truecrypt -t -k "" --protect-hidden=no --fs-options=utf8 ~/mnt/external/container.tc ~/mnt/sde'
-        result = tcmount.build_mount_external_command('sde', 'utf8', None)
-        self.assertEqual(result, expected)
-
-    def test_build_mount_external_command_explicit_target(self):
-        # Honor explicit target over external_device name
-        expected = 'test -f ~/mnt/external/container.tc && sudo truecrypt -t -k "" --protect-hidden=no --fs-options=utf8 ~/mnt/external/container.tc ~/mnt/disk3'
-        result = tcmount.build_mount_external_command('sde', 'utf8', 'disk3')
-        self.assertEqual(result, expected)
 
     def test_process_mounting_external_with_explicit_target(self):
-        # Verify process_mounting delegates to build_mount_external_command with explicit target
-        with patch('tcmount.build_mount_external_command') as mock_build_ext, \
-                patch('tcmount.os_exec') as mock_os_exec, \
+        with patch('tcmount.run_external_mount', return_value=0) as mock_run_ext, \
                 patch('tcmount.is_truecrypt_installed', return_value=True), \
                 patch('tcmount.is_veracrypt_installed', return_value=False):
-            mock_build_ext.return_value = 'mocked external mount command'
-
-            def options():
-                return None
-            options.veracrypt = False
-            options.tc_compat = False
-            options.no_utf8 = False
-            options.readonly = False
-            options.all = False
-            options.external = 'sde'  # -e sde
+            options = make_options(external='sde')
 
             # args includes an unrelated device ('sdb') and an explicit target ('disk3')
             tcmount.process_mounting(options, ['sdb', 'disk3'])
 
-            mock_build_ext.assert_called_with('sde', 'utf8', 'disk3')
-            mock_os_exec.assert_called_with('mocked external mount command')
+            mock_run_ext.assert_called_with('sde', 'utf8', ['truecrypt'], 'disk3')
 
     def test_process_mounting_external_unmount_default(self):
-        # -e sde unmount -> detach by container path
-        with patch('tcmount.build_unmount_external_command') as mock_build_unmount_ext, \
-                patch('tcmount.os_exec') as mock_os_exec, \
+        with patch('tcmount.run_external_unmount', return_value=0) as mock_run_ext_unmount, \
                 patch('tcmount.is_truecrypt_installed', return_value=True), \
                 patch('tcmount.is_veracrypt_installed', return_value=False):
-            mock_build_unmount_ext.return_value = 'mocked external unmount command'
-
-            def options():
-                return None
-            options.veracrypt = False
-            options.tc_compat = False
-            options.no_utf8 = False
-            options.readonly = False
-            options.all = False
-            options.external = 'sde'
+            options = make_options(external='sde')
 
             tcmount.process_mounting(options, ['unmount'])
 
-            mock_build_unmount_ext.assert_called_once()
-            mock_os_exec.assert_called_with('mocked external unmount command')
+            mock_run_ext_unmount.assert_called_once_with(['truecrypt'])
 
     def test_process_mounting_external_unmount_explicit_target(self):
         # -e sde disk3 unmount -> detach by container path (target ignored)
-        with patch('tcmount.build_unmount_external_command') as mock_build_unmount_ext, \
-                patch('tcmount.os_exec') as mock_os_exec, \
+        with patch('tcmount.run_external_unmount', return_value=0) as mock_run_ext_unmount, \
                 patch('tcmount.is_truecrypt_installed', return_value=True), \
                 patch('tcmount.is_veracrypt_installed', return_value=False):
-            mock_build_unmount_ext.return_value = 'mocked external unmount command'
-
-            def options():
-                return None
-            options.veracrypt = False
-            options.tc_compat = False
-            options.no_utf8 = False
-            options.readonly = False
-            options.all = False
-            options.external = 'sde'
+            options = make_options(external='sde')
 
             tcmount.process_mounting(options, ['disk3', 'unmount'])
 
-            mock_build_unmount_ext.assert_called_once()
-            mock_os_exec.assert_called_with('mocked external unmount command')
+            mock_run_ext_unmount.assert_called_once_with(['truecrypt'])
+
+    def test_process_mounting_all_continues_and_aggregates(self):
+        with patch('tcmount.run_mount_all', return_value=1) as mock_run_all, \
+                patch('tcmount.is_truecrypt_installed', return_value=True), \
+                patch('tcmount.is_veracrypt_installed', return_value=False):
+            options = make_options(all_devices=True)
+            self.assertEqual(tcmount.process_mounting(options, []), 1)
+            mock_run_all.assert_called_once_with('utf8', ['truecrypt'])
 
 
 if __name__ == '__main__':

--- a/test/wp_cachectl_test.py
+++ b/test/wp_cachectl_test.py
@@ -54,15 +54,30 @@
 #        Confirms that L3 W3TC flush is skipped when W3TC is not active.
 #    - test_w3tc_used_when_active:
 #        Confirms that L3 W3TC flush is attempted when W3TC is active.
+#    - test_find_command_resolves_executable_on_path:
+#        Confirms find_command() resolves a bare command name found on PATH.
+#    - test_find_command_missing_returns_none:
+#        Confirms find_command() returns None when the command is not found on PATH.
+#    - test_find_command_empty_path_component_is_cwd:
+#        Confirms find_command() resolves an empty PATH component to the current directory.
+#    - test_find_command_absolute_path_checked_directly:
+#        Confirms find_command() checks a path-separator-containing command directly,
+#        without searching PATH, matching WP_BIN set to an absolute path.
 #
 #  Version History:
+#  v1.1 2026-09-03
+#       Add tests for the manual PATH search in find_command(), replacing the
+#       previous 'command -v' based lookup, including the WP_BIN absolute
+#       path case.
 #  v1.0 2026-01-29
 #       Initial test implementation for wp_cachectl.py.
 #
 ########################################################################
 
 import os
+import shutil
 import sys
+import tempfile
 
 # Adjust the path to import script from the parent directory
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -281,6 +296,58 @@ class TestWpCachectl(unittest.TestCase):
         )
         self.assertEqual(rc, 0)
         self.assertIn("w3-total-cache flush all", out)
+
+    def make_fake_path(self, commands, non_executable):
+        """ Create a temporary PATH directory containing the given commands; return its path. """
+        directory = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, directory)
+        for command in commands:
+            path = os.path.join(directory, command)
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("#!/bin/sh\n")
+            if command not in non_executable:
+                os.chmod(path, 0o755)
+            else:
+                os.chmod(path, 0o644)
+        return directory
+
+    def test_find_command_resolves_executable_on_path(self):
+        directory = self.make_fake_path(["wp"], [])
+        with mock.patch.dict(os.environ, {"PATH": directory}):
+            found = wp_cachectl.find_command("wp")
+            self.assertTrue(wp_cachectl.command_exists("wp"))
+        self.assertEqual(os.path.realpath(found),
+                         os.path.realpath(os.path.join(directory, "wp")))
+
+    def test_find_command_missing_returns_none(self):
+        directory = self.make_fake_path([], [])
+        with mock.patch.dict(os.environ, {"PATH": directory}):
+            self.assertIsNone(wp_cachectl.find_command("nonexistent_command"))
+            self.assertFalse(wp_cachectl.command_exists("nonexistent_command"))
+
+    def test_find_command_empty_path_component_is_cwd(self):
+        directory = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, directory)
+        command_name = "fake_command_for_cwd_test"
+        path = os.path.join(directory, command_name)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("#!/bin/sh\n")
+        os.chmod(path, 0o755)
+        original_cwd = os.getcwd()
+        self.addCleanup(os.chdir, original_cwd)
+        os.chdir(directory)
+        with mock.patch.dict(os.environ, {"PATH": ""}):
+            found = wp_cachectl.find_command(command_name)
+        self.assertEqual(os.path.realpath(found), os.path.realpath(path))
+
+    def test_find_command_absolute_path_checked_directly(self):
+        directory = self.make_fake_path(["wp-custom"], [])
+        absolute_path = os.path.join(directory, "wp-custom")
+        with mock.patch.dict(os.environ, {"PATH": ""}):
+            self.assertEqual(wp_cachectl.find_command(absolute_path), absolute_path)
+            self.assertTrue(wp_cachectl.command_exists(absolute_path))
+        missing_absolute_path = os.path.join(directory, "does-not-exist")
+        self.assertIsNone(wp_cachectl.find_command(missing_absolute_path))
 
 
 if __name__ == "__main__":

--- a/wp_cachectl.py
+++ b/wp_cachectl.py
@@ -90,6 +90,11 @@
 #  - 9: Unsupported Python version
 #
 #  Version History:
+#  v1.1 2026-09-03
+#       Replaced 'command -v' based lookup with a manual PATH search in
+#       command_exists(), matching the shell script helper's PATH lookup and
+#       exit semantics. A WP_BIN containing a path separator is checked
+#       directly instead of being searched on PATH.
 #  v1.0 2026-01-29
 #       Initial release. Event-driven cache operations with W3TC support.
 #
@@ -164,15 +169,25 @@ def get_script_version():
     return "unknown"
 
 
+def find_command(command):
+    """
+    Search PATH for command's executable path, using a manual PATH search.
+    When command contains a path separator, it is checked directly instead
+    of being searched on PATH. Return the full path when found, or None
+    when not found.
+    """
+    if os.sep in command or (os.altsep and os.altsep in command):
+        return command if os.path.isfile(command) and os.access(command, os.X_OK) else None
+    for directory in os.environ.get("PATH", "").split(os.pathsep):
+        candidate = os.path.join(directory if directory else ".", command)
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
 def command_exists(command):
-    """Check whether a command exists in PATH using 'command -v'."""
-    with open(os.devnull, "w") as devnull:
-        return subprocess.call(
-            "command -v %s" % command,
-            shell=True,
-            stdout=devnull,
-            stderr=devnull,
-        ) == 0
+    """Check whether a command exists, using a manual PATH search."""
+    return find_command(command) is not None
 
 
 def log_info(msg):


### PR DESCRIPTION
## Summary
- Fix `luksmount.py`'s sudo privilege check to suppress `sudo -v`'s own output while keeping the
  interactive password prompt intact, give a single `[ERROR]` line for both a non-zero exit and an
  exec failure, and fix `find_command()` to search the current directory for an empty PATH component
  instead of skipping it.
- Fix `tcmount.py` to build and run mount/unmount commands as argument lists instead of shell strings
  (no `shell=True`, no unprotected embedding of device/target values into shell text), propagate the
  external command's failure status to the script's own exit status, and require both `get-device` and
  `get-mountpoint` to resolve successfully before running the detach command on unmount.
- Replace the shell-based `command -v` command lookup with a manual PATH search in `tcmount.py`,
  `cal.py`, `du.py`, and `wp_cachectl.py`, per doc/POLICY's guidance to implement a manual PATH search
  matching the shell script helper's lookup and exit semantics. `wp_cachectl.py`'s lookup checks a
  path-separator-containing `WP_BIN` directly instead of searching PATH.

## Behavior
- CLI options, exit codes (including tcmount's custom 1/11/12/13), the legacy external-container path,
  explicit-target mount/unmount, and `--all`'s continue-through-all-devices-then-aggregate-failure
  semantics are all unchanged.
- luksmount's confirm-before-sudo ordering and exit-1-without-running-cryptsetup/mount-on-sudo-failure
  behavior are unchanged; luksmount still never closes the mapper or unmounts.
- No new files, dependencies, or CLI redesign; no changes outside the files listed below.

## Version
- luksmount.py: v1.0 (description updated, no version bump)
- tcmount.py: v5.1 -> v5.2
- cal.py: v1.5 -> v1.6
- du.py: v1.7 -> v1.8
- wp_cachectl.py: v1.0 -> v1.1
- Matching test files updated; doc/VERSIONS v2.0.2 (Release Date: TBD) entry updated to 3 one-line bullets.

## Validation
- `python test/luksmount_test.py`, `python test/tcmount_test.py`, `python test/cal_test.py`,
  `python test/du_test.py`, `python test/wp_cachectl_test.py`: all pass.
- `python find_pycompat.py .`: no compatibility issues outside the existing `test/dummy.py` fixture.
- `./run_tests.sh`: full suite passes (40 Python test scripts, 559 test cases).
- `python check_header_doc.py -R .`: no header documentation violations.
- Confirmed no `shell=True` remains in tcmount's mount/unmount path, and no `command -v` / `which` /
  `shutil.which` remain as functional code in the four updated lookup scripts.
- `git diff --check`: no whitespace errors.

## Scope
Exactly 11 files: `luksmount.py`, `test/luksmount_test.py`, `tcmount.py`, `test/tcmount_test.py`,
`cal.py`, `test/cal_test.py`, `du.py`, `test/du_test.py`, `wp_cachectl.py`, `test/wp_cachectl_test.py`,
`doc/VERSIONS`.