### PR TITLE
Document installer log retention

### DIFF
--- a/doc/POLICY
+++ b/doc/POLICY
@@ -466,6 +466,7 @@ never asked to touch.
 - Preserve an installer's established continuation, ordering, interaction,
   and side-effect behavior unless changing that behavior is explicitly part
   of the requested work.
+- An installer must preserve log files during uninstallation.
 
 ### 1.6 Documentation
 

--- a/installer/install_apache_log_analysis.sh
+++ b/installer/install_apache_log_analysis.sh
@@ -24,6 +24,9 @@
 #  - The `$SCRIPTS` environment variable must be set.
 #  - SSL Apache logs (ssl_*) must exist under /var/log/apache2.
 #
+#  Notes:
+#  - Log files are preserved when --uninstall is used.
+#
 #  Version History:
 #  v2.4 2026-09-06
 #       Show usage for unsupported arguments instead of starting installation.

--- a/installer/install_chkrootkit.sh
+++ b/installer/install_chkrootkit.sh
@@ -30,6 +30,7 @@
 #  - Creating log.expected trusts the current log.today as baseline. Review
 #    the first run output before accepting it as expected in security critical
 #    environments.
+#  - Log files are preserved when --uninstall is used.
 #
 #  Version History:
 #  v2.3 2026-09-06

--- a/installer/install_clamscan.sh
+++ b/installer/install_clamscan.sh
@@ -27,6 +27,9 @@
 #  - The user must have `sudo` installed.
 #  - This script is intended for Linux systems only.
 #
+#  Notes:
+#  - Log files are preserved when --uninstall is used.
+#
 #  Version History:
 #  v3.2 2026-09-06
 #       Show usage for unsupported arguments instead of starting installation.

--- a/installer/install_fix-permissions.sh
+++ b/installer/install_fix-permissions.sh
@@ -36,6 +36,7 @@
 #    it will not be overwritten.
 #  - The `fix-permissions` script is deployed to `/etc/cron.daily` with
 #    appropriate permissions.
+#  - Log files are preserved when --uninstall is used.
 #
 #  Version History:
 #  v2.2 2026-09-06

--- a/installer/install_get_resources.sh
+++ b/installer/install_get_resources.sh
@@ -21,6 +21,7 @@
 #  Notes:
 #  - Ensure the SCRIPTS environment variable is set to the directory containing
 #    the get_resources script and its related files before running this script.
+#  - Log files are preserved when --uninstall is used.
 #
 #  Version History:
 #  v3.2 2026-09-06

--- a/installer/install_run_tests.sh
+++ b/installer/install_run_tests.sh
@@ -26,6 +26,7 @@
 #    the run_tests script and its configuration file before running this script.
 #  - After deployment, review and potentially edit /etc/cron.config/run_tests.conf
 #    and /etc/cron.d/run_tests to finalize the configuration.
+#  - Log files are preserved when --uninstall is used.
 #
 #  Version History:
 #  v2.5 2026-09-06
@@ -35,7 +36,7 @@
 #       equivalent, since mawk on some systems matches it incorrectly.
 #  v2.3 2025-08-19
 #       Add --uninstall option to remove deployed script, config, cron job,
-#       logrotate entry, and the run_tests log file.
+#       and logrotate entry while preserving the run_tests log file.
 #  v2.2 2025-07-30
 #       Move script to /etc/cron.exec and config to /etc/cron.config.
 #  v2.1 2025-06-23


### PR DESCRIPTION
### Problem

- `install_run_tests.sh` v2.3 incorrectly stated that uninstall removes the run_tests log file.
- installer implementations preserve operational log files, but several user-facing headers did not state that behavior explicitly.
- this ambiguity led to an incorrect proposal to add the run_tests log to uninstall removal targets.

### Change

- correct the historical `install_run_tests.sh` v2.3 wording.
- document log preservation in the relevant installer headers that lacked an explicit note (`install_run_tests.sh`, `install_fix-permissions.sh`, `install_apache_log_analysis.sh`, `install_get_resources.sh`, `install_clamscan.sh`, `install_chkrootkit.sh`).
- leave `install_rsync_backup.sh` unchanged because its header already documents log preservation.
- add the single repository-wide installer rule to `doc/POLICY` (`#### 1.5.4 Installer Execution Model`): "An installer must preserve log files during uninstallation."

### Runtime

- no implementation or runtime behavior changes.
- no uninstall target changes.
- no executable version bumps.
- no `doc/VERSIONS` change.

### Validation

- Read-only review of all 7 installers' `uninstall()` bodies confirms each preserves its log file(s)/directory: `install_run_tests.sh` (`/var/log/sysadmin/run_tests.log`), `install_rsync_backup.sh` (`/var/log/sysadmin/rsync_backup.log`), `install_fix-permissions.sh` (`/var/log/sysadmin/fix-permissions.log`), `install_apache_log_analysis.sh` (`/var/log/sysadmin/apache_summary.log`), `install_get_resources.sh` (`/var/log/sysadmin/resources.log`), `install_clamscan.sh` (`/var/log/clamav`), `install_chkrootkit.sh` (`/var/log/chkrootkit`) — none appear in any removal list or `rm` target.
- The exact sentence "Log files are preserved when --uninstall is used." appears exactly once in each of the 6 changed installer headers' Notes section; `install_rsync_backup.sh` keeps its existing equivalent sentence unchanged.
- `install_run_tests.sh` v2.3 now reads "...and logrotate entry while preserving the run_tests log file." — the prior "...and the run_tests log file" removal wording is gone.
- `doc/POLICY` `#### 1.5.4 Installer Execution Model` contains the new bullet exactly once; no other policy wording changed.
- `python3 check_header_doc.py -a --root .` — exit status 0, no header documentation errors.
- `SCRIPTS=<repo root> sh test/check_scripts.sh` — 140/140 scripts pass the existing `-h` help validation (new header Notes lines emit correctly through the existing usage mechanism).
- `git diff --check` — no whitespace errors.
- Final diff covers exactly 7 files (`doc/POLICY` + the 6 installer headers); no implementation line changed; no executable version bump; no `doc/VERSIONS`, README, `FEATURES.md`, or test diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vCzKyX9cBpr6PTzYsYfcZ)_