### PR TITLE
Add pyck to nightly repository checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,11 @@ It exits with a non-zero status when any test fails.
 A second layer runs nightly from `cron/bin/run_tests`, which drives
 `run_tests.sh` once per configured Python and Ruby version and then applies the
 repository-wide checks: the shell script validation (`test/check_scripts.sh`),
-the header documentation check (`check_header_doc.py -a`), and the
-compatibility check (`find_pycompat.py`). Checks that belong to the repository
-as a whole, rather than to one interpreter version, are wired there instead of
-into `run_tests.sh`.
+the header documentation check (`check_header_doc.py -a`), a Python
+code-quality dry run (`pyck.py`) against the top-level `*.py` files and
+`test/*.py`, and the compatibility check (`find_pycompat.py`). Checks that
+belong to the repository as a whole, rather than to one interpreter version,
+are wired there instead of into `run_tests.sh`.
 
 ---
 

--- a/cron/bin/run_tests
+++ b/cron/bin/run_tests
@@ -7,10 +7,12 @@
 #  This script automates the process of running tests for projects developed
 #  in Python and Ruby. It loads configuration settings from an external
 #  configuration file, iterates through specified versions of Python and Ruby
-#  to run tests, runs repository-wide script and header validation checks,
-#  and performs a compatibility check using the first Python
-#  version in the loop. It is intended to be executed automatically via cron
-#  jobs and sends a summary email to an administrator upon completion.
+#  to run tests, runs a repository-wide shell script validation check, a
+#  repository-wide header documentation check, a pyck.py dry-run Python
+#  code-quality check, and a find_pycompat.py compatibility check, with the
+#  pyck.py and compatibility checks using the first Python version in the
+#  loop. It is intended to be executed automatically via cron jobs and sends
+#  a summary email to an administrator upon completion.
 #
 #  Author: id774 (More info: http://id774.net)
 #  Source Code: https://github.com/id774/scripts
@@ -41,7 +43,10 @@
 #  - The script is designed to be run in environments where Python and Ruby
 #    are used for development and testing.
 #  - In addition to language-specific tests, the script runs repository-wide
-#    checks for shell scripts, header documentation, and Python compatibility.
+#    checks for shell scripts, header documentation, Python code quality, and
+#    Python compatibility.
+#  - The pyck.py dry-run requires autopep8, flake8, autoflake, and isort to be
+#    installed in the first configured Python environment's bin directory.
 #  - Ensure the specified Python and Ruby versions are installed and accessible.
 #  - This script is typically deployed to /etc/cron.exec/run_tests and run by cron.
 #
@@ -52,6 +57,9 @@
 #  4. Configuration variables not set.
 #
 #  Version History:
+#  v3.0 2026-09-06
+#       Add pyck.py dry-run to nightly repository checks and use the first
+#       configured Python environment for its formatter and linter commands.
 #  v2.8 2026-09-05
 #       Return the current run's actual failure status instead of always 0,
 #       and stop deriving failure state from historical JOBLOG content.
@@ -218,6 +226,37 @@ run_check_header_doc() {
     fi
 }
 
+# Run Python code quality inspection
+run_pyck() {
+    if [ -z "$first_python_version" ]; then
+        return 0
+    fi
+
+    if [ ! -f "$SCRIPTS/pyck.py" ]; then
+        record_failure
+        mark_failure
+        return 1
+    fi
+
+    echo >> "$JOBLOG" 2>&1
+    echo "=== Running pyck.py for Python code quality inspection. ===" >> "$JOBLOG" 2>&1
+
+    PATH="/opt/python/$first_python_version/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+        "/opt/python/$first_python_version/bin/python" \
+        "$SCRIPTS/pyck.py" \
+        "$SCRIPTS"/*.py \
+        "$SCRIPTS"/test/*.py >> "$JOBLOG" 2>&1
+    result=$?
+
+    if [ "$result" -ge 1 ]; then
+        echo "[WARN] Python code quality inspection failed. Check logs for details." >> "$JOBLOG" 2>&1
+        mark_failure
+    else
+        echo "[INFO] Python code quality inspection completed successfully." >> "$JOBLOG" 2>&1
+    fi
+    echo >> "$JOBLOG" 2>&1
+}
+
 # Perform Python compatibility check
 run_compatibility_check() {
     # Require a Python interpreter path (reuse first_python_version from the test loop)
@@ -292,6 +331,7 @@ main() {
 
     run_check_scripts
     run_check_header_doc
+    run_pyck
     run_compatibility_check
 
     finalize

--- a/doc/POLICY
+++ b/doc/POLICY
@@ -882,8 +882,10 @@ document changed.
 - The nightly `cron/bin/run_tests` job is the second layer. It drives
   `run_tests.sh` once per configured Python and Ruby version, then runs
   `test/check_scripts.sh` (which exercises every shell script through `-h`),
-  `check_header_doc.py -a`, and the `find_pycompat.py` compatibility check
-  across the repository, and mails the result to the administrator.
+  `check_header_doc.py -a`, a `pyck.py` dry-run against the top-level Python
+  files and the Python files directly under `test/`, using the first
+  configured Python environment, and the `find_pycompat.py` compatibility
+  check across the repository, and mails the result to the administrator.
 - A check that belongs to the repository as a whole, rather than to one
   interpreter version, is wired into the cron job rather than into
   `run_tests.sh`, so that it runs once per night instead of once per

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -13,6 +13,7 @@ v2.0.2 (Release Date: TBD)
   run's actual check results.
 - Separate pyck.py formatter and linter ignore policies, excluding W503 and
   W504 from Flake8 while retaining the existing checks for other rules.
+- Run pyck.py in dry-run mode as a nightly repository-wide Python code-quality check using the configured Python environment.
 
 v2.0.1 (2026-08-26)
 -------------------


### PR DESCRIPTION
## Current problem

- The nightly workflow (`cron/bin/run_tests`) runs shell script, header documentation, and Python compatibility checks, but does not run the `pyck.py` dry-run Python code-quality check.
- `pyck.py` searches `PATH` for `autopep8`, `flake8`, `autoflake`, and `isort`, so specifying only the absolute path of the Python executable does not guarantee that the selected Python environment and its helper tools are consistent.

## Behavior after this change

- Added a single `pyck.py` dry-run to the nightly repository-wide checks, inserted between the header documentation check and the compatibility check.
- The dry-run targets only the top-level `*.py` files and `test/*.py`.
- The `bin` directory of the first configured Python environment (`first_python_version`) is placed at the front of `PATH` for the `pyck.py` process only.
- `PATH` is not exported and does not affect any other function or the parent shell.
- `run_compatibility_check` still runs afterward, and continue-on-failure / `OVERALL_STATUS` aggregation are preserved.
- No source files are modified (dry-run only, no `-i`/`--auto-fix`).

## Compatibility

- No CLI option changes.
- No configuration format changes.
- No cron schedule or execution user changes.
- No new dependency packages or version changes.
- No `pyck.py` or `find_pycompat.py` semantics changes.
- Relative order of existing repository-wide checks (`run_check_scripts` -> `run_check_header_doc` -> `run_compatibility_check`) is preserved; `run_pyck` is inserted between the second and third.

## Dependency

- Running `pyck.py` nightly requires `autopep8`, `flake8`, `autoflake`, and `isort` to be present in the first configured Python environment.
- These are already part of the existing `installer/install_pip.sh` package set; that package set is unchanged.

## Validation

- Shell syntax check (`sh -n cron/bin/run_tests`): PASS, exit 0.
- Repository shell script validation (`test/check_scripts.sh`): PASS, exit 0 (140/140 scripts succeeded, including `cron/bin/run_tests -h`).
- Header documentation validation (`check_header_doc.py -a`): PASS, exit 0, no violations.
- Python compatibility validation (`find_pycompat.py`): PASS, exit 0, only the existing `test/dummy.py` fixture findings reported (expected).
- pyck dry-run smoke validation: PASS. Using a Python environment with `autopep8`, `flake8`, `autoflake`, and `isort` installed in its `bin`, with that `bin` placed first on `PATH`, `pyck.py` resolved all four helper commands and completed with exit 0 against the top-level `*.py` files and `test/*.py`. Tracked source files were unchanged before and after the run (verified via `git hash-object` comparison).
- `git diff --check`: PASS, exit 0.

## Version history

- Bumped `cron/bin/run_tests` executable version to v3.0.
- Added one bullet to the unreleased `v2.0.2` entry in `doc/VERSIONS`.
- Existing release dates and bullets in `doc/VERSIONS` are unchanged.

## Merge

This pull request has not been merged.
