### PR TITLE
Separate pyck Flake8 ignore policy

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -11,6 +11,8 @@ v2.0.2 (Release Date: TBD)
   wp_cachectl.py with Python-native PATH lookup.
 - Fix the nightly quality gate so its exit status reflects the current
   run's actual check results.
+- Separate pyck.py formatter and linter ignore policies, excluding W503 and
+  W504 from Flake8 while retaining the existing checks for other rules.
 
 v2.0.1 (2026-08-26)
 -------------------

--- a/pyck.py
+++ b/pyck.py
@@ -65,7 +65,17 @@
 #  - Python Version: 3.2 or later
 #  - Dependencies: autopep8, flake8, autoflake, isort
 #
+#  pyck uses separate ignore policies for autopep8 and Flake8. autopep8
+#  ignores E302, E402, and E501. Flake8 ignores E302, E402, E501, W503, and
+#  W504. W503 and W504 are mutually exclusive operator line-break
+#  conventions, so pyck excludes both from Flake8 rather than enforcing
+#  either one. Other Flake8 rules are not added to the explicit ignore
+#  list and remain enforced.
+#
 #  Version History:
+#  v3.1 2026-09-05
+#       Separate autopep8 and Flake8 ignore policies, keeping E302/E402/E501
+#       for autopep8 and additionally ignoring W503/W504 in Flake8.
 #  v3.0 2026-08-23
 #       Distinguish auto-fixable changes from lint findings, report
 #       unresolved lint issues after auto-fix, and use isolated formatter
@@ -113,6 +123,9 @@ import shlex
 import subprocess
 import sys
 import tempfile
+
+AUTOPEP8_IGNORE_ERRORS = "E302,E402,E501"
+FLAKE8_IGNORE_ERRORS = "E302,E402,E501,W503,W504"
 
 
 def usage():
@@ -205,40 +218,40 @@ def resolve_target_files(paths):
                 actual_path), file=sys.stderr)
     return target_files
 
-def dry_run_formatting(paths, ignore_errors, config_path):
+def dry_run_formatting(paths, autopep8_ignore_errors, config_path):
     """ Perform a dry run to show which files auto-fix would change, without making actual changes. """
     print("[INFO] DRY RUN: No files will be modified. Use -i to auto-fix.")
     for file_path in resolve_target_files(paths):
         run_command(
             "flake8 --isolated --ignore={} {}".format(
-                ignore_errors, shlex.quote(file_path)),
+                FLAKE8_IGNORE_ERRORS, shlex.quote(file_path)),
             show_files="Lint issue (manual review candidate):")
         run_command("autoflake --config={} --imports=django,requests,urllib3 --check {}".format(
                     shlex.quote(config_path), shlex.quote(file_path)),
                     show_files="Would clean: {}".format(file_path), literal_message=True)
         run_command("autopep8 --global-config={} --ignore-local-config --ignore={} --diff --exit-code {}".format(
-                    shlex.quote(config_path), ignore_errors, shlex.quote(file_path)),
+                    shlex.quote(config_path), autopep8_ignore_errors, shlex.quote(file_path)),
                     show_files="Would format: {}".format(file_path), literal_message=True)
         run_command("isort --settings-path={} --check-only {}".format(
                     shlex.quote(config_path), shlex.quote(file_path)),
                     show_files="Would sort imports in: {}".format(file_path), literal_message=True)
 
-def execute_formatting(paths, ignore_errors, config_path):
+def execute_formatting(paths, autopep8_ignore_errors, config_path):
     """ Execute auto-formatting and report lint issues that remain afterward. """
     for file_path in resolve_target_files(paths):
-        format_file(file_path, ignore_errors, config_path)
+        format_file(file_path, autopep8_ignore_errors, config_path)
         run_command(
             "flake8 --isolated --ignore={} {}".format(
-                ignore_errors, shlex.quote(file_path)),
+                FLAKE8_IGNORE_ERRORS, shlex.quote(file_path)),
             show_files="Manual fix required:")
 
-def format_file(file_path, ignore_errors, config_path):
+def format_file(file_path, autopep8_ignore_errors, config_path):
     """ Format a single Python file by cleaning up imports, and applying 'autopep8' and 'isort'. """
     command = "autoflake --config={} --imports=django,requests,urllib3 -i {}".format(
         shlex.quote(config_path), shlex.quote(file_path))
     subprocess.Popen(command, shell=True).wait()
     command = "autopep8 --global-config={} --ignore-local-config --ignore={} -v -i {}".format(
-        shlex.quote(config_path), ignore_errors, shlex.quote(file_path))
+        shlex.quote(config_path), autopep8_ignore_errors, shlex.quote(file_path))
     subprocess.Popen(command, shell=True).wait()
     format_imports(file_path, config_path)
 
@@ -265,7 +278,6 @@ def main():
     for path in args.paths:
         expanded_paths.extend(glob.glob(path) or [path])
 
-    ignore_errors = "E302,E402,E501"
     check_command("autopep8")
     check_command("flake8")
     check_command("autoflake")
@@ -274,9 +286,9 @@ def main():
     with tempfile.TemporaryDirectory() as temp_dir:
         config_path = create_isolated_config(temp_dir)
         if args.auto_fix:
-            execute_formatting(expanded_paths, ignore_errors, config_path)
+            execute_formatting(expanded_paths, AUTOPEP8_IGNORE_ERRORS, config_path)
         else:
-            dry_run_formatting(expanded_paths, ignore_errors, config_path)
+            dry_run_formatting(expanded_paths, AUTOPEP8_IGNORE_ERRORS, config_path)
 
     return 0
 

--- a/test/pyck_test.py
+++ b/test/pyck_test.py
@@ -65,8 +65,13 @@
 #    - Verify create_isolated_config() writes the formatter/linter configuration used by pyck.
 #    - Verify format_imports() passes the isolated configuration to isort.
 #    - Verify main() creates one isolated temporary configuration and passes it to dry-run and auto-fix processing.
+#    - Verify that pyck keeps autopep8 on E302/E402/E501 while Flake8 additionally ignores
+#      W503/W504, without restoring the rest of Flake8's default ignore set.
 #
 #  Version History:
+#  v1.5 2026-09-05
+#       Cover separate autopep8 and Flake8 ignore policies, verifying that
+#       W503/W504 are ignored only by Flake8 while autopep8 remains unchanged.
 #  v1.4 2026-08-22
 #       Cover auto-fix change detection, lint candidate reporting, and
 #       unresolved lint diagnostics after auto-fix.
@@ -284,7 +289,7 @@ class TestPyck(unittest.TestCase):
 
         # Verify subprocess.Popen calls for the single file
         mock_popen.assert_any_call(
-            "flake8 --isolated --ignore=E302,E402,E501 path/to/single_file.py", shell=True, stdout=-1)
+            "flake8 --isolated --ignore=E302,E402,E501,W503,W504 path/to/single_file.py", shell=True, stdout=-1)
         mock_popen.assert_any_call(
             "autoflake --config=/tmp/pyck.cfg --imports=django,requests,urllib3 --check path/to/single_file.py", shell=True, stdout=-1)
         mock_popen.assert_any_call(
@@ -308,7 +313,7 @@ class TestPyck(unittest.TestCase):
             ['path/to/file1.py', 'path/to/file2.py'], 'E302,E402,E501', CONFIG_PATH)
 
         expected_calls = [
-            call("flake8 --isolated --ignore=E302,E402,E501 path/to/file1.py",
+            call("flake8 --isolated --ignore=E302,E402,E501,W503,W504 path/to/file1.py",
                  shell=True, stdout=-1),
             call("autoflake --config=/tmp/pyck.cfg --imports=django,requests,urllib3 --check path/to/file1.py",
                  shell=True, stdout=-1),
@@ -316,7 +321,7 @@ class TestPyck(unittest.TestCase):
                  shell=True, stdout=-1),
             call("isort --settings-path=/tmp/pyck.cfg --check-only path/to/file1.py",
                  shell=True, stdout=-1),
-            call("flake8 --isolated --ignore=E302,E402,E501 path/to/file2.py",
+            call("flake8 --isolated --ignore=E302,E402,E501,W503,W504 path/to/file2.py",
                  shell=True, stdout=-1),
             call("autoflake --config=/tmp/pyck.cfg --imports=django,requests,urllib3 --check path/to/file2.py",
                  shell=True, stdout=-1),
@@ -344,7 +349,7 @@ class TestPyck(unittest.TestCase):
             ['path/to/my file.py'], 'E302,E402,E501', CONFIG_PATH_WITH_SPACES)
 
         mock_popen.assert_any_call(
-            "flake8 --isolated --ignore=E302,E402,E501 'path/to/my file.py'", shell=True, stdout=-1)
+            "flake8 --isolated --ignore=E302,E402,E501,W503,W504 'path/to/my file.py'", shell=True, stdout=-1)
         mock_popen.assert_any_call(
             "autoflake --config='/tmp/pyck config/pyck.cfg' --imports=django,requests,urllib3 --check 'path/to/my file.py'", shell=True, stdout=-1)
         mock_popen.assert_any_call(
@@ -374,7 +379,7 @@ class TestPyck(unittest.TestCase):
         for name in ('file1.py', 'file2.py'):
             target = os.path.join('path/to/directory', name)
             expected_calls.extend([
-                call("flake8 --isolated --ignore=E302,E402,E501 {}".format(target),
+                call("flake8 --isolated --ignore=E302,E402,E501,W503,W504 {}".format(target),
                      shell=True, stdout=-1),
                 call("autoflake --config=/tmp/pyck.cfg --imports=django,requests,urllib3 --check {}".format(target),
                      shell=True, stdout=-1),
@@ -410,7 +415,7 @@ class TestPyck(unittest.TestCase):
                            ('path/to/dir2', 'file3.py'), ('path/to/dir2', 'file4.py')):
             target = os.path.join(root, name)
             expected_calls.extend([
-                call("flake8 --isolated --ignore=E302,E402,E501 {}".format(target),
+                call("flake8 --isolated --ignore=E302,E402,E501,W503,W504 {}".format(target),
                      shell=True, stdout=-1),
                 call("autoflake --config=/tmp/pyck.cfg --imports=django,requests,urllib3 --check {}".format(target),
                      shell=True, stdout=-1),
@@ -647,7 +652,7 @@ class TestPyck(unittest.TestCase):
             'path/to/single_file.py', 'E302,E402,E501', CONFIG_PATH)
 
         mock_run_command.assert_called_once_with(
-            "flake8 --isolated --ignore=E302,E402,E501 path/to/single_file.py",
+            "flake8 --isolated --ignore=E302,E402,E501,W503,W504 path/to/single_file.py",
             show_files="Manual fix required:")
 
     @patch('pyck.run_command')
@@ -679,13 +684,13 @@ class TestPyck(unittest.TestCase):
         mock_format_file.assert_any_call('path/to/file.py', 'E302,E402,E501', CONFIG_PATH)
 
         mock_run_command.assert_any_call(
-            "flake8 --isolated --ignore=E302,E402,E501 path/to/directory/file1.py",
+            "flake8 --isolated --ignore=E302,E402,E501,W503,W504 path/to/directory/file1.py",
             show_files="Manual fix required:")
         mock_run_command.assert_any_call(
-            "flake8 --isolated --ignore=E302,E402,E501 path/to/directory/file2.py",
+            "flake8 --isolated --ignore=E302,E402,E501,W503,W504 path/to/directory/file2.py",
             show_files="Manual fix required:")
         mock_run_command.assert_any_call(
-            "flake8 --isolated --ignore=E302,E402,E501 path/to/file.py",
+            "flake8 --isolated --ignore=E302,E402,E501,W503,W504 path/to/file.py",
             show_files="Manual fix required:")
 
         # Test behavior when path is neither a file nor a directory
@@ -719,10 +724,10 @@ class TestPyck(unittest.TestCase):
         mock_format_file.assert_any_call(expected_file2_path, 'E302,E402,E501', CONFIG_PATH)
 
         mock_run_command.assert_any_call(
-            "flake8 --isolated --ignore=E302,E402,E501 path/to/directory/file1.py",
+            "flake8 --isolated --ignore=E302,E402,E501,W503,W504 path/to/directory/file1.py",
             show_files="Manual fix required:")
         mock_run_command.assert_any_call(
-            "flake8 --isolated --ignore=E302,E402,E501 path/to/directory/file2.py",
+            "flake8 --isolated --ignore=E302,E402,E501,W503,W504 path/to/directory/file2.py",
             show_files="Manual fix required:")
 
     @patch('pyck.run_command')
@@ -758,16 +763,16 @@ class TestPyck(unittest.TestCase):
             mock_format_file.assert_any_call(file_path, 'E302,E402,E501', CONFIG_PATH)
 
         mock_run_command.assert_any_call(
-            "flake8 --isolated --ignore=E302,E402,E501 path/to/dir1/file1.py",
+            "flake8 --isolated --ignore=E302,E402,E501,W503,W504 path/to/dir1/file1.py",
             show_files="Manual fix required:")
         mock_run_command.assert_any_call(
-            "flake8 --isolated --ignore=E302,E402,E501 path/to/dir1/file2.py",
+            "flake8 --isolated --ignore=E302,E402,E501,W503,W504 path/to/dir1/file2.py",
             show_files="Manual fix required:")
         mock_run_command.assert_any_call(
-            "flake8 --isolated --ignore=E302,E402,E501 path/to/dir2/file3.py",
+            "flake8 --isolated --ignore=E302,E402,E501,W503,W504 path/to/dir2/file3.py",
             show_files="Manual fix required:")
         mock_run_command.assert_any_call(
-            "flake8 --isolated --ignore=E302,E402,E501 path/to/dir2/file4.py",
+            "flake8 --isolated --ignore=E302,E402,E501,W503,W504 path/to/dir2/file4.py",
             show_files="Manual fix required:")
 
     @patch('pyck.run_command')
@@ -789,7 +794,7 @@ class TestPyck(unittest.TestCase):
             call.format_file(
                 'path/to/file.py', 'E302,E402,E501', CONFIG_PATH),
             call.run_command(
-                'flake8 --isolated --ignore=E302,E402,E501 path/to/file.py',
+                'flake8 --isolated --ignore=E302,E402,E501,W503,W504 path/to/file.py',
                 show_files='Manual fix required:'),
         ])
 
@@ -826,7 +831,7 @@ class TestPyck(unittest.TestCase):
             ['path/to/my file.py'], 'E302,E402,E501', CONFIG_PATH_WITH_SPACES)
 
         mock_run_command.assert_called_once_with(
-            "flake8 --isolated --ignore=E302,E402,E501 "
+            "flake8 --isolated --ignore=E302,E402,E501,W503,W504 "
             "'path/to/my file.py'",
             show_files='Manual fix required:')
 


### PR DESCRIPTION
## Summary
- Separate autopep8 and Flake8 ignore policies in pyck.py.
- Keep autopep8 on E302/E402/E501 and additionally ignore W503/W504 only in Flake8.
- Preserve the existing enforcement of other Flake8 rules and update pyck tests and the unreleased v2.0.2 history.

## Validation
- pyck unit tests: PASS
- repository standard test suite: PASS
- repository-wide pyck dry-run: PASS; no W503/W504 lint diagnostics
- focused Flake8 policy check: PASS; E704 remains reported while W503/W504 are ignored
- diff / scope checks: PASS

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01NRfKQVhTtFfNfZeQJuxqop

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRfKQVhTtFfNfZeQJuxqop)_