### PR TITLE
Fix nightly quality gate failure detection

### DIFF
--- a/cron/bin/run_tests
+++ b/cron/bin/run_tests
@@ -52,6 +52,9 @@
 #  4. Configuration variables not set.
 #
 #  Version History:
+#  v2.8 2026-09-05
+#       Return the current run's actual failure status instead of always 0,
+#       and stop deriving failure state from historical JOBLOG content.
 #  v2.7 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -118,6 +121,11 @@ record_failure() {
     echo "[WARN] Some tests failed. Check logs for details." >> "$JOBLOG" 2>&1
 }
 
+# Mark the current run as failed, independent of JOBLOG content
+mark_failure() {
+    OVERALL_STATUS=1
+}
+
 # Determine the script's directory and load configuration
 initialize() {
     if ! is_running_from_cron; then
@@ -165,6 +173,7 @@ run_tests() {
 
     if [ "$result" -ge 1 ]; then
         record_failure
+        mark_failure
     fi
 }
 
@@ -178,6 +187,7 @@ run_check_scripts() {
 
         if [ "$result" -ge 1 ]; then
             echo "[WARN] Some tests failed in shell script tests. Check logs for details." >> "$JOBLOG" 2>&1
+            mark_failure
         else
             echo "[INFO] All shell script tests completed successfully." >> "$JOBLOG" 2>&1
         fi
@@ -200,6 +210,7 @@ run_check_header_doc() {
 
         if [ "$result" -ge 1 ]; then
             echo "[WARN] Some tests failed in Header documentation inspection. Check logs for details." >> "$JOBLOG" 2>&1
+            mark_failure
         else
             echo "[INFO] Header documentation inspection completed successfully." >> "$JOBLOG" 2>&1
         fi
@@ -216,6 +227,7 @@ run_compatibility_check() {
 
     if [ ! -f "$SCRIPTS/find_pycompat.py" ]; then
         record_failure
+        mark_failure
         return 1
     fi
 
@@ -225,8 +237,7 @@ run_compatibility_check() {
 
     if [ "$result" -ge 1 ]; then
         echo "[WARN] Some tests failed in Python compatibility inspection. Check logs for details." >> "$JOBLOG" 2>&1
-    elif grep -q "Some tests failed" "$JOBLOG"; then
-        record_failure
+        mark_failure
     else
         echo "[INFO] All tests completed successfully for all versions." >> "$JOBLOG" 2>&1
     fi
@@ -255,6 +266,7 @@ main() {
 
     initialize
 
+    OVERALL_STATUS=0
     first_python_version=""
 
     py_list=$(echo "$python_versions")
@@ -288,7 +300,7 @@ main() {
         send_mail_to_admin
     fi
 
-    return 0
+    return "$OVERALL_STATUS"
 }
 
 # Execute main function

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -9,6 +9,8 @@ v2.0.2 (Release Date: TBD)
   ~/mnt/<target> namespace, and return mount and unmount failures.
 - Replace shell-based command lookup in cal.py, du.py, tcmount.py, and
   wp_cachectl.py with Python-native PATH lookup.
+- Fix the nightly quality gate so its exit status reflects the current
+  run's actual check results.
 
 v2.0.1 (2026-08-26)
 -------------------

--- a/find_pycompat.py
+++ b/find_pycompat.py
@@ -8,7 +8,10 @@
 #  within a specified directory. It identifies usage of features introduced in Python 3.x,
 #  including f-strings, subprocess.run, subprocess.DEVNULL, async/await keywords,
 #  type hints, nonlocal statements, matrix multiplication operators, asyncio library,
-#  yield from, extended unpacking, pathlib module, and notably, the shutil.which function.
+#  yield from, pathlib module, and notably, the shutil.which function.
+#  Detection also covers the corresponding import forms of these features (e.g.,
+#  "import pathlib", "from asyncio import ..."), so importing a restricted feature
+#  directly does not bypass the check.
 #  The script helps in identifying code segments that may not be compatible with earlier
 #  versions of Python, facilitating easier code migration and compatibility assessments.
 #  It now also tracks the detected issues and provides feedback on whether the issues
@@ -41,6 +44,10 @@
 #  contain patterns resembling Python 3.x features but are unrelated to code functionality.
 #
 #  Version History:
+#  v3.7 2026-09-05
+#       Also detect the import forms of pathlib, asyncio, subprocess.run,
+#       subprocess.DEVNULL, and shutil.which; drop the stale "extended
+#       unpacking" claim from the Description.
 #  v3.6 2025-07-01
 #       Standardized termination behavior for consistent script execution.
 #  v3.5 2025-06-23
@@ -157,15 +164,15 @@ def main():
     # Define patterns for each feature
     features = {
         "f-strings": r"f['\"][^'\"]*\{[^}]*\}[^'\"]*['\"]",
-        "subprocess.run and subprocess.DEVNULL": r"subprocess\.run|subprocess\.DEVNULL",
+        "subprocess.run and subprocess.DEVNULL": r"subprocess\.run|subprocess\.DEVNULL|\bfrom\s+subprocess\s+import\b.*\b(?:run|DEVNULL)\b",
         "async/await keywords": r"\basync\b|\bawait\b",
         "nonlocal keyword": r"\bnonlocal\b",
-        "asyncio usage": r"\basyncio\.",
+        "asyncio usage": r"\basyncio\.|\bimport\s+asyncio\b|\bfrom\s+asyncio\s+import\b",
         "yield from usage": r"\byield from\b",
         "matrix multiplication operator": r"\b[a-zA-Z_][a-zA-Z0-9_]*\s+@\s+[a-zA-Z_][a-zA-Z0-9_]*\b",
-        "pathlib usage": r"\bpathlib\.",
+        "pathlib usage": r"\bpathlib\.|\bimport\s+pathlib\b|\bfrom\s+pathlib\s+import\b",
         "type hints": r"\bdef\b.*->",
-        "shutil.which usage": r"\bshutil\.which\b"
+        "shutil.which usage": r"\bshutil\.which\b|\bfrom\s+shutil\s+import\b.*\bwhich\b"
     }
 
     # Perform search for each feature

--- a/test/find_pycompat_test.py
+++ b/test/find_pycompat_test.py
@@ -6,6 +6,12 @@
 #  Description:
 #  This script contains comprehensive unit tests for the find_pycompat.py script.
 #  It verifies the script's functionality including the detection of various Python 3.x features.
+#  Assertions are based on the actual detection result recorded in
+#  find_pycompat.detected_issues, not merely on whether the target file was opened,
+#  so a regression in the underlying regular expressions is caught by these tests.
+#  Detection also covers the corresponding import forms of pathlib, asyncio,
+#  subprocess.run, subprocess.DEVNULL, and shutil.which, so importing a restricted
+#  feature directly is verified to no longer bypass the check.
 #  Recent updates have modified the detection pattern for the matrix multiplication operator
 #  to require spaces around it. These tests ensure that the updated patterns accurately identify
 #  the intended features without false positives or negatives.
@@ -23,6 +29,9 @@
 #    - Do not detect subprocess.run usage when absent.
 #    - Detect subprocess.DEVNULL usage when present.
 #    - Do not detect subprocess.DEVNULL usage when absent.
+#    - Detect 'from subprocess import run' usage when present.
+#    - Detect 'from subprocess import DEVNULL' usage when present.
+#    - Do not detect 'from subprocess import Popen' as a subprocess.run/DEVNULL issue.
 #    - Detect async/await keywords when present.
 #    - Do not detect async/await keywords when absent.
 #    - Detect function type hints (-> return annotation) when present.
@@ -34,14 +43,25 @@
 #    - Do not detect matrix multiplication operator when '@' is not used (failure case).
 #    - Detect asyncio usage when present.
 #    - Do not detect asyncio usage when absent.
+#    - Detect 'import asyncio' usage when present.
+#    - Detect 'from asyncio import ...' usage when present.
 #    - Detect 'yield from' usage when present.
 #    - Do not detect 'yield from' usage when absent.
 #    - Detect pathlib usage when present.
 #    - Do not detect pathlib usage when absent.
+#    - Detect 'import pathlib' usage when present.
+#    - Detect 'from pathlib import ...' usage when present.
 #    - Detect shutil.which usage when present.
 #    - Do not detect shutil.which usage when absent.
+#    - Detect 'from shutil import which' usage when present.
+#    - Exclude a comment line from detection even when the pattern matches.
+#    - Exclude a line containing an email address from detection even when the pattern matches.
+#    - Detected issues do not leak from one test to the next.
 #
 #  Version History:
+#  v1.5 2026-09-05
+#       Assert actual detection results instead of only that the file was
+#       opened, and add tests for import-form detection and exclusions.
 #  v1.4 2024-03-12
 #       Updated tests to reflect the modified detection pattern for the matrix multiplication operator.
 #  v1.3 2024-02-11
@@ -57,15 +77,28 @@
 ########################################################################
 
 import os
-import re
 import subprocess
 import sys
 import unittest
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import patch
 
 # Adjust the path to import script from the parent directory
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import find_pycompat
+
+
+class _FakeTextFile(object):
+    """ A minimal file-like context manager backed by an in-memory string,
+    so 'with open(...) as f: for line in f:' iterates over real content. """
+
+    def __init__(self, content):
+        self._lines = content.splitlines(True)
+
+    def __enter__(self):
+        return iter(self._lines)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
 
 
 class TestFindPyCompat(unittest.TestCase):
@@ -78,10 +111,12 @@ class TestFindPyCompat(unittest.TestCase):
         self.mock_open = patch('builtins.open').start()
         self.mock_print = patch('builtins.print').start()
         self.file_content = ""
+        find_pycompat.detected_issues[:] = []
 
     def tearDown(self):
         """ Tear down mocks after each test. """
         patch.stopall()
+        find_pycompat.detected_issues[:] = []
 
     def test_usage_shows_help(self):
         script_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -96,7 +131,7 @@ class TestFindPyCompat(unittest.TestCase):
         self.assertIn('Usage:', out.decode('utf-8'))
 
     def mock_file_read(self, *args, **kwargs):
-        return MagicMock(read=lambda: self.file_content)
+        return _FakeTextFile(self.file_content)
 
     def test_f_strings_detection_success(self):
         pattern = r"f['\"][^'\"]*\{[^}]*\}[^'\"]*['\"]"
@@ -106,21 +141,28 @@ class TestFindPyCompat(unittest.TestCase):
         pattern = r"f['\"][^'\"]*\{[^}]*\}[^'\"]*['\"]"
         self.run_feature_test("f-strings", pattern, "print('Hello')", should_match=False)
 
+    SUBPROCESS_PATTERN = r"subprocess\.run|subprocess\.DEVNULL|\bfrom\s+subprocess\s+import\b.*\b(?:run|DEVNULL)\b"
+
     def test_subprocess_run_detection_success(self):
-        pattern = r"subprocess\.run"
-        self.run_feature_test("subprocess.run", pattern, "subprocess.run(['ls', '-l'])", should_match=True)
+        self.run_feature_test("subprocess.run", self.SUBPROCESS_PATTERN, "subprocess.run(['ls', '-l'])", should_match=True)
 
     def test_subprocess_run_detection_failure(self):
-        pattern = r"subprocess\.run"
-        self.run_feature_test("subprocess.run", pattern, "print('subprocess')", should_match=False)
+        self.run_feature_test("subprocess.run", self.SUBPROCESS_PATTERN, "print('subprocess')", should_match=False)
 
     def test_subprocess_devnull_detection_success(self):
-        pattern = r"subprocess\.DEVNULL"
-        self.run_feature_test("subprocess.DEVNULL", pattern, "subprocess.Popen(['ls'], stdout=subprocess.DEVNULL)", should_match=True)
+        self.run_feature_test("subprocess.DEVNULL", self.SUBPROCESS_PATTERN, "subprocess.Popen(['ls'], stdout=subprocess.DEVNULL)", should_match=True)
 
     def test_subprocess_devnull_detection_failure(self):
-        pattern = r"subprocess\.DEVNULL"
-        self.run_feature_test("subprocess.DEVNULL", pattern, "print('DEVNULL')", should_match=False)
+        self.run_feature_test("subprocess.DEVNULL", self.SUBPROCESS_PATTERN, "print('DEVNULL')", should_match=False)
+
+    def test_subprocess_from_import_run_detection_success(self):
+        self.run_feature_test("subprocess.run", self.SUBPROCESS_PATTERN, "from subprocess import run", should_match=True)
+
+    def test_subprocess_from_import_devnull_detection_success(self):
+        self.run_feature_test("subprocess.DEVNULL", self.SUBPROCESS_PATTERN, "from subprocess import DEVNULL", should_match=True)
+
+    def test_subprocess_from_import_unrelated_symbol_detection_failure(self):
+        self.run_feature_test("subprocess.run", self.SUBPROCESS_PATTERN, "from subprocess import PIPE, Popen", should_match=False)
 
     def test_async_await_keywords_detection_success(self):
         pattern = r"\basync\b|\bawait\b"
@@ -158,13 +200,19 @@ class TestFindPyCompat(unittest.TestCase):
         pattern = r"\b[a-zA-Z_][a-zA-Z0-9_]*\s+@\s+[a-zA-Z_][a-zA-Z0-9_]*\b"
         self.run_feature_test("matrix multiplication operator", pattern, "a * b", should_match=False)
 
+    ASYNCIO_PATTERN = r"\basyncio\.|\bimport\s+asyncio\b|\bfrom\s+asyncio\s+import\b"
+
     def test_asyncio_usage_detection_success(self):
-        pattern = r"\basyncio\."
-        self.run_feature_test("asyncio usage", pattern, "import asyncio\nasyncio.run(main())", should_match=True)
+        self.run_feature_test("asyncio usage", self.ASYNCIO_PATTERN, "import asyncio\nasyncio.run(main())", should_match=True)
 
     def test_asyncio_usage_detection_failure(self):
-        pattern = r"\basyncio\."
-        self.run_feature_test("asyncio usage", pattern, "import sys", should_match=False)
+        self.run_feature_test("asyncio usage", self.ASYNCIO_PATTERN, "import sys", should_match=False)
+
+    def test_asyncio_import_detection_success(self):
+        self.run_feature_test("asyncio usage", self.ASYNCIO_PATTERN, "import asyncio", should_match=True)
+
+    def test_asyncio_from_import_detection_success(self):
+        self.run_feature_test("asyncio usage", self.ASYNCIO_PATTERN, "from asyncio import sleep", should_match=True)
 
     def test_yield_from_usage_detection_success(self):
         pattern = r"\byield from\b"
@@ -174,36 +222,59 @@ class TestFindPyCompat(unittest.TestCase):
         pattern = r"\byield from\b"
         self.run_feature_test("yield from usage", pattern, "def foo(): yield bar()", should_match=False)
 
+    PATHLIB_PATTERN = r"\bpathlib\.|\bimport\s+pathlib\b|\bfrom\s+pathlib\s+import\b"
+
     def test_pathlib_usage_detection_success(self):
-        pattern = r"\bpathlib\."
-        self.run_feature_test("pathlib usage", pattern, "from pathlib import Path\nPath('/usr/local')", should_match=True)
+        self.run_feature_test("pathlib usage", self.PATHLIB_PATTERN, "pathlib.Path('/usr/local')", should_match=True)
 
     def test_pathlib_usage_detection_failure(self):
-        pattern = r"\bpathlib\."
-        self.run_feature_test("pathlib usage", pattern, "import os", should_match=False)
+        self.run_feature_test("pathlib usage", self.PATHLIB_PATTERN, "import os", should_match=False)
+
+    def test_pathlib_import_detection_success(self):
+        self.run_feature_test("pathlib usage", self.PATHLIB_PATTERN, "import pathlib", should_match=True)
+
+    def test_pathlib_from_import_detection_success(self):
+        self.run_feature_test("pathlib usage", self.PATHLIB_PATTERN, "from pathlib import Path", should_match=True)
+
+    SHUTIL_WHICH_PATTERN = r"\bshutil\.which\b|\bfrom\s+shutil\s+import\b.*\bwhich\b"
 
     def test_shutil_which_detection_success(self):
-        pattern = r"\bshutil\.which\b"
-        self.run_feature_test("shutil.which usage", pattern, "if not shutil.which('gcc'):", should_match=True)
+        self.run_feature_test("shutil.which usage", self.SHUTIL_WHICH_PATTERN, "if not shutil.which('gcc'):", should_match=True)
 
     def test_shutil_which_detection_failure(self):
-        pattern = r"\bshutil\.which\b"
-        self.run_feature_test("shutil.which usage", pattern, "if not cmd_exists('gcc'):", should_match=False)
+        self.run_feature_test("shutil.which usage", self.SHUTIL_WHICH_PATTERN, "if not cmd_exists('gcc'):", should_match=False)
+
+    def test_shutil_from_import_which_detection_success(self):
+        self.run_feature_test("shutil.which usage", self.SHUTIL_WHICH_PATTERN, "from shutil import which", should_match=True)
+
+    def test_comment_line_excluded_from_detection(self):
+        self.run_feature_test("asyncio usage", self.ASYNCIO_PATTERN, "# import asyncio", should_match=False)
+
+    def test_email_containing_line_excluded_from_detection(self):
+        self.run_feature_test(
+            "async/await keywords",
+            r"\basync\b|\bawait\b",
+            "send report to admin@example.com and await response",
+            should_match=False,
+        )
+
+    def test_detected_issues_do_not_leak_between_tests(self):
+        self.run_feature_test("pathlib usage", self.PATHLIB_PATTERN, "import pathlib", should_match=True)
+        self.assertEqual(find_pycompat.detected_issues, ['dummy.py'])
+
+        find_pycompat.detected_issues[:] = []
+        self.run_feature_test("pathlib usage", self.PATHLIB_PATTERN, "import os", should_match=False)
+        self.assertEqual(find_pycompat.detected_issues, [])
 
     def run_feature_test(self, feature_name, pattern, test_string, should_match):
         self.file_content = test_string
         self.mock_open.side_effect = self.mock_file_read
         find_pycompat.search_feature('.', feature_name, pattern)
 
-        file_open_call = call(os.path.join('.', 'dummy.py'), 'r', encoding='utf-8')
         if should_match:
-            self.mock_open.assert_has_calls([file_open_call])
+            self.assertIn('dummy.py', find_pycompat.detected_issues)
         else:
-            if file_open_call in self.mock_open.mock_calls:
-                compiled_pattern = re.compile(pattern)
-                self.assertFalse(compiled_pattern.search(self.file_content))
-            else:
-                self.mock_open.assert_not_called()
+            self.assertNotIn('dummy.py', find_pycompat.detected_issues)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Current problem
- The nightly job (`cron/bin/run_tests`) never reflected child check failures (interpreter tests, shell script validation, header documentation validation, Python compatibility validation) in its process exit status; `main()` always returned `0`.
- The success determination after the compatibility check relied on `grep -q "Some tests failed" "$JOBLOG"`, so failure text left in the append-only log by a previous run leaked into the current run's result.
- `find_pycompat.py`'s tests mostly asserted that the target file was opened, not that a compatibility issue was actually detected. Also, `pathlib`, `asyncio`, `subprocess.run`, `subprocess.DEVNULL`, and `shutil.which` were only detected in their module-qualified form, so importing the same restricted feature directly could bypass detection.

## Behavior after this change
- `cron/bin/run_tests` now tracks each child check's result in an in-process aggregate status flag (`OVERALL_STATUS`) and returns it as the process exit status. Continue-on-failure (a failing check does not skip later independent checks) is preserved.
- The current run's failure determination no longer greps historical JOBLOG content; historical log text no longer affects the current run's exit status. The existing JOBLOG append behavior, finalization, and optional admin mail path are preserved.
- `find_pycompat.py`'s `pathlib`, `asyncio`, `subprocess.run`, `subprocess.DEVNULL`, and `shutil.which` detectors were extended to also match `import pathlib`, `from pathlib import ...`, `import asyncio`, `from asyncio import ...`, `from subprocess import run`, `from subprocess import DEVNULL`, and `from shutil import which`. Existing module-qualified detection, comment-line/email-address-line exclusion, and the existing spaces-only matrix multiplication operator behavior are unchanged.
- `test/find_pycompat_test.py`'s positive/negative tests now assert the actual detection result (`find_pycompat.detected_issues`) instead of only whether the file was opened, and new tests cover the import forms above.

## Compatibility
- The only intentional behavior changes are false-success/false-pass corrections: (1) `cron/bin/run_tests` now exits `1` instead of `0` when the current run has a failure, and (2) the previously missed import-form usages of policy-restricted Python constructs are now detected.
- No changes to CLI options, configuration file format, path layout (including `/opt/python/<version>/bin/python` and `/opt/ruby/<version>/bin/rspec`), the mail interface, supported language versions, or dependencies.

## Validation
- `python3 test/find_pycompat_test.py` (35 tests): PASS
- `sh -n cron/bin/run_tests`: PASS
- `SCRIPTS=<repo root> sh test/check_scripts.sh` (140 scripts): PASS
- `python3 check_header_doc.py -a --root <repo root>`: PASS (no violations)
- `python3 find_pycompat.py <repo root>`: PASS (only the expected `dummy.py` fixture detected)
- Top-level `run_tests.sh` on the available Python 3.11.15 (576 test cases; Ruby test skipped, RSpec not installed): PASS
- `git diff --check`: PASS

## Version history
- Added one coherent bullet to the unreleased `v2.0.2 (Release Date: TBD)` entry in `doc/VERSIONS` for this nightly quality gate correction. The release date and existing bullets are unchanged.

## Merge
- This pull request has not been merged.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194UKJJuDwgGqCLegZbexcS