### PR TITLE
Fix ClamAV deployment consistency

### DIFF
--- a/cron/etc/cron.d/clamscan
+++ b/cron/etc/cron.d/clamscan
@@ -1,7 +1,7 @@
-# Scheduled execution of clamscan.sh
+# Scheduled execution of ClamAV scan wrapper
 # Logs will be sent to the root user via cron MAILTO
 
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 MAILTO=root
 
-01 04 * * 0 root test -x /etc/cron.exec/clamscan.sh && /etc/cron.exec/clamscan.sh
+01 01 * * 0 root test -x /etc/cron.exec/clamscan && /etc/cron.exec/clamscan

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -22,6 +22,7 @@ v2.0.2 (Release Date: TBD)
 - Make setup_scripts.sh preserve failures from both configured-collection
   and current-directory execute-permission passes.
 - Check uname before system detection in affected installer scripts.
+- Align ClamAV cron deployment with its tracked definition and remove the deployed wrapper on uninstall.
 - Fix setup_sysadmin_scripts.sh usage examples and prerequisite error output.
 
 v2.0.1 (2026-08-26)

--- a/installer/install_clamscan.sh
+++ b/installer/install_clamscan.sh
@@ -5,7 +5,7 @@
 #
 #  Description:
 #  This script automates the setup for ClamAV scans by:
-#  - Deploying the clamscan.sh script.
+#  - Deploying the clamscan wrapper and clamscan.sh worker.
 #  - Configuring clamscan exclusions.
 #  - Installing /etc/cron.d/clamscan unless it already exists.
 #  - Managing log rotation for ClamAV logs.
@@ -32,8 +32,7 @@
 #
 #  Version History:
 #  v3.2 2026-09-06
-#       Show usage for unsupported arguments instead of starting installation.
-#       Check uname before using it for system detection.
+#       Fix CLI handling, system detection, and ClamAV deployment consistency.
 #  v3.1 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -131,7 +130,7 @@ create_cron_dirs() {
 # Deploy ClamAV setup files
 install() {
     check_system
-    check_commands cp chmod chown mkdir touch cat tee
+    check_commands cp chmod chown mkdir touch
     check_scripts
     check_sudo
 
@@ -171,15 +170,10 @@ install() {
         echo "[INFO] Skipping cron job installation: /etc/cron.d/clamscan already exists."
     else
         echo "[INFO] Installing cron job to /etc/cron.d/clamscan"
-        cat <<'EOF' | sudo tee /etc/cron.d/clamscan >/dev/null
-# Scheduled execution of clamscan.sh
-# Logs will be sent to the root user via cron MAILTO
-
-PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-MAILTO=root
-
-01 01 * * 0 root test -x /etc/cron.exec/clamscan && /etc/cron.exec/clamscan
-EOF
+        if ! sudo cp "$SCRIPTS/cron/etc/cron.d/clamscan" /etc/cron.d/clamscan; then
+            echo "[ERROR] Failed to copy cron configuration." >&2
+            exit 1
+        fi
     fi
     sudo chmod 0640 /etc/cron.d/clamscan
     sudo chown root:adm /etc/cron.d/clamscan
@@ -220,6 +214,12 @@ uninstall() {
         sudo rm -v /etc/cron.exec/clamscan.sh
     else
         echo "[INFO] /etc/cron.exec/clamscan.sh not found. Skipping."
+    fi
+
+    if [ -f /etc/cron.exec/clamscan ]; then
+        sudo rm -v /etc/cron.exec/clamscan
+    else
+        echo "[INFO] /etc/cron.exec/clamscan not found. Skipping."
     fi
 
     if [ -f /etc/cron.config/clamscan.conf ]; then


### PR DESCRIPTION
### Problem

- installer deploys `/etc/cron.exec/clamscan` but uninstall leaves it behind.
- the tracked cron definition differs from the cron definition generated by the installer.

### Change

- make `cron/etc/cron.d/clamscan` the canonical cron definition using the existing 01:01 Sunday wrapper entrypoint.
- copy that definition during installation instead of duplicating it in a heredoc.
- remove `/etc/cron.exec/clamscan` during uninstall.

### Compatibility

- keep the existing installer schedule, wrapper entrypoint, skip-existing behavior, permissions, ownership, and log retention.
- no new dependency or option.

### Validation

- `sh -n installer/install_clamscan.sh` — exit status 0, no syntax errors.
- `SCRIPTS=<repo root> sh test/check_scripts.sh` — 140/140 scripts pass, including `install_clamscan.sh -h`.
- `python3 check_header_doc.py -a --root .` — exit status 0, no header or Version History format errors.
- `git diff --check` — no whitespace errors.
- Inspected `cron/etc/cron.d/clamscan`: exactly one execution line, schedule `01 01 * * 0`, user `root`, entrypoint `/etc/cron.exec/clamscan`, no direct `clamscan.sh` invocation, no `04:01` schedule.
- Source review of `installer/install_clamscan.sh`: no heredoc remains; cron job copy source is `$SCRIPTS/cron/etc/cron.d/clamscan`, destination `/etc/cron.d/clamscan`; existing-file skip semantics, `0640` permission, and `root:adm` ownership on `/etc/cron.d/clamscan` are unchanged and unconditional; `cat`/`tee` removed from `install()`'s `check_commands` and no longer used anywhere in the file.
- Source review of `uninstall()`: cleanup order is `clamscan.sh` → `clamscan` (new) → `clamscan.conf` → `cron.d/clamscan` → `logrotate.d/clamscan`; `/var/log/clamav/clamscan.log` and `/var/log/clamav/clamav.log` do not appear in any removal path; no additional historical paths were added.
- `git status`/`git diff --stat` confirm exactly 3 changed files: `installer/install_clamscan.sh`, `cron/etc/cron.d/clamscan`, `doc/VERSIONS`.
- A live install/uninstall smoke test was not performed: this container has no `clamav` system user and the change would write to real `/etc/cron.d`, `/etc/cron.exec`, etc., so a live run risks environment-specific failures unrelated to this change rather than validating it. Verification relies on the source- and file-level checks above.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vCzKyX9cBpr6PTzYsYfcZ)_