### PR TITLE
Fix setup_sysadmin interface diagnostics

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -22,6 +22,7 @@ v2.0.2 (Release Date: TBD)
 - Make setup_scripts.sh preserve failures from both configured-collection
   and current-directory execute-permission passes.
 - Check uname before system detection in affected installer scripts.
+- Fix setup_sysadmin_scripts.sh usage examples and prerequisite error output.
 
 v2.0.1 (2026-08-26)
 -------------------

--- a/installer/setup_sysadmin_scripts.sh
+++ b/installer/setup_sysadmin_scripts.sh
@@ -23,16 +23,25 @@
 #      $2 = optional install path (default: /usr/local/sbin)
 #
 #  path as arguments. For example:
-#      ./install_sysadmin_scripts.sh install
-#      ./install_sysadmin_scripts.sh install /usr/local/sbin
-#      ./install_sysadmin_scripts.sh uninstall
+#      ./setup_sysadmin_scripts.sh install
+#      ./setup_sysadmin_scripts.sh install /usr/local/sbin
+#      ./setup_sysadmin_scripts.sh uninstall
 #
 #  Notes:
 #  - Ensure that the 'SCRIPTS' environment variable is set to the path containing
 #    the administration scripts.
 #  - Running the script with 'uninstall' will remove all installed administration scripts.
 #
+#  Exit Status:
+#  0. Success, or usage was displayed.
+#  1. A general setup, install, uninstall, or prerequisite failure occurred.
+#  2. An internal install_scripts call received an invalid argument count.
+#  126. A required command exists but is not executable.
+#  127. A required command is not found.
+#
 #  Version History:
+#  v2.3 2026-09-06
+#       Fix usage examples and send prerequisite errors to standard error.
 #  v2.2 2026-09-03
 #       Add luksmount command to Debian install and uninstall targets.
 #  v2.1 2026-07-11
@@ -96,7 +105,7 @@ usage() {
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
     if ! sudo -v 2>/dev/null; then
-        echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access."
+        echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1
     fi
 }
@@ -118,8 +127,8 @@ check_commands() {
 # Check if SCRIPTS variable is set
 check_scripts() {
     if [ -z "$SCRIPTS" ]; then
-        echo "[ERROR] SCRIPTS environment variable is not set."
-        echo "Please set the SCRIPTS variable to the path of your system administration scripts."
+        echo "[ERROR] SCRIPTS environment variable is not set." >&2
+        echo "Please set the SCRIPTS variable to the path of your system administration scripts." >&2
         exit 1
     fi
 }


### PR DESCRIPTION
## Problem

- The actual file is `setup_sysadmin_scripts.sh`, but its header Usage examples referenced a different, nonexistent filename: `install_sysadmin_scripts.sh` (all 3 examples).
- `check_sudo()`'s `[ERROR]` message went to stdout instead of stderr.
- `check_scripts()`'s two diagnostic lines (`[ERROR] SCRIPTS environment variable is not set.` and the follow-up instruction) went to stdout instead of stderr.

## Change

- Corrected the 3 Usage examples to reference `setup_sysadmin_scripts.sh`, the script's actual name.
- Added `>&2` to `check_sudo()`'s existing error `echo` (message wording unchanged).
- Added `>&2` to both of `check_scripts()`'s existing error `echo` lines (message wording unchanged).
- Added a concise `Exit Status` header section (the script exposes more than one caller-facing exit status but previously documented none), placed per `doc/POLICY` 1.6.2 ordering directly before `Version History`.
- Added one Version History entry.

Exit status values themselves are unchanged: `0` success/usage, `1` general setup/install/uninstall/prerequisite failure, `2` invalid internal `install_scripts` argument count, `126` required command not executable, `127` required command not found.

## Scope

Exactly 2 files: `installer/setup_sysadmin_scripts.sh` and `doc/VERSIONS`. No install/uninstall targets, `setup_environment`, argument semantics, default path, command checks, sudo timing, exit status values, normal stdout output, or source/target names changed. No test files, `doc/POLICY`, README, or FEATURES changed. No new test infrastructure added.

## Validation

- `sh -n installer/setup_sysadmin_scripts.sh` — no syntax errors.
- `SCRIPTS=<repo root> sh test/check_scripts.sh` — 140/140 scripts pass the existing `-h` help validation.
- `python3 check_header_doc.py -a --root .` — no header documentation errors.
- `git diff --check` — no whitespace errors.
- `-h` output now shows the corrected 3 `setup_sysadmin_scripts.sh` examples; `install_sysadmin_scripts.sh` no longer appears anywhere in the output.
- Controlled invocation with `SCRIPTS` unset: both `check_scripts()` diagnostic lines are on stderr, stdout is empty, and the process exits `1`.
- `check_sudo()`'s failure path was not safely reproducible in this environment (the container runs as root, where `sudo -v` always succeeds, and deliberately breaking sudo to test the failure path risks unrelated side effects) — confirmed instead by source inspection that its `echo` now carries `>&2`, with wording and the `exit 1` unchanged.
- Final diff reviewed: exactly the 2 scoped files changed; no install/uninstall target, argument-parsing, or exit-status-value changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vCzKyX9cBpr6PTzYsYfcZ)_