### PR TITLE
Align fix-permissions installer contract

### DIFF
--- a/installer/install_fix-permissions.sh
+++ b/installer/install_fix-permissions.sh
@@ -21,22 +21,26 @@
 #      ./install_fix-permissions.sh --uninstall
 #
 #  Requirements:
-#  - The `SCRIPTS` environment variable must be set to the directory
-#    containing the `fix-permissions` script and its configurations.
-#  - Must be executed with sufficient permissions to modify system
-#    directories (typically as root or with sudo).
-#  - Requires `logrotate` to be installed for log rotation setup.
-#  - The script will not overwrite an existing fix-permissions cron job
-#    if it already exists.
+#  - Linux system.
+#  - The invoking user must have sudo privileges.
+#  - Install mode requires `SCRIPTS` to point to the repository source files.
+#  - Install mode requires `logrotate` to be available.
+#
+#  Exit Status:
+#  0: The selected workflow completed, or usage/help/version was displayed.
+#  1: System, environment, sudo, or critical installation failure.
+#  126: A required command exists but is not executable.
+#  127: A required command is not found.
 #
 #  Notes:
-#  - The script ensures that `/var/log/sysadmin` is created if it does
-#    not exist and configures it securely.
-#  - If a log rotation configuration for `fix-permissions` already exists,
-#    it will not be overwritten.
-#  - The `fix-permissions` script is deployed to `/etc/cron.daily` with
-#    appropriate permissions.
-#  - Log files are preserved when --uninstall is used.
+#  - `/etc/cron.daily/fix-permissions` is refreshed from the repository on
+#    every install.
+#  - Existing `/etc/logrotate.d/fix-permissions` is not overwritten.
+#  - Existing `/etc/cron.config/fix-permissions.conf` is not overwritten.
+#  - `/var/log/sysadmin/fix-permissions.log` is preserved by uninstall.
+#  - `--uninstall` attempts all configured removal targets; an individual
+#    removal failure is reported with `[WARN]` and does not stop later
+#    removals.
 #
 #  Version History:
 #  v2.2 2026-09-06
@@ -82,6 +86,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -123,7 +129,7 @@ check_sudo() {
 install() {
     # Perform initial checks
     check_system
-    check_commands cp chmod chown mkdir touch logrotate uname
+    check_commands cp chmod chown mkdir touch logrotate
     check_scripts
     check_sudo
 


### PR DESCRIPTION
## Problem

- `install_fix-permissions.sh` uses `uname` before its prerequisite is owned by `check_system()`.
- the header says an existing cron job is preserved, but install has intentionally refreshed `/etc/cron.daily/fix-permissions` on every run since the 2025-05-17 deployment change.

## Change

- make `check_system()` own `uname` and drop `uname` from install's own `check_commands` list.
- document the established deployment contract: refresh the cron executable while preserving existing logrotate and `fix-permissions.conf` configuration files.
- add Requirements and Exit Status details that match install and uninstall behavior.

## Compatibility

- preserve all install targets, processing order, permissions, ownership, config-preservation behavior, uninstall targets/order, and removal-warning continuation.
- preserve `/var/log/sysadmin/fix-permissions.log` on uninstall.
- `uninstall` keeps its existing prerequisite set (`rm`, `sudo`) unchanged; it does not call `check_system`.
- no new dependency, no `test` prerequisite, no fail-fast conversion, no status aggregation, and no runtime `fix-permissions.sh` change.
- no executable version bump and no `doc/VERSIONS` entry, per maintainer direction that this documentation/ownership realignment does not warrant one.

## Validation

- `sh -n installer/install_fix-permissions.sh` — syntax OK.
- `sh installer/install_fix-permissions.sh -h` — renders the updated header correctly, exit 0.
- `python3 check_header_doc.py -a --root .` — 0 issues.
- `SCRIPTS=$(pwd) sh test/check_scripts.sh` — 140/140 scripts pass, including this installer's `-h`.
- No trailing whitespace or tabs introduced.
- Controlled missing-`uname` smoke check on install (temporary PATH shim, not committed, excluding `uname`): status 127 with the exact existing missing-command message, no sudo prompt, no filesystem side effect.
- Controlled missing-`rm` smoke check on `--uninstall` (temporary PATH shim, not committed, excluding `rm`): status 127 with the exact existing missing-command message, confirming uninstall's own prerequisite check is unaffected by the `check_system` change.
- Static source review confirms: cron executable copy has no existing-file guard (refreshed every install); logrotate config and `fix-permissions.conf` each keep their existing-file guard; the uninstall log file is not in the removal target list; `uninstall()` no longer calls `check_system`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01262BQ6giB2EyKZvjoHVVzV