### PR TITLE
Fix tcmount combination test environment isolation

### DIFF
--- a/test/tcmount_test.py
+++ b/test/tcmount_test.py
@@ -555,9 +555,14 @@ class TestTcMount(unittest.TestCase):
             tcmount.process_mounting(options, ['sdb'])
         self.assertEqual(cm.exception.code, 13)
 
+    @patch('tcmount.os.path.isfile', return_value=True)
+    @patch('tcmount.is_block_device', return_value=True)
+    @patch('tcmount.is_veracrypt_installed', return_value=True)
+    @patch('tcmount.is_truecrypt_installed', return_value=True)
     @patch('tcmount.os_exec')
-    def test_process_mounting_combinations(self, mock_os_exec):
-        self.check_both_installed()
+    def test_process_mounting_combinations(
+            self, mock_os_exec, mock_truecrypt, mock_veracrypt,
+            mock_is_block_device, mock_isfile):
         mock_os_exec.return_value = 0
 
         test_cases = [


### PR DESCRIPTION
## Summary
- Isolated `test_process_mounting_combinations()` from the host's TrueCrypt/VeraCrypt installation state and from the presence of `/dev/sdb` and the external container file.
- Production code and the expected argv assertions are unchanged.

## Cause
- After the argv-based mount execution change, the production path gained block-device and external-container-file prerequisite checks, but the combination test only mocked `os_exec()`.
- On environments without both TrueCrypt and VeraCrypt installed, `self.check_both_installed()` skipped the target test entirely, hiding the missing mocks.

## Scope
- Only `test/tcmount_test.py` changed.
- Production code, dependencies, version, and documentation are unchanged.

## Validation
- `python test/tcmount_test.py`: 56 tests, OK (3 skipped; target method not skipped, 0 FAIL, 0 ERROR)
- `./run_tests.sh`: all Python tests passed (40 scripts, 576 cases, 27 skipped); RSpec skipped (not installed)
- `git diff --check`: clean
- Final changed files: `test/tcmount_test.py` only