### PR TITLE
Fix block device helper prerequisites

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -7,6 +7,7 @@ v2.0.2 (Release Date: TBD)
   as luksmount with the Debian system administration scripts.
 - Harden tcmount.py against shell interpretation, preserve the legacy
   ~/mnt/<target> namespace, and return mount and unmount failures.
+- Align block-device helper prerequisite checks with their runtime dependencies.
 - Replace shell-based command lookup in cal.py, du.py, tcmount.py, and
   wp_cachectl.py with Python-native PATH lookup.
 - Fix the nightly quality gate so its exit status reflects the current

--- a/get-device.sh
+++ b/get-device.sh
@@ -38,7 +38,7 @@
 #      => /dev/sdc
 #
 #  Requirements:
-#    - Linux, findmnt(8), lsblk(8), sed(1), head(1), tail(1), awk(1)
+#    - Linux, uname(1), findmnt(8), lsblk(8), sed(1), head(1), tail(1), awk(1)
 #
 #  Exit Status:
 #  0. Success.
@@ -49,6 +49,8 @@
 #  127. Required command is not installed.
 #
 #  Version History:
+#  v1.3 2026-09-06
+#       Check uname before system detection.
 #  v1.2 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -72,6 +74,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1

--- a/get-mountpoint.sh
+++ b/get-mountpoint.sh
@@ -40,7 +40,7 @@
 #      => /            # when the deepest descendant mounts "/"
 #
 #  Requirements:
-#    - Linux, findmnt(8), lsblk(8), awk(1), mktemp(1)
+#    - Linux, uname(1), findmnt(8), lsblk(8), readlink(1), awk(1), mktemp(1), rm(1)
 #
 #  Exit Status:
 #  0. Success.
@@ -51,6 +51,8 @@
 #  127. Required command is not installed.
 #
 #  Version History:
+#  v1.4 2026-09-06
+#       Check system and temporary-file dependencies before use.
 #  v1.3 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -76,6 +78,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -336,7 +340,7 @@ main() {
     esac
 
     check_system
-    check_commands lsblk findmnt readlink awk
+    check_commands lsblk findmnt readlink awk mktemp rm
     validate_args "$@"
     resolve_and_print "$DEVICE"
     return $?

--- a/get-serial.sh
+++ b/get-serial.sh
@@ -25,7 +25,7 @@
 #      get-serial.sh "$(get-device.sh ~/mnt/disk1)"
 #
 #  Requirements:
-#    - Linux, udevadm(8), lsblk(8), sed(1), head(1), awk(1)
+#    - Linux, uname(1), udevadm(8), lsblk(8), sed(1), head(1), awk(1)
 #
 #  Exit Status:
 #  0. Success.
@@ -37,6 +37,8 @@
 #  127. Required command is not installed.
 #
 #  Version History:
+#  v1.4 2026-09-06
+#       Check uname before system detection.
 #  v1.3 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -62,6 +64,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1


### PR DESCRIPTION
### Problem

- the three block-device helpers use `uname` before declaring that prerequisite.
- `get-mountpoint.sh` also uses `mktemp` and `rm` without including them in its normal prerequisite check.
- header Requirements do not fully match runtime dependencies.

### Change

- make each `check_system()` own `uname` validation.
- add `mktemp` and `rm` to `get-mountpoint.sh` normal prerequisite checks.
- synchronize the directly affected Requirements entries.

### Compatibility

- normal behavior is unchanged when required commands are available.
- missing prerequisites now use the repository's existing prerequisite diagnostics and 126/127 contract.
- no option, configuration, resolution algorithm, or persistent side effect changes.

### Validation

- `sh -n` on all 3 changed scripts — exit status 0, no syntax errors.
- `SCRIPTS=<repo root> sh test/check_scripts.sh` — 140/140 scripts pass, including `get-device.sh -h`, `get-mountpoint.sh -h`, `get-serial.sh -h`.
- `python3 check_header_doc.py -a --root .` — exit status 0, no header or Version History format errors.
- `git diff --check` — no whitespace errors.
- Controlled PATH-based smoke tests (no files added to the repository):
  - With `uname` absent from `PATH` (all other dependencies present): all 3 scripts report `[ERROR] Command 'uname' is not installed...` on stderr and exit `127`, without reaching device/mountpoint/serial resolution.
  - `get-mountpoint.sh` with `mktemp` absent from `PATH`: reports `[ERROR] Command 'mktemp' is not installed...` and exits `127` before argument validation runs (confirmed by using a nonexistent device path, which would otherwise fail argument validation with exit `2`).
  - `get-mountpoint.sh` with `rm` absent from `PATH`: reports `[ERROR] Command 'rm' is not installed...` and exits `127`, same precedence confirmation.
- With the full normal `PATH`, `get-device.sh` and `get-mountpoint.sh` still reach their existing argument-validation failure (exit `2`) for a nonexistent path, confirming supported-environment behavior is unchanged; `get-serial.sh`'s `127` on this container is pre-existing and unrelated (this container has no `udevadm` installed, and `udevadm` was already a required command before this change).
- Source review confirmed for all 3 files: `check_commands uname` is the first executable statement in `check_system()`; main-side `check_commands` lists are exactly `lsblk findmnt tail sed head` (`get-device.sh`), `lsblk findmnt readlink awk mktemp rm` (`get-mountpoint.sh`), and `udevadm lsblk sed head` (`get-serial.sh`), with no `uname` duplicated in any of them; Requirements lines match the specified dependency lists exactly.
- Final diff reviewed: exactly 4 files changed (`get-device.sh`, `get-mountpoint.sh`, `get-serial.sh`, `doc/VERSIONS`); each script has exactly one new Version History entry with a single description line; no other Version History entries changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vCzKyX9cBpr6PTzYsYfcZ)_