### PR TITLE
Check uname before system detection

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -21,6 +21,7 @@ v2.0.2 (Release Date: TBD)
   instead of starting installation.
 - Make setup_scripts.sh preserve failures from both configured-collection
   and current-directory execute-permission passes.
+- Check uname before system detection in affected installer scripts.
 
 v2.0.1 (2026-08-26)
 -------------------

--- a/installer/debian_desktop_apt.sh
+++ b/installer/debian_desktop_apt.sh
@@ -59,6 +59,8 @@
 #  These should be resolved based on the output of the apt-get command.
 #
 #  Version History:
+#  v2.3 2026-09-06
+#       Check uname before using it for system detection.
 #  v2.2 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -227,9 +229,10 @@ main() {
         -h|--help|-v|--version) usage ;;
     esac
 
+    check_commands uname
     check_system
     check_desktop_installed
-    check_commands apt-get dpkg-query grep uname ls
+    check_commands apt-get dpkg-query grep ls
     check_sudo
     apt_upgrade
     desktop_environment

--- a/installer/debian_setup.sh
+++ b/installer/debian_setup.sh
@@ -66,6 +66,8 @@
 #  - Errors from underlying scripts should be resolved based on their output.
 #
 #  Version History:
+#  v2.3 2026-09-06
+#       Check uname before using it for system detection.
 #  v2.2 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -320,9 +322,10 @@ main() {
         -h|--help|-v|--version) usage ;;
     esac
 
+    check_commands uname
     check_system
     setup_environment
-    check_commands zsh git cut getent ln rm chown chsh mkdir uname
+    check_commands zsh git cut getent ln rm chown chsh mkdir
     check_sudo
     set_zsh_to_default
     install_dot_files

--- a/installer/install_clamscan.sh
+++ b/installer/install_clamscan.sh
@@ -33,6 +33,7 @@
 #  Version History:
 #  v3.2 2026-09-06
 #       Show usage for unsupported arguments instead of starting installation.
+#       Check uname before using it for system detection.
 #  v3.1 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -127,8 +128,9 @@ create_cron_dirs() {
 
 # Deploy ClamAV setup files
 install() {
+    check_commands uname
     check_system
-    check_commands cp chmod chown mkdir touch uname cat tee
+    check_commands cp chmod chown mkdir touch cat tee
     check_scripts
     check_sudo
 

--- a/installer/install_run_tests.sh
+++ b/installer/install_run_tests.sh
@@ -31,6 +31,7 @@
 #  Version History:
 #  v2.5 2026-09-06
 #       Show usage for unsupported arguments instead of starting installation.
+#       Check uname before using it for system detection.
 #  v2.4 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -231,9 +232,10 @@ final_message() {
 
 # Perform installation steps
 install() {
+    check_commands uname
     check_system
     check_scripts
-    check_commands cp chmod chown touch mkdir tee uname
+    check_commands cp chmod chown touch mkdir tee
     check_sudo
     setup_log_directory
     setup_log_file

--- a/installer/macos_setup.sh
+++ b/installer/macos_setup.sh
@@ -52,6 +52,8 @@
 #  - Exits if sudo privileges are not granted.
 #
 #  Version History:
+#  v2.2 2026-09-06
+#       Check uname before using it for system detection.
 #  v2.1 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -202,9 +204,10 @@ main() {
         -h|--help|-v|--version) usage ;;
     esac
 
+    check_commands uname
     check_system
     setup_environment
-    check_commands zsh git ln rm chown uname mkdir
+    check_commands zsh git ln rm chown mkdir
     check_sudo
     install_dot_files
     install_dot_zsh

--- a/installer/setup_motd.sh
+++ b/installer/setup_motd.sh
@@ -30,6 +30,8 @@
 #  - Commands: sudo, awk, sh, test
 #
 #  Version History:
+#  v1.2 2026-09-06
+#       Check uname before using it for system detection.
 #  v1.1 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -103,8 +105,9 @@ main() {
         -h|--help|-v|--version) usage ;;
     esac
 
+    check_commands uname
     check_system
-    check_commands awk sh uname
+    check_commands awk sh
     check_sudo
     clear_motd
     return 0

--- a/installer/setup_securetty.sh
+++ b/installer/setup_securetty.sh
@@ -24,6 +24,8 @@
 #  in some systems like macOS.
 #
 #  Version History:
+#  v1.8 2026-09-06
+#       Check uname before using it for system detection.
 #  v1.7 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -107,8 +109,9 @@ main() {
         -h|--help|-v|--version) usage ;;
     esac
 
+    check_commands uname
     check_system
-    check_commands sh uname
+    check_commands sh
     check_sudo
     clear_securetty
     return 0


### PR DESCRIPTION
## Problem

Seven installer/setup scripts call `check_system()` (which runs `uname` to detect the OS) before their `check_commands ... uname` prerequisite check runs later in the same normal execution path:

- `installer/install_run_tests.sh`
- `installer/install_clamscan.sh`
- `installer/setup_motd.sh`
- `installer/setup_securetty.sh`
- `installer/debian_desktop_apt.sh`
- `installer/debian_setup.sh`
- `installer/macos_setup.sh`

If `uname` is missing or not executable, `check_system()` runs it anyway, gets no usable output, and reports the wrong diagnosis (e.g. "This script is intended for Linux systems only.", exit `1`) instead of the correct prerequisite failure ("Command 'uname' is not installed...", exit `127`, or "...is not executable...", exit `126`).

## Change

- In each of the 7 scripts, add `check_commands uname` immediately before the existing `check_system` call.
- Remove `uname` from each script's later `check_commands` call so it is not checked twice.
- No other prerequisite ordering, unrelated steps (e.g. `check_desktop_installed`, `setup_environment`, `check_scripts`), or command sets changed — only `uname`'s check moved earlier.
- Updated each affected script's Version History (consolidated into the existing same-day entry for `install_run_tests.sh` and `install_clamscan.sh`, since they already had a `2026-09-06` entry).
- Added one bullet to the current unreleased `doc/VERSIONS` entry.

## Scope

Exactly these 8 files: the 7 scripts above plus `doc/VERSIONS`. No test files, `doc/POLICY`, README, or FEATURES changed. No new test infrastructure added.

## Compatibility

- `uname` missing: unchanged `check_commands` message, exit `127` (now reported correctly instead of being masked by `check_system`).
- `uname` not executable: unchanged `check_commands` message, exit `126` (same).
- `uname` usable but unsupported OS: unchanged `check_system` message and exit status.
- Supported OS: unchanged subsequent processing order.
- No fail-fast or batch-failure-aggregation behavior introduced; installers remain batch-oriented as before.

## Validation

- `sh -n` on all 7 changed scripts — no syntax errors.
- `SCRIPTS=<repo root> sh test/check_scripts.sh` — 140/140 scripts pass the existing `-h` help validation.
- `python3 check_header_doc.py -a --root .` — no header documentation errors.
- `python3 find_pycompat.py .` — no new compatibility issues (only the existing `test/dummy.py` fixture reported, as expected).
- `git diff --check` — no whitespace errors.
- Source review on all 7 files: `check_commands uname` precedes `check_system`; the later `check_commands` no longer lists `uname`; the required-command set is otherwise unchanged; unrelated steps keep their original relative position; normal processing order and batch continuation are unchanged.
- Controlled PATH-based smoke test (no files added to the repository) using `setup_motd.sh` as a representative case:
  - With a `PATH` containing every prerequisite except `uname`: the fixed script reports `[ERROR] Command 'uname' is not installed. Please install uname and try again.` and exits `127`.
  - Running the pre-fix version (`origin/master`) under the identical `PATH` instead reports `[ERROR] This script is intended for Linux systems only.` and exits `1` — confirming the defect and the fix.
  - With the full normal `PATH` restored, the script proceeds past the prerequisite checks exactly as before.
- The `126` (not-executable) case depends on shell-specific `command -v` semantics for non-executable files and was not reproduced live; `check_commands()` itself is unmodified by this change, so its existing, already-correct handling of that case is unaffected — recorded here as source-level verification per the repository's test policy for scripts without dedicated automated tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vCzKyX9cBpr6PTzYsYfcZ)_