### PR TITLE
Encapsulate uname system check dependency

### DIFF
--- a/installer/debian_desktop_apt.sh
+++ b/installer/debian_desktop_apt.sh
@@ -99,6 +99,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     os="$(uname -s 2>/dev/null)"
     if [ "$os" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
@@ -229,7 +231,6 @@ main() {
         -h|--help|-v|--version) usage ;;
     esac
 
-    check_commands uname
     check_system
     check_desktop_installed
     check_commands apt-get dpkg-query grep ls

--- a/installer/debian_setup.sh
+++ b/installer/debian_setup.sh
@@ -111,6 +111,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -322,7 +324,6 @@ main() {
         -h|--help|-v|--version) usage ;;
     esac
 
-    check_commands uname
     check_system
     setup_environment
     check_commands zsh git cut getent ln rm chown chsh mkdir

--- a/installer/install_clamscan.sh
+++ b/installer/install_clamscan.sh
@@ -77,6 +77,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -128,7 +130,6 @@ create_cron_dirs() {
 
 # Deploy ClamAV setup files
 install() {
-    check_commands uname
     check_system
     check_commands cp chmod chown mkdir touch cat tee
     check_scripts

--- a/installer/install_run_tests.sh
+++ b/installer/install_run_tests.sh
@@ -81,6 +81,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -232,7 +234,6 @@ final_message() {
 
 # Perform installation steps
 install() {
-    check_commands uname
     check_system
     check_scripts
     check_commands cp chmod chown touch mkdir tee

--- a/installer/macos_setup.sh
+++ b/installer/macos_setup.sh
@@ -81,6 +81,8 @@ usage() {
 
 # Check if the system is macOS
 check_system() {
+    check_commands uname
+
     if [ "$(uname)" != "Darwin" ]; then
         echo "[ERROR] This script is intended for macOS only." >&2
         exit 1
@@ -204,7 +206,6 @@ main() {
         -h|--help|-v|--version) usage ;;
     esac
 
-    check_commands uname
     check_system
     setup_environment
     check_commands zsh git ln rm chown mkdir

--- a/installer/setup_motd.sh
+++ b/installer/setup_motd.sh
@@ -54,6 +54,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -105,7 +107,6 @@ main() {
         -h|--help|-v|--version) usage ;;
     esac
 
-    check_commands uname
     check_system
     check_commands awk sh
     check_sudo

--- a/installer/setup_securetty.sh
+++ b/installer/setup_securetty.sh
@@ -58,6 +58,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -109,7 +111,6 @@ main() {
         -h|--help|-v|--version) usage ;;
     esac
 
-    check_commands uname
     check_system
     check_commands sh
     check_sudo


### PR DESCRIPTION
## Problem

In 7 installer/setup scripts, `check_system()` directly uses `uname` to detect the OS, but the `uname` prerequisite check (`check_commands uname`) lived at the call site in `main()`/`install()`, ahead of `check_system()`. This makes `uname`'s prerequisite check the caller's responsibility rather than `check_system()`'s own, so any future reordering of that call site could reintroduce an unchecked `uname` use.

## Change

In each of:

- `installer/install_run_tests.sh`
- `installer/install_clamscan.sh`
- `installer/setup_motd.sh`
- `installer/setup_securetty.sh`
- `installer/debian_desktop_apt.sh`
- `installer/debian_setup.sh`
- `installer/macos_setup.sh`

added `check_commands uname` as the first statement inside `check_system()`, and removed the now-redundant standalone `check_commands uname` from the caller. `check_system()`'s OS-detection body is otherwise unchanged. No comments were added, since the leading `check_commands uname` line makes the dependency self-evident.

## Compatibility

- User-visible behavior is unchanged: `uname` missing still exits `127` with the existing message, non-executable still exits `126`, unsupported OS still exits with the existing `check_system` message and status, and a supported OS still proceeds to the existing next steps.
- Exit status semantics, dependency sets, and processing order (including all other `check_commands` calls and batch continuation) are unchanged — only where `uname`'s own check happens moved from the call site into `check_system()`.
- This is an internal refactor only: no executable Version History entries were added or bumped, and `doc/VERSIONS` was not changed, per policy for behavior-preserving internal changes.

## Validation

- `sh -n` on all 7 changed scripts — no syntax errors.
- `SCRIPTS=<repo root> sh test/check_scripts.sh` — 140/140 scripts pass the existing `-h` help validation.
- `python3 check_header_doc.py -a --root .` — no header documentation errors.
- `git diff --check` — no whitespace errors.
- Source review on all 7 files: `check_commands uname` is the first executable statement in `check_system()`; no standalone `check_commands uname` remains in `main()`/`install()`; no duplicate `uname` prerequisite check exists; each `check_system()`'s OS-detection body is otherwise byte-for-byte unchanged; all other `check_commands` calls keep their original position and content.
- Controlled PATH-based smoke test (no files added to the repository) using `setup_motd.sh`: with `uname` absent from `PATH`, the script still reports `[ERROR] Command 'uname' is not installed...` and exits `127` (now via `check_system()` itself rather than the removed call-site check).
- With the full normal `PATH`, `setup_motd.sh` and `setup_securetty.sh` both proceed past `check_system()` to their next existing step exactly as before.
- The wrong-OS and non-executable-`uname` (`126`) paths were not exercised live, since doing so safely would require a fake `uname` shim or shell-dependent `command -v` tricks, which this change does not introduce; each `check_system()` OS-detection body and `check_commands()` itself are diff-confirmed unchanged, so these paths are unaffected.
- Final diff reviewed: exactly the 7 scoped files changed; no header, Version History, `doc/VERSIONS`, or `doc/POLICY` changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vCzKyX9cBpr6PTzYsYfcZ)_