### PR TITLE
Fix setup_scripts permission failure handling

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -19,6 +19,8 @@ v2.0.2 (Release Date: TBD)
   while keeping lint findings and dry-run change candidates advisory.
 - Make default-install installers show usage for unsupported arguments
   instead of starting installation.
+- Make setup_scripts.sh limit execute-permission changes to SCRIPTS and
+  preserve failures from the target permission pass.
 
 v2.0.1 (2026-08-26)
 -------------------

--- a/setup_scripts.sh
+++ b/setup_scripts.sh
@@ -22,15 +22,16 @@
 #  your script collection before running this script.
 #
 #  Notes:
-#  - This script should be run from the root directory of the script collection.
 #  - Make sure to back up your scripts before running this script as a precaution.
 #  - SCRIPTS environment variable must be set to the path of the script collection.
 #  - Execute permissions will be added:
 #      - To all *.sh, *.py, *.rb files under the SCRIPTS path
-#      - To all *.sh, *.py, *.rb files in the current directory
 #      - To all files under scripts/cron/bin (no extension filter)
 #
 #  Version History:
+#  v2.6 2026-09-06
+#       Stop modifying unrelated current-directory scripts and preserve the
+#       SCRIPTS execute-permission operation status.
 #  v2.5 2026-08-22
 #       Use POSIX find for current-directory script selection.
 #  v2.4 2026-07-11
@@ -114,9 +115,8 @@ set_permissions() {
     find "$SCRIPTS" -type f -exec chmod u+rw,g+r,g-w,o+r,o-w {} \;
     RC1=$?
 
-    echo "[INFO] Granting execute permissions to script files (*.sh, *.py, *.rb) including current directory."
+    echo "[INFO] Granting execute permissions to script files (*.sh, *.py, *.rb) under the SCRIPTS path."
     find "$SCRIPTS" -type f \( -name "*.sh" -o -name "*.py" -o -name "*.rb" \) -exec chmod u+x,g+x,o+x {} \;
-    find . ! -path . -prune -type f \( -name "*.sh" -o -name "*.py" -o -name "*.rb" \) -exec chmod u+x,g+x,o+x {} \;
     RC2=$?
 
     echo "[INFO] Granting execute permissions to installer scripts (*.sh, *.py, *.rb)."


### PR DESCRIPTION
## Problem

`set_permissions()` in `setup_scripts.sh` ran two `find`/`chmod` invocations back to back before checking the result:

```sh
find "$SCRIPTS" -type f \( -name "*.sh" -o -name "*.py" -o -name "*.rb" \) -exec chmod u+x,g+x,o+x {} \;
find . ! -path . -prune -type f \( -name "*.sh" -o -name "*.py" -o -name "*.rb" \) -exec chmod u+x,g+x,o+x {} \;
RC2=$?
```

`RC2` only ever reflected the *second* `find .` command. A failure in the first, `$SCRIPTS`-targeted command was silently masked whenever the second command happened to succeed, so a real `$SCRIPTS` permission failure would not surface in the script's final aggregate status or exit code.

Separately, the second `find .` command operated on the process's current working directory rather than `$SCRIPTS`. If the script were invoked from a directory other than the `$SCRIPTS` root, it would chmod `.sh`/`.py`/`.rb` files there too — files unrelated to the script collection this tool is meant to manage.

## Change

- Removed the `find .` current-directory pass entirely; `$SCRIPTS`'s own recursive `find` already covers every `.sh`/`.py`/`.rb` file in the collection, including its top-level files.
- `RC2=$?` now immediately follows the single `find "$SCRIPTS" ...` execute-permission command, so it captures that command's actual status.
- Updated the `[INFO]` message and header `Notes` to describe the SCRIPTS-only behavior, and removed the now-inapplicable "run from the collection root" note and the "current directory" bullet.
- All other permission passes (read/write pass, installer, test, cron/bin) and the final `RC1`..`RC5` aggregate check are unchanged.

The intended `$SCRIPTS` permission model — recursive execute-bit grant for `.sh`/`.py`/`.rb` under `$SCRIPTS`, plus the installer/test/cron-bin passes — is fully preserved; only the unrelated cwd side effect and the failure-masking are removed.

## Testing

No dedicated Shell Script test was added (this repository has no dedicated automated test infrastructure for `setup_scripts.sh`); validation used the existing shell validation plus controlled, uncommitted temporary execution:

- `sh -n setup_scripts.sh` — no syntax errors.
- `SCRIPTS=<repo root> sh test/check_scripts.sh` — 140/140 scripts pass the existing `-h` help validation.
- Controlled temporary run: a scratch `SCRIPTS` directory with non-executable `.sh`/`.py`/`.rb` files, invoked from a separate scratch working directory containing an unrelated non-executable `.sh` file.
  - Result: the `SCRIPTS` files received execute permission (`rwxr-xr-x`), the unrelated cwd file's mode was untouched (`rw-------`), and the process exited `0`.
- Controlled temporary run with a non-existent `SCRIPTS` path: `find` reported failure and the script exited `1` (previously this could have been masked to `0` by a successful `find .`).
- Source inspection: `RC2=$?` directly follows the `$SCRIPTS` execute-permission `find`; no `find .` permission command remains.
- `check_header_doc.py -a` — no header documentation errors.
- `find_pycompat.py .` — no new compatibility issues (only the existing `test/dummy.py` fixture reported, as expected).
- `git diff --check` — no whitespace errors.

`doc/VERSIONS`'s current unreleased `v2.0.2 (Release Date: TBD)` entry remains unreleased; this change adds one bullet to it.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vCzKyX9cBpr6PTzYsYfcZ)_