### PR TITLE
Fix tcmount target path compatibility

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -3,9 +3,12 @@ scripts Repository Version History
 
 v2.0.2 (Release Date: TBD)
 --------------------------
-- Add luksmount.py to open and mount a LUKS device after confirmation, and fix its sudo check and PATH lookup.
-- Fix tcmount.py to run mount and unmount without a shell, propagating command failures to the exit status.
-- Replace shell-based command lookup with a manual PATH search in tcmount.py, cal.py, du.py, and wp_cachectl.py.
+- Add luksmount.py for confirmed LUKS opening and mounting, and install it
+  as luksmount with the Debian system administration scripts.
+- Harden tcmount.py against shell interpretation, preserve the legacy
+  ~/mnt/<target> namespace, and return mount and unmount failures.
+- Replace shell-based command lookup in cal.py, du.py, tcmount.py, and
+  wp_cachectl.py with Python-native PATH lookup.
 
 v2.0.1 (2026-08-26)
 -------------------

--- a/tcmount.py
+++ b/tcmount.py
@@ -104,7 +104,8 @@
 #       external command failure status to the script's exit status. Unmount
 #       now aborts without running the detach command when get-device or
 #       get-mountpoint resolution fails. Replaced 'command -v' based lookup
-#       with a manual PATH search in command_exists().
+#       with a manual PATH search in command_exists(). Preserve the legacy
+#       ~/mnt/<target> namespace when an explicit target starts with '/'.
 #  v5.1 2025-09-01
 #       Fix external mount to honor explicit target and preserve legacy container path.
 #       Change unmount logic to always resolve real mountpoint via get-device/get-mountpoint.
@@ -292,6 +293,10 @@ def is_block_device(path):
     except OSError:
         return False
 
+def build_mountpoint_path(target):
+    """ Return the legacy ~/mnt/<target> path with home expansion. """
+    return os.path.expanduser('~/mnt/' + target)
+
 def build_mount_argv(tool_argv, device, mount_options, target=None):
     """
     Build the argument list to mount /dev/<device> to ~/mnt/<target or device>.
@@ -301,7 +306,7 @@ def build_mount_argv(tool_argv, device, mount_options, target=None):
     if not target:
         target = device
     source = '/dev/' + device
-    mount_point = os.path.expanduser(os.path.join('~', 'mnt', target))
+    mount_point = build_mountpoint_path(target)
     return (['sudo'] + tool_argv +
             ['-t', '-k', '', '--protect-hidden=no', '--fs-options=%s' % mount_options,
              source, mount_point])
@@ -312,7 +317,7 @@ def build_mount_external_argv(tool_argv, mount_options, target):
     ~/mnt/<target>.
     """
     external_file = os.path.expanduser(os.path.join('~', 'mnt', 'external', 'container.tc'))
-    mount_point = os.path.expanduser(os.path.join('~', 'mnt', target))
+    mount_point = build_mountpoint_path(target)
     return (['sudo'] + tool_argv +
             ['-t', '-k', '', '--protect-hidden=no', '--fs-options=%s' % mount_options,
              external_file, mount_point])
@@ -342,7 +347,7 @@ def resolve_real_mountpoint(target):
     get-mountpoint. Return the mountpoint, or None when resolution fails.
     Neither helper is invoked past the first failure.
     """
-    mount_point = os.path.expanduser(os.path.join('~', 'mnt', target))
+    mount_point = build_mountpoint_path(target)
     try:
         device = subprocess.check_output(['get-device', mount_point]).decode('utf-8').strip()
     except (subprocess.CalledProcessError, OSError):

--- a/test/tcmount_test.py
+++ b/test/tcmount_test.py
@@ -26,11 +26,19 @@
 #    - Build a mount argument list with read-only filesystem option.
 #    - Build a mount argument list without UTF-8 filesystem option.
 #    - Build a mount argument list with an explicit target mount directory.
+#    - Build a mount argument list with an absolute-looking explicit target, staying
+#      under the ~/mnt/<target> namespace instead of escaping to the absolute path.
 #    - Build a mount argument list for VeraCrypt TC-compat mode with the correct tool tokens.
 #    - Build a detach argument list for a resolved mountpoint.
 #    - Build an external container mount argument list using the default mount target (device name).
 #    - Build an external container mount argument list honoring an explicit target mount directory.
+#    - Build an external container mount argument list with an absolute-looking explicit
+#      target, staying under the ~/mnt/<target> namespace.
 #    - Build an external container unmount argument list by its fixed file path.
+#    - build_mountpoint_path() expands a normal target under ~/mnt/.
+#    - build_mountpoint_path() keeps an absolute-looking target under ~/mnt/, never
+#      escaping to the absolute path itself.
+#    - build_mountpoint_path() preserves a '..' traversal token without normalization.
 #    - list_all_devices() includes the first (sdc) and last (sdz) devices.
 #    - Detect TrueCrypt installation when the truecrypt command is available.
 #    - Detect VeraCrypt installation when the veracrypt command is available.
@@ -42,6 +50,8 @@
 #    - os_exec() returns 1 and prints a diagnostic when the command cannot be executed.
 #    - is_block_device() returns True only for a path whose mode is a block device.
 #    - resolve_real_mountpoint() returns the resolved path when get-device and get-mountpoint both succeed.
+#    - resolve_real_mountpoint() calls get-device with an absolute-looking target kept
+#      under the ~/mnt/<target> namespace.
 #    - resolve_real_mountpoint() returns None and does not call get-mountpoint when get-device fails.
 #    - resolve_real_mountpoint() returns None when get-mountpoint fails after get-device succeeds.
 #    - run_single_mount() rejects a non-block-device source without executing a command.
@@ -76,7 +86,10 @@
 #       shell=True anywhere, command failures propagate to process_mounting()'s
 #       return value, --all continues past failures and aggregates status, and
 #       get-device/get-mountpoint failures block the detach command. Added
-#       tests for the manual PATH search in find_command().
+#       tests for the manual PATH search in find_command(). Added coverage
+#       for build_mountpoint_path() and for absolute-looking explicit
+#       targets staying under the ~/mnt/<target> namespace across mount,
+#       external mount, and unmount resolution.
 #  v1.3 2025-08-31
 #       Add 5 tests for external container (-e): mount default/explicit target,
 #       process_mounting explicit target, and unmount default/explicit target.
@@ -151,6 +164,24 @@ class TestTcMount(unittest.TestCase):
 
     # -- argument-list builders -----------------------------------------
 
+    def test_build_mountpoint_path(self):
+        self.assertEqual(
+            tcmount.build_mountpoint_path('disk1'),
+            os.path.expanduser('~/mnt/disk1'))
+
+    def test_build_mountpoint_path_absolute_looking_target(self):
+        # A leading '/' in target must not escape the ~/mnt/ namespace.
+        expected = os.path.expanduser('~/mnt//tmp/foo')
+        result = tcmount.build_mountpoint_path('/tmp/foo')
+        self.assertEqual(result, expected)
+        self.assertNotEqual(result, '/tmp/foo')
+
+    def test_build_mountpoint_path_preserves_traversal_token(self):
+        # No normalization or rejection of '..' tokens in target.
+        self.assertEqual(
+            tcmount.build_mountpoint_path('../disk1'),
+            os.path.expanduser('~/mnt/../disk1'))
+
     def test_build_mount_argv(self):
         expected = ['sudo', 'truecrypt', '-t', '-k', '', '--protect-hidden=no',
                     '--fs-options=utf8', '/dev/sdb', os.path.expanduser('~/mnt/sdb')]
@@ -174,6 +205,15 @@ class TestTcMount(unittest.TestCase):
                     '--fs-options=utf8', '/dev/sdb', os.path.expanduser('~/mnt/disk1')]
         result = tcmount.build_mount_argv(['truecrypt'], 'sdb', 'utf8', 'disk1')
         self.assertEqual(result, expected)
+
+    def test_build_mount_argv_with_absolute_looking_explicit_target(self):
+        # A leading '/' in the explicit target must stay under ~/mnt/, not
+        # escape to the absolute path itself.
+        expected = ['sudo', 'truecrypt', '-t', '-k', '', '--protect-hidden=no',
+                    '--fs-options=utf8', '/dev/sdb', os.path.expanduser('~/mnt//tmp/foo')]
+        result = tcmount.build_mount_argv(['truecrypt'], 'sdb', 'utf8', '/tmp/foo')
+        self.assertEqual(result, expected)
+        self.assertNotEqual(result[-1], '/tmp/foo')
 
     def test_build_mount_argv_tc_compat_tool_tokens(self):
         # tc-compat mounts as two argv words: 'veracrypt', '-tc'.
@@ -208,6 +248,17 @@ class TestTcMount(unittest.TestCase):
                     os.path.expanduser('~/mnt/disk3')]
         result = tcmount.build_mount_external_argv(['truecrypt'], 'utf8', 'disk3')
         self.assertEqual(result, expected)
+
+    def test_build_mount_external_argv_absolute_looking_target(self):
+        # Explicit target namespace is preserved under ~/mnt/, while the
+        # fixed legacy container path is unaffected.
+        expected = ['sudo', 'truecrypt', '-t', '-k', '', '--protect-hidden=no',
+                    '--fs-options=utf8',
+                    os.path.expanduser('~/mnt/external/container.tc'),
+                    os.path.expanduser('~/mnt//tmp/foo')]
+        result = tcmount.build_mount_external_argv(['truecrypt'], 'utf8', '/tmp/foo')
+        self.assertEqual(result, expected)
+        self.assertNotEqual(result[-1], '/tmp/foo')
 
     def test_build_unmount_external_argv(self):
         expected = ['sudo', 'truecrypt', '-d', os.path.expanduser('~/mnt/external/container.tc')]
@@ -316,6 +367,18 @@ class TestTcMount(unittest.TestCase):
         self.assertEqual(result, '/mnt/real')
         self.assertEqual(mock_check_output.call_args_list[0],
                          call(['get-device', os.path.expanduser('~/mnt/disk1')]))
+        self.assertEqual(mock_check_output.call_args_list[1],
+                         call(['get-mountpoint', '/dev/sdb1']))
+
+    @patch('tcmount.subprocess.check_output')
+    def test_resolve_real_mountpoint_absolute_looking_target(self, mock_check_output):
+        # get-device must be called with the ~/mnt/ namespaced path, not the
+        # bare absolute-looking target.
+        mock_check_output.side_effect = [b'/dev/sdb1\n', b'/mnt/real\n']
+        result = tcmount.resolve_real_mountpoint('/tmp/foo')
+        self.assertEqual(result, '/mnt/real')
+        self.assertEqual(mock_check_output.call_args_list[0],
+                         call(['get-device', os.path.expanduser('~/mnt//tmp/foo')]))
         self.assertEqual(mock_check_output.call_args_list[1],
                          call(['get-mountpoint', '/dev/sdb1']))
 


### PR DESCRIPTION
## Summary

- PR #96's argv conversion introduced a regression: an absolute-looking explicit target (e.g. `/tmp/foo`) escaped the `~/mnt/<target>` namespace because `os.path.join('~', 'mnt', target)` discards preceding components when `target` starts with `/`.
- Restored the legacy `~/mnt/<target>` string semantics with a shared `build_mountpoint_path()` helper (`os.path.expanduser('~/mnt/' + target)`).
- Unified `build_mount_argv()`, `build_mount_external_argv()`, and `resolve_real_mountpoint()` on this same helper.
- Aligned the unreleased `v2.0.2` entry in `doc/VERSIONS` with the implementation as it stands after this fix.

## Preserved Behavior

- CLI / options / custom exit codes (1 / 11 / 12 / 13) unchanged
- No shell execution regression (mount/unmount still run as argv lists, no `shell=True`)
- Failure propagation unchanged
- `--all` semantics unchanged
- No new target validation, normalization, or rejection (e.g. `../disk1` still resolves to `~/mnt/../disk1` verbatim)
- No dependency changes

## Versions

```text
tcmount.py: v5.2 2026-09-03, same-day entry updated
test/tcmount_test.py: v1.4 2026-09-03, same-day entry updated
repository: v2.0.2 (Release Date: TBD), still unreleased
```

## Validation

- `python test/tcmount_test.py`: 56 tests, OK (4 skipped — TrueCrypt/VeraCrypt not installed in this environment, documented skip)
- `find_pycompat.py .`: only the expected `test/dummy.py` fixture flagged; no new compatibility issues in `tcmount.py` or `test/tcmount_test.py`
- `./run_tests.sh`: all Python tests passed (40 scripts, 565 cases, 28 skipped); RSpec skipped (not installed, documented optional skip)
- `check_header_doc.py -R . -a`: no header violations
- Static check: `build_mount_argv()`, `build_mount_external_argv()`, and `resolve_real_mountpoint()` all use `build_mountpoint_path(target)`; no remaining `os.path.join('~', 'mnt', target)` construction for user-supplied targets
- `git diff --check`: clean

## Scope

Exactly 3 files changed: `tcmount.py`, `test/tcmount_test.py`, `doc/VERSIONS`.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01F99TE7MJ2fSxdJQFVq5exs