### PR TITLE
Preserve setup_scripts permission failures

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -19,6 +19,8 @@ v2.0.2 (Release Date: TBD)
   while keeping lint findings and dry-run change candidates advisory.
 - Make default-install installers show usage for unsupported arguments
   instead of starting installation.
+- Make setup_scripts.sh preserve failures from both configured-collection
+  and current-directory execute-permission passes.
 
 v2.0.1 (2026-08-26)
 -------------------

--- a/setup_scripts.sh
+++ b/setup_scripts.sh
@@ -31,6 +31,9 @@
 #      - To all files under scripts/cron/bin (no extension filter)
 #
 #  Version History:
+#  v2.6 2026-09-06
+#       Preserve failures from both collection and current-directory execute
+#       permission passes without changing either documented target.
 #  v2.5 2026-08-22
 #       Use POSIX find for current-directory script selection.
 #  v2.4 2026-07-11
@@ -115,9 +118,23 @@ set_permissions() {
     RC1=$?
 
     echo "[INFO] Granting execute permissions to script files (*.sh, *.py, *.rb) including current directory."
+
+    # These scans are intentionally separate. SCRIPTS covers the configured
+    # collection tree, while "." covers the invocation directory as a distinct
+    # documented target. Do not remove either scan as redundant.
     find "$SCRIPTS" -type f \( -name "*.sh" -o -name "*.py" -o -name "*.rb" \) -exec chmod u+x,g+x,o+x {} \;
+    RC2_SCRIPTS=$?
+
     find . ! -path . -prune -type f \( -name "*.sh" -o -name "*.py" -o -name "*.rb" \) -exec chmod u+x,g+x,o+x {} \;
-    RC2=$?
+    RC2_CURRENT=$?
+
+    # Preserve both results so a successful later scan cannot mask an earlier
+    # permission failure.
+    if [ "$RC2_SCRIPTS" -eq 0 ] && [ "$RC2_CURRENT" -eq 0 ]; then
+        RC2=0
+    else
+        RC2=1
+    fi
 
     echo "[INFO] Granting execute permissions to installer scripts (*.sh, *.py, *.rb)."
     RC3=0


### PR DESCRIPTION
### Problem

- `setup_scripts.sh` intentionally applies execute permissions to both the configured `SCRIPTS` collection and the invocation current directory.
- the current code stores only the status of the second scan, so a successful current-directory pass can mask failure of the earlier `SCRIPTS` pass.
- the two scans are documented historical behavior and must not be treated as redundant.

### Change

- keep both existing permission scans.
- capture each scan status independently.
- aggregate them into RC2 without changing continue-on-failure behavior.
- add nearby code comments explaining why both scans are intentional and why both statuses must be retained.

### Scope

- `setup_scripts.sh`
- `doc/VERSIONS`

### Test Policy

- no new dedicated Shell Script test, harness, mock, stub, or alternate test execution path.
- existing Shell Script validation and controlled temporary execution only.

### Validation

- `sh -n setup_scripts.sh` — exit status 0, no syntax errors.
- `SCRIPTS=<repo root> sh test/check_scripts.sh` — exit status 0, 140/140 scripts pass the existing `-h` help validation.
- `python3 check_header_doc.py -a --root .` — exit status 0, no header documentation errors.
- Controlled temporary execution: a scratch `SCRIPTS` collection directory containing a non-executable `collection.py`, and a separate scratch current directory containing a non-executable `current.sh`, with neither `installer`, `test`, nor `cron/bin` present under the scratch collection. Running `setup_scripts.sh` from the scratch current directory with `SCRIPTS` pointing at the scratch collection:
  - process exit status 0
  - `collection.py` received execute permission
  - `current.sh` received execute permission
  - both files, in two different directories, were processed — confirming both the `SCRIPTS` target and the current-directory target remain active.
- Source-level control-flow inspection: `RC2_SCRIPTS=$?` follows the `SCRIPTS` `find` directly, `RC2_CURRENT=$?` follows the current-directory `find` directly, `RC2` is `0` only when both are `0` and `1` otherwise, neither scan exits early, RC3/RC4/RC5 operations still run afterward, and the final aggregate condition is unchanged.
- `python3 find_pycompat.py .` — no new compatibility issues (only the existing `test/dummy.py` fixture reported, as expected).
- `git diff --check` — no whitespace errors.
- Final diff reviewed: exactly `setup_scripts.sh` and `doc/VERSIONS` changed; both `find` commands remain; header Notes, v2.2/v2.5 Version History, RC1/RC3/RC4/RC5, and the final aggregate condition are all unchanged.

### Compatibility

- current-directory execute-permission behavior is preserved.
- configured `SCRIPTS` execute-permission behavior is preserved.
- installer / test / cron-bin passes are unchanged.
- only failure reporting becomes correct when either of the two primary execute-permission scans fails.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vCzKyX9cBpr6PTzYsYfcZ)_