### PR TITLE
Reject unsupported installer arguments

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -17,6 +17,8 @@ v2.0.2 (Release Date: TBD)
   code-quality check using the configured Python environment.
 - Make pyck.py return non-zero for formatter or linter execution failures
   while keeping lint findings and dry-run change candidates advisory.
+- Make default-install installers show usage for unsupported arguments
+  instead of starting installation.
 
 v2.0.1 (2026-08-26)
 -------------------

--- a/installer/install_apache_log_analysis.sh
+++ b/installer/install_apache_log_analysis.sh
@@ -25,6 +25,8 @@
 #  - SSL Apache logs (ssl_*) must exist under /var/log/apache2.
 #
 #  Version History:
+#  v2.4 2026-09-06
+#       Show usage for unsupported arguments instead of starting installation.
 #  v2.3 2026-07-26
 #       Deploy and uninstall apache_blog_analysis.py alongside the existing
 #       apache_log_analysis.sh and apache_calculater.py scripts.
@@ -272,8 +274,11 @@ main() {
         -u|--uninstall)
             uninstall
             ;;
-        ""|*)
+        "")
             install "$@"
+            ;;
+        *)
+            usage
             ;;
     esac
 

--- a/installer/install_chkrootkit.sh
+++ b/installer/install_chkrootkit.sh
@@ -32,6 +32,8 @@
 #    environments.
 #
 #  Version History:
+#  v2.3 2026-09-06
+#       Show usage for unsupported arguments instead of starting installation.
 #  v2.2 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -221,8 +223,11 @@ main() {
         -u|--uninstall)
             uninstall
             ;;
-        ""|*)
+        "")
             install
+            ;;
+        *)
+            usage
             ;;
     esac
 

--- a/installer/install_clamscan.sh
+++ b/installer/install_clamscan.sh
@@ -28,6 +28,8 @@
 #  - This script is intended for Linux systems only.
 #
 #  Version History:
+#  v3.2 2026-09-06
+#       Show usage for unsupported arguments instead of starting installation.
 #  v3.1 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -244,8 +246,11 @@ main() {
         -u|--uninstall)
             uninstall
             ;;
-        ""|*)
+        "")
             install
+            ;;
+        *)
+            usage
             ;;
     esac
 

--- a/installer/install_fix-permissions.sh
+++ b/installer/install_fix-permissions.sh
@@ -38,6 +38,8 @@
 #    appropriate permissions.
 #
 #  Version History:
+#  v2.2 2026-09-06
+#       Show usage for unsupported arguments instead of starting installation.
 #  v2.1 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -239,8 +241,11 @@ main() {
         -u|--uninstall)
             uninstall
             ;;
-        ""|*)
+        "")
             install "$@"
+            ;;
+        *)
+            usage
             ;;
     esac
 

--- a/installer/install_get_resources.sh
+++ b/installer/install_get_resources.sh
@@ -23,6 +23,8 @@
 #    the get_resources script and its related files before running this script.
 #
 #  Version History:
+#  v3.2 2026-09-06
+#       Show usage for unsupported arguments instead of starting installation.
 #  v3.1 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -217,8 +219,11 @@ main() {
         -u|--uninstall)
             uninstall
             ;;
-        ""|*)
+        "")
             install "$@"
+            ;;
+        *)
+            usage
             ;;
     esac
 

--- a/installer/install_munin-symlink.sh
+++ b/installer/install_munin-symlink.sh
@@ -31,6 +31,8 @@
 #  - The configuration file is deployed with permission 640 (readable by adm group).
 #
 #  Version History:
+#  v2.3 2026-09-06
+#       Show usage for unsupported arguments instead of starting installation.
 #  v2.2 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -231,8 +233,11 @@ main() {
         -u|--uninstall)
             uninstall
             ;;
-        *)
+        "")
             install
+            ;;
+        *)
+            usage
             ;;
     esac
     return 0

--- a/installer/install_munin-sync.sh
+++ b/installer/install_munin-sync.sh
@@ -50,6 +50,8 @@
 #       /etc/cron.d/munin-sync
 #
 #  Version History:
+#  v2.3 2026-09-06
+#       Show usage for unsupported arguments instead of starting installation.
 #  v2.2 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -254,8 +256,11 @@ main() {
         -u|--uninstall)
             uninstall
             ;;
-        *)
+        "")
             install
+            ;;
+        *)
+            usage
             ;;
     esac
     return 0

--- a/installer/install_rsync_backup.sh
+++ b/installer/install_rsync_backup.sh
@@ -35,6 +35,8 @@
 #  - Use --uninstall to remove installed components while preserving log files.
 #
 #  Version History:
+#  v3.2 2026-09-06
+#       Show usage for unsupported arguments instead of starting installation.
 #  v3.1 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -231,8 +233,11 @@ main() {
         -u|--uninstall)
             uninstall
             ;;
-        ""|*)
+        "")
             install
+            ;;
+        *)
+            usage
             ;;
     esac
 

--- a/installer/install_run_tests.sh
+++ b/installer/install_run_tests.sh
@@ -28,6 +28,8 @@
 #    and /etc/cron.d/run_tests to finalize the configuration.
 #
 #  Version History:
+#  v2.5 2026-09-06
+#       Show usage for unsupported arguments instead of starting installation.
 #  v2.4 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -279,8 +281,11 @@ main() {
         -u|--uninstall)
             uninstall
             ;;
-        *)
+        "")
             install
+            ;;
+        *)
+            usage
             ;;
     esac
     return 0

--- a/installer/setup_dot_ipython.sh
+++ b/installer/setup_dot_ipython.sh
@@ -32,6 +32,8 @@
 #  - 'SCRIPTS' environment variable must be correctly set.
 #
 #  Version History:
+#  v2.2 2026-09-06
+#       Show usage for unsupported arguments instead of starting installation.
 #  v2.1 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -211,8 +213,11 @@ main() {
         -u|--uninstall)
             uninstall
             ;;
-        ""|*)
+        "")
             install "$@"
+            ;;
+        *)
+            usage
             ;;
     esac
 

--- a/installer/setup_nvim.sh
+++ b/installer/setup_nvim.sh
@@ -29,6 +29,8 @@
 #  - NeoVim must be installed and available in PATH.
 #
 #  Version History:
+#  v1.3 2026-09-06
+#       Show usage for unsupported arguments instead of starting installation.
 #  v1.2 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -175,11 +177,14 @@ main() {
         -h|--help|-v|--version)
             usage
             ;;
-        -u|--uninstall|--uninstall)
+        -u|--uninstall)
             uninstall
             ;;
-        ""|*)
+        "")
             install
+            ;;
+        *)
+            usage
             ;;
     esac
 

--- a/installer/setup_python_symlink.sh
+++ b/installer/setup_python_symlink.sh
@@ -28,6 +28,8 @@
 #  - The 'apt' command must be available on the system.
 #
 #  Version History:
+#  v1.2 2026-09-06
+#       Show usage for unsupported arguments instead of starting installation.
 #  v1.1 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -119,9 +121,12 @@ main() {
             check_environment apt-get dpkg uname grep
             uninstall_python_symlink
             ;;
-        *)
+        "")
             check_environment apt-get uname
             install_python_symlink
+            ;;
+        *)
+            usage
             ;;
     esac
     return 0


### PR DESCRIPTION
## Summary

Several default-install installer scripts publish only two invocation forms — a zero-argument install/setup mode and `-u`/`--uninstall` — but their `main()` dispatch routed any *unrecognized* first argument into the install branch (`""|*)` or a bare `*)` catching everything not already matched). An unsupported option such as a typo'd flag therefore started installation instead of being rejected, even though the script's own header `Usage:` documents no other positional argument.

This fixes the dispatch in the 12 affected scripts so an unsupported first argument shows `usage()` (existing output, exit status `0`) and never begins any install/uninstall/prerequisite work:

- `installer/install_run_tests.sh`
- `installer/install_clamscan.sh`
- `installer/install_chkrootkit.sh`
- `installer/install_munin-sync.sh`
- `installer/install_rsync_backup.sh`
- `installer/install_munin-symlink.sh`
- `installer/install_get_resources.sh`
- `installer/install_fix-permissions.sh`
- `installer/install_apache_log_analysis.sh`
- `installer/setup_nvim.sh` (also de-duplicates a repeated `--uninstall` pattern in the same `case` arm: `-u|--uninstall|--uninstall)` → `-u|--uninstall)`)
- `installer/setup_dot_ipython.sh`
- `installer/setup_python_symlink.sh`

**Excluded on purpose:** `installer/install_dotvim.sh` and `installer/setup_sysadmin_scripts.sh` are not touched, because each documents a real positional argument beyond install/uninstall (a custom installation path, and an optional install path alongside the install/uninstall action, respectively) — collapsing unknown arguments to `usage()` there would break a valid, documented interface.

Valid invocations are unchanged: no-argument install/setup and `-u`/`--uninstall` still call the same functions in the same order as before, with the same call form (`install` vs `install "$@"` preserved per script). No Shell Script test code, harness, or mock/stub infrastructure was added — this repository has no dedicated automated test suite for these installers, and the change is validated with the existing `test/check_scripts.sh` plus direct execution.

`doc/VERSIONS` gets one additional bullet under the existing unreleased `v2.0.2 (Release Date: TBD)` entry; `v2.0.2` remains unreleased.

## Test plan

- `sh -n` on all 12 changed scripts — no syntax errors.
- `SCRIPTS=<repo root> sh test/check_scripts.sh` — 140/140 scripts pass the existing `-h` health check.
- Each of the 12 scripts run with `--definitely-unsupported-option`:
  - exit status `0`
  - exactly one ` Usage:` line in the output (the header usage text)
  - no `[INFO]`/`[ERROR]` runtime log lines and no `sudo` invocation, confirming no prerequisite/install/uninstall side effect started
- No-argument and `-u`/`--uninstall` dispatch arms inspected: unchanged call targets and call form.
- `check_header_doc.py -a --root .` — no header violations.
- `find_pycompat.py .` — no new compatibility issues (only the existing `test/dummy.py` fixture reported, as expected).
- `git diff --check` — no whitespace errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vCzKyX9cBpr6PTzYsYfcZ)_