### PR TITLE
Clarify idempotent state contract

### DIFF
--- a/anthy_create_aa_dic.sh
+++ b/anthy_create_aa_dic.sh
@@ -47,6 +47,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1

--- a/check_reboot.sh
+++ b/check_reboot.sh
@@ -68,6 +68,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -170,7 +172,7 @@ main() {
     esac
 
     check_system
-    check_commands awk sed id uname
+    check_commands awk sed id
 
     # Track whether any method indicates a reboot requirement.
     reboot_required=0

--- a/clear_chromium_cache.sh
+++ b/clear_chromium_cache.sh
@@ -23,8 +23,11 @@
 #  - This script no longer forcefully terminates Chromium processes.
 #  - Ensure that Chromium is closed before running with the -c option
 #    to avoid potential data corruption.
+#  - If the Web Data path is already absent, clearing is a successful no-op.
 #
 #  Version History:
+#  v1.8 2026-09-08
+#       Treat an already absent Chromium Web Data path as a successful no-op.
 #  v1.7 2026-07-11
 #       Replace the non-portable awk {n,} interval in usage() and recognize
 #       --help/--version explicitly before getopts parsing.
@@ -65,8 +68,7 @@ clear_cache() {
         echo "[INFO] Cleared: $cache_dir"
         exit 0
     else
-        echo "[ERROR] Not found: $cache_dir" >&2
-        exit 1
+        exit 0
     fi
 }
 

--- a/doc/POLICY
+++ b/doc/POLICY
@@ -271,8 +271,8 @@ repository is already being edited.
 
 - **1: General failure**
   The default failure code.
-  Use for invalid arguments, missing resources, processing errors, or any
-  failure that does not require explicit classification. For an invalid or
+  Use for invalid arguments, missing required resources, processing errors, or
+  any failure that does not require explicit classification. For an invalid or
   unsupported CLI option specifically, the exit status follows the
   established usage behavior defined in Section 1.3.1 instead: both the
   repository-standard `0` and the existing accepted `1` are valid, and this
@@ -294,6 +294,11 @@ repository is already being edited.
 
 #### 1.3.3 Logging and Output
 - Use unified log prefixes: `[INFO]`, `[WARN]`, `[ERROR]`.
+- Do not label a successful no-op as `[ERROR]`. Use no output, `[INFO]`, or
+  `[WARN]` according to the operation's user-facing and operational contract.
+- Log level and process status are separate signals. `[WARN]` may accompany
+  exit status `0` when a condition is noteworthy but the requested operation
+  still satisfies its contract.
 - Informational messages go to standard output.
 - Error messages always go to standard error.
 - Log messages must be human-readable and suitable for cron execution.
@@ -421,9 +426,47 @@ never asked to touch.
   keep the directly related implementation and documentation consistent with
   these rules.
 
-#### 1.5.2 Idempotency and State Checks
+#### 1.5.2 Idempotency, State Checks, and No-op Results
 - Prefer state-changing operations to remain safe when repeated over the same
-  input. This is especially useful for installers and scheduled jobs.
+  input. This is especially useful for installers, setup tools, cleanup tools,
+  uninstallers, and scheduled jobs.
+- Judge success against the operation's contract and required postcondition,
+  not merely by whether the run changed something.
+- For a state-converging operation whose purpose is to ensure, clear, remove,
+  disable, configure, or uninstall a state, treat the run as a successful
+  no-op when the required postcondition already holds and the invocation's
+  required prerequisites have been satisfied. Do not report failure merely
+  because no mutation was necessary.
+- Idempotency does not mean that every run with zero work is successful. A
+  batch, synchronization, extraction, monitoring, transfer, conversion, or
+  other input-driven operation may legitimately treat zero matching inputs as
+  failure when its contract requires work or input to be present.
+- Distinguish required resources from optional or state-owned targets.
+  Absence of a required input, configuration, source, or other prerequisite
+  is a failure. Absence of a target may be success when the operation's
+  required postcondition is precisely that the target be absent or require
+  no change.
+- A successful no-op may be silent, informational, or warning-level according
+  to its operational significance. A warning does not by itself make the
+  operation fail. Do not label the no-op itself as an error.
+- A successful no-op does not waive invocation prerequisites. A supported
+  environment, required configuration, required privilege, and other
+  prerequisites that belong to a valid invocation are still checked according
+  to the tool's contract even when the state-changing branch turns out to be
+  unnecessary.
+- In a Shell Script whose contract requires sudo privileges, `check_sudo`
+  remains part of normal invocation even when the requested state already
+  holds. Do not move, skip, or conditionalize `check_sudo` merely to make a
+  no-op path avoid the privilege check.
+- This no-op policy does not by itself authorize moving, deleting, or
+  weakening `check_commands`, system checks, configuration checks, or other
+  established startup prerequisites. Change such prerequisite semantics only
+  when that is explicitly part of the work.
+- After required invocation prerequisites have been validated, a successful
+  no-op should not create temporary files, rewrite unchanged files, restart
+  or reload services, prompt for confirmation that exists only to authorize
+  the unnecessary state change, or perform another state-changing side
+  effect merely to report that no change was needed.
 - Check current state before changing it when that prevents duplicate,
   conflicting, or corrupted persistent state. Appending a line, creating a
   link, enabling a service, and installing a package commonly benefit from
@@ -919,6 +962,10 @@ Before a change is proposed, consider these questions:
   a log message?
 - For state-changing work, has repeat execution been considered, and would a
   second run create unintended duplication or corruption?
+- For a state-converging operation, does the requested postcondition already
+  hold, and if so does the valid invocation complete as a successful no-op
+  without confusing that case with missing required input or zero-work batch
+  semantics?
 - Does it change an existing option, exit status, output, or configuration key
   that a cron entry or a deployed copy depends on?
 - Does it change control flow, processing order, side effects, or whether later
@@ -1091,6 +1138,16 @@ check_commands() {
   which runs `sudo -v` and refuses the run when it fails.
 - Elevated privileges cover the operations that need them and no more. A
   script that needs root for one step does not run its whole body under it.
+- A validation helper owns the external-command prerequisites that it directly
+  uses to make its validation decision. In particular, a `check_system`
+  function that invokes `uname` calls `check_commands uname` before its first
+  use of `uname`; callers do not carry `uname` solely on behalf of that
+  `check_system` call.
+- Moving an existing `uname` prerequisite check into `check_system` and
+  removing the now-redundant caller-side `uname` check is a prerequisite
+  ownership normalization. By maintainer decision, that normalization alone
+  does not bump the executable version. If the same executable has another
+  behavior change, apply the normal versioning rules to that other change.
 - Do not perform a generic network-connectivity preflight merely because a
   later operation uses the network. Apply the Network Operations policy in
   1.4.3.

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -22,13 +22,14 @@ v2.0.2 (Release Date: TBD)
   starting installation.
 - Make setup_scripts.sh preserve failures from both configured-collection and
   current-directory execute-permission passes.
-- Check uname before system detection in affected installer scripts.
+- Make check_system own uname prerequisite checks across Shell Scripts.
 - Align ClamAV cron deployment with its tracked definition and remove the deployed
   wrapper on uninstall.
 - Fix setup_sysadmin_scripts.sh usage examples and prerequisite error output.
 - Fix Homebrew paths, user ownership, and post-reinstall environment.
 - Preserve the user's GPG keyring context when installing APT signing keys.
 - Align munin-sync installer prerequisites and Linux-only uninstall behavior.
+- Align state-converging no-op results with repository-wide idempotency rules.
 
 v2.0.1 (2026-08-26)
 -------------------

--- a/dpkg-hold.sh
+++ b/dpkg-hold.sh
@@ -84,6 +84,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1

--- a/erase_history.py
+++ b/erase_history.py
@@ -89,11 +89,21 @@
 #    to a comma-separated list of command names (e.g. "eh,hh").
 #    When the first token in the history entry matches one of these names,
 #    it is considered self invocation.
+#  - When no removable history lines exist, the script returns success
+#    without prompting or rewriting the history file.
 #
 #  Requirements:
 #  - Python Version: 3.3 or later
 #
+#  Exit Status:
+#  0: Success, including no removable history lines, or help/version output.
+#  1: Missing history file, read/write failure, or user abort.
+#  2: Invalid arguments or invalid line-count request.
+#
 #  Version History:
+#  v1.3 2026-09-08
+#       Use status 1 for a missing history file and return success without
+#       rewriting when no history lines are available to remove.
 #  v1.2 2026-02-25
 #       Detect self invocation by script path instead of command name.
 #       Support alias-based self invocation via ERASE_HISTORY_SELF_NAMES.
@@ -319,13 +329,12 @@ def erase_tail_lines(history_path, n, quiet):
         n (int): Number of lines to remove.
 
     Exits:
-        1: On read/write failure.
-        2: If the history file does not exist.
+        1: On read/write failure, or if the history file does not exist.
     """
 
     if not os.path.exists(history_path):
         print("[ERROR] History file does not exist - %s" % history_path, file=sys.stderr)
-        sys.exit(2)
+        sys.exit(1)
 
     try:
         with open(history_path, 'r', encoding='utf-8', errors='replace') as f:
@@ -355,6 +364,11 @@ def erase_tail_lines(history_path, n, quiet):
 
         removed_lines = lines[start:end]
         keep_lines = lines[:start] + lines[end:]
+
+    if not removed_lines:
+        if not quiet:
+            print("[INFO] No history lines to remove.")
+        return
 
     if not quiet:
         for line in removed_lines:

--- a/installer/configure_sysctl.sh
+++ b/installer/configure_sysctl.sh
@@ -93,6 +93,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -313,7 +315,7 @@ main() {
 
     # Check prerequisites
     check_system
-    check_commands sysctl uname tee cat ip grep tr
+    check_commands sysctl tee cat ip grep tr
     check_sudo
 
     # Define configuration paths

--- a/installer/create_emergencyadmin.sh
+++ b/installer/create_emergencyadmin.sh
@@ -48,6 +48,8 @@ usage() {
 
 # Check if the system is macOS
 check_system() {
+    check_commands uname
+
     if [ "$(uname)" != "Darwin" ]; then
         echo "[ERROR] This script is intended for macOS only." >&2
         exit 1
@@ -167,7 +169,7 @@ main() {
     esac
 
     check_system
-    check_commands uname id chmod ls logname dscl stty sort tail sysadminctl fdesetup defaults
+    check_commands id chmod ls logname dscl stty sort tail sysadminctl fdesetup defaults
     check_sudo
     check_user_exists
 

--- a/installer/debian_gnome_flashback_setup.sh
+++ b/installer/debian_gnome_flashback_setup.sh
@@ -83,6 +83,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     os="$(uname -s 2>/dev/null)"
     if [ "$os" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
@@ -400,7 +402,7 @@ main() {
     check_scripts
     check_session_bus
     check_desktop_installed
-    check_commands gsettings dconf mkdir cp awk chmod uname grep ls
+    check_commands gsettings dconf mkdir cp awk chmod grep ls
 
     confirm_apply_settings
 

--- a/installer/debian_gnome_setup.sh
+++ b/installer/debian_gnome_setup.sh
@@ -63,6 +63,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     os="$(uname -s 2>/dev/null)"
     if [ "$os" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
@@ -371,7 +373,7 @@ main() {
     check_session_bus
 
     # Verify required commands for this script
-    check_commands gsettings dconf mkdir cp awk uname grep systemctl
+    check_commands gsettings dconf mkdir cp awk grep systemctl
 
     confirm_apply_settings
 

--- a/installer/debian_init.sh
+++ b/installer/debian_init.sh
@@ -91,6 +91,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -213,7 +215,7 @@ main() {
     # Check if the system is Debian-based before proceeding
     check_system
     setup_environment
-    check_commands awk tr uname
+    check_commands awk tr
     check_debian_based
 
     # Ask for confirmation before proceeding

--- a/installer/debian_xfce_setup.sh
+++ b/installer/debian_xfce_setup.sh
@@ -68,6 +68,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     os="$(uname -s 2>/dev/null)"
     if [ "$os" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
@@ -454,7 +456,7 @@ main() {
     check_scripts
     check_session_bus
     check_desktop_installed
-    check_commands xfconf-query mkdir cp awk chmod uname grep ls
+    check_commands xfconf-query mkdir cp awk chmod grep ls
 
     confirm_apply_settings
 

--- a/installer/disable_freshclam_syslog.sh
+++ b/installer/disable_freshclam_syslog.sh
@@ -57,6 +57,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -124,7 +126,7 @@ main() {
     esac
 
     check_system
-    check_commands mkdir tee systemctl uname
+    check_commands mkdir tee systemctl
     check_sudo
     create_override
     reload_systemd

--- a/installer/install_apache_log_analysis.sh
+++ b/installer/install_apache_log_analysis.sh
@@ -77,6 +77,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -224,7 +226,7 @@ setup_log_rotation() {
 # Perform installation steps
 install() {
     check_system
-    check_commands sh cp chmod chown mkdir touch uname
+    check_commands sh cp chmod chown mkdir touch
     check_scripts
     check_sudo
     check_ssl_logs

--- a/installer/install_autoconf.sh
+++ b/installer/install_autoconf.sh
@@ -67,6 +67,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -169,7 +171,7 @@ main() {
 
     # Perform initial checks
     check_system
-    check_commands wget make tar mkdir cp rm chown uname
+    check_commands wget make tar mkdir cp rm chown
     check_sudo
 
     # Run the installation process

--- a/installer/install_awstats.sh
+++ b/installer/install_awstats.sh
@@ -58,6 +58,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -169,7 +171,7 @@ main() {
     esac
 
     check_system
-    check_commands apt-get chmod chown uname find
+    check_commands apt-get chmod chown find
     check_sudo
 
     install_awstats

--- a/installer/install_cassandra.sh
+++ b/installer/install_cassandra.sh
@@ -62,6 +62,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -177,7 +179,7 @@ main() {
     esac
 
     check_system
-    check_commands wget tar mkdir mv rm uname chown ln
+    check_commands wget tar mkdir mv rm chown ln
     check_sudo
     install_cassandra "$@"
 

--- a/installer/install_chkrootkit.sh
+++ b/installer/install_chkrootkit.sh
@@ -71,6 +71,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -146,7 +148,7 @@ initialize_baseline() {
 install() {
     # Perform initial checks
     check_system
-    check_commands cp chmod chown mkdir touch uname grep
+    check_commands cp chmod chown mkdir touch grep
     check_scripts
     check_sudo
 

--- a/installer/install_des.sh
+++ b/installer/install_des.sh
@@ -60,6 +60,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -94,7 +96,7 @@ setup_environment() {
     check_system
 
     echo "[INFO] Checking system requirements..."
-    check_commands wget md5sum tar make rm mkdir cp chown uname
+    check_commands wget md5sum tar make rm mkdir cp chown
     check_sudo
     OWNER=root:root
 }

--- a/installer/install_gdm_themes.sh
+++ b/installer/install_gdm_themes.sh
@@ -60,6 +60,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -128,7 +130,7 @@ main() {
     esac
 
     check_system
-    check_commands wget tar chown rm uname
+    check_commands wget tar chown rm
     check_sudo
     install_gdm_themes
 

--- a/installer/install_gdm_themes2.sh
+++ b/installer/install_gdm_themes2.sh
@@ -60,6 +60,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -128,7 +130,7 @@ main() {
     esac
 
     check_system
-    check_commands wget tar chown rm uname
+    check_commands wget tar chown rm
     check_sudo
     install_gdm_themes2
 

--- a/installer/install_get_resources.sh
+++ b/installer/install_get_resources.sh
@@ -72,6 +72,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -112,7 +114,7 @@ check_sudo() {
 # Perform installation steps
 install() {
     check_system
-    check_commands cp chmod chown mkdir touch uname
+    check_commands cp chmod chown mkdir touch
     check_scripts
     check_sudo
 

--- a/installer/install_google_chrome.sh
+++ b/installer/install_google_chrome.sh
@@ -73,6 +73,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -115,7 +117,7 @@ setup_environment() {
 
     echo "[INFO] Checking required commands..."
     # Verify that all external tools required by the script are available.
-    check_commands awk uname cp rm chmod mktemp curl gpg tee apt grep mkdir dpkg
+    check_commands awk cp rm chmod mktemp curl gpg tee apt grep mkdir dpkg
 
     # Verify the current user has sudo privileges for system modifications.
     check_sudo

--- a/installer/install_munin-symlink.sh
+++ b/installer/install_munin-symlink.sh
@@ -65,6 +65,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -184,7 +186,7 @@ EOF
 # Perform installation steps
 install() {
     check_system
-    check_commands chmod chown tee mkdir cp uname
+    check_commands chmod chown tee mkdir cp
     check_scripts
     check_sudo
 

--- a/installer/install_munin.sh
+++ b/installer/install_munin.sh
@@ -64,6 +64,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -149,7 +151,7 @@ main() {
     # Perform initial checks
     check_system
     check_scripts
-    check_commands sudo systemctl apt-get htpasswd cp chown chmod uname rm ln
+    check_commands sudo systemctl apt-get htpasswd cp chown chmod rm ln
 
     # Run the installation process
     install_munin

--- a/installer/install_paco.sh
+++ b/installer/install_paco.sh
@@ -71,6 +71,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -174,7 +176,7 @@ main() {
 
     # Perform initial checks
     check_system
-    check_commands wget make tar mkdir chown cp rm uname
+    check_commands wget make tar mkdir chown cp rm
     check_sudo
 
     # Run the installation process

--- a/installer/install_resin.sh
+++ b/installer/install_resin.sh
@@ -67,6 +67,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -170,7 +172,7 @@ main() {
 
     # Perform initial checks
     check_system
-    check_commands wget make unzip chown mkdir cp rm uname
+    check_commands wget make unzip chown mkdir cp rm
     check_sudo
 
     # Run the installation process

--- a/installer/install_rsync_backup.sh
+++ b/installer/install_rsync_backup.sh
@@ -83,6 +83,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -124,7 +126,7 @@ check_sudo() {
 install() {
     # Perform initial checks
     check_system
-    check_commands cp chmod chown mkdir touch uname
+    check_commands cp chmod chown mkdir touch
     check_scripts
     check_sudo
 

--- a/installer/install_talib.sh
+++ b/installer/install_talib.sh
@@ -67,6 +67,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -186,7 +188,7 @@ main() {
 
     # Perform initial checks
     check_system
-    check_commands curl make tar uname mkdir cp chown rm
+    check_commands curl make tar mkdir cp chown rm
     check_sudo
 
     # Run the installation process

--- a/installer/install_truecrypt.sh
+++ b/installer/install_truecrypt.sh
@@ -57,6 +57,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1

--- a/installer/install_veracrypt.sh
+++ b/installer/install_veracrypt.sh
@@ -57,6 +57,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1

--- a/installer/macos_finder_settings.sh
+++ b/installer/macos_finder_settings.sh
@@ -55,6 +55,8 @@ usage() {
 
 # Check if the system is macOS
 check_system() {
+    check_commands uname
+
     if [ "$(uname)" != "Darwin" ]; then
         echo "[ERROR] This script is intended for macOS only." >&2
         exit 1
@@ -114,7 +116,7 @@ main() {
     esac
 
     check_system
-    check_commands uname defaults killall
+    check_commands defaults killall
     configure_finder_settings
     return 0
 }

--- a/installer/macos_system_folder_localizations.sh
+++ b/installer/macos_system_folder_localizations.sh
@@ -55,6 +55,8 @@ usage() {
 
 # Check if the system is macOS
 check_system() {
+    check_commands uname
+
     if [ "$(uname)" != "Darwin" ]; then
         echo "[ERROR] This script is intended for macOS only." >&2
         exit 1
@@ -139,7 +141,7 @@ main() {
             ;;
         enable|disable)
             check_system
-            check_commands uname touch rm
+            check_commands touch rm
             check_sudo
             if [ "$1" = "enable" ]; then
                 enable_localization

--- a/installer/munin_plugins_links.sh
+++ b/installer/munin_plugins_links.sh
@@ -59,6 +59,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -108,7 +110,7 @@ configure_munin_plugins() {
     check_system
     check_sudo
     check_directories
-    check_commands sudo munin-node-configure chmod rm systemctl uname
+    check_commands sudo munin-node-configure chmod rm systemctl
 
     TMP_SCRIPT_DIR=${TMP:-/tmp}
     SCRIPT_NAME=$TMP_SCRIPT_DIR/create-munin-plugins-links.sh

--- a/installer/purge_apt_cache.sh
+++ b/installer/purge_apt_cache.sh
@@ -55,6 +55,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -124,7 +126,7 @@ main() {
 
     check_system
     check_debian
-    check_commands aptitude awk sed chmod rm uname grep
+    check_commands aptitude awk sed chmod rm grep
     check_sudo
     set_temp_file
     trap 'rm -f "$SCRIPT_NAME"' EXIT

--- a/installer/purge_kernels.sh
+++ b/installer/purge_kernels.sh
@@ -64,6 +64,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1

--- a/installer/remove-tracker.sh
+++ b/installer/remove-tracker.sh
@@ -76,6 +76,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -107,7 +109,7 @@ check_sudo() {
 # Initial checks and setup
 perform_initial_checks() {
     check_system
-    check_commands systemctl dpkg pgrep pkill apt uname grep apt-mark
+    check_commands systemctl dpkg pgrep pkill apt grep apt-mark
     check_sudo
 }
 

--- a/installer/set_ipv6_macos.sh
+++ b/installer/set_ipv6_macos.sh
@@ -53,6 +53,8 @@ usage() {
 
 # Check if the system is macOS
 check_system() {
+    check_commands uname
+
     if [ "$(uname)" != "Darwin" ]; then
         echo "[ERROR] This script is intended for macOS only." >&2
         exit 1
@@ -84,7 +86,7 @@ main() {
         usage
     fi
 
-    check_commands uname networksetup head tail
+    check_commands networksetup head tail
 
     # Parse arguments
     if [ "$1" = "--enable" ]; then

--- a/installer/setup_aliases.sh
+++ b/installer/setup_aliases.sh
@@ -55,6 +55,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -180,7 +182,7 @@ main() {
     esac
 
     check_system
-    check_commands sudo grep tee newaliases sed mv id truncate touch chown uname chmod rm
+    check_commands sudo grep tee newaliases sed mv id truncate touch chown chmod rm
     check_scripts
 
     SCRIPT_PATH="$SCRIPTS/usershells.py"

--- a/installer/setup_apache2_ssl.sh
+++ b/installer/setup_apache2_ssl.sh
@@ -90,6 +90,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -222,7 +224,7 @@ main() {
     esac
 
     check_system
-    check_commands make-ssl-cert a2enmod a2ensite a2dissite hostname uname mkdir cp chmod chown
+    check_commands make-ssl-cert a2enmod a2ensite a2dissite hostname mkdir cp chmod chown
     check_scripts
     check_sudo
     detect_host_fqdn

--- a/installer/setup_aptconf.sh
+++ b/installer/setup_aptconf.sh
@@ -49,6 +49,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -107,7 +109,7 @@ main() {
     esac
 
     check_system
-    check_commands cp chmod chown uname
+    check_commands cp chmod chown
     check_scripts
     check_sudo
 

--- a/installer/setup_crontab.sh
+++ b/installer/setup_crontab.sh
@@ -66,6 +66,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -131,7 +133,7 @@ main() {
     esac
 
     check_system
-    check_commands grep uname mkdir tee cut
+    check_commands grep mkdir tee cut
     check_sudo
     create_directories
     add_entry "$WEEKDAY_ENTRY"

--- a/installer/setup_dos_guard.sh
+++ b/installer/setup_dos_guard.sh
@@ -57,6 +57,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -235,7 +237,7 @@ main() {
 
     check_system
     check_scripts
-    check_commands cmp cp chmod chown mkdir a2enmod apachectl systemctl fail2ban-client uname cat rm sed
+    check_commands cmp cp chmod chown mkdir a2enmod apachectl systemctl fail2ban-client cat rm sed
     check_sudo
     resolve_sources
 

--- a/installer/setup_iptables.sh
+++ b/installer/setup_iptables.sh
@@ -58,6 +58,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -158,7 +160,7 @@ main() {
 
     check_system
     check_scripts
-    check_commands dpkg apt-get debconf-set-selections iptables-restore chmod mkdir cp systemctl uname dirname sh
+    check_commands dpkg apt-get debconf-set-selections iptables-restore chmod mkdir cp systemctl dirname sh
     check_sudo
 
     TEMPLATE_PATH="$SCRIPTS/etc/iptables/rules.v4"

--- a/installer/setup_karabiner-elements.sh
+++ b/installer/setup_karabiner-elements.sh
@@ -52,6 +52,8 @@ usage() {
 
 # Check if the system is macOS
 check_system() {
+    check_commands uname
+
     if [ "$(uname)" != "Darwin" ]; then
         echo "[ERROR] This script is intended for macOS only." >&2
         exit 1
@@ -123,7 +125,7 @@ main() {
     esac
 
     check_system
-    check_commands uname mkdir date mv cp
+    check_commands mkdir date mv cp
     check_scripts
     setup_karabiner
     return 0

--- a/installer/setup_memcached_conf.sh
+++ b/installer/setup_memcached_conf.sh
@@ -56,6 +56,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -130,7 +132,7 @@ main() {
     esac
 
     check_system
-    check_commands mv awk uname
+    check_commands mv awk
     check_sudo
     check_conf_file
 

--- a/installer/setup_motd.sh
+++ b/installer/setup_motd.sh
@@ -21,15 +21,24 @@
 #
 #  Notes:
 #  - No backups are created; the script edits /etc/motd directly if present.
-#  - The script is no-op when /etc/motd does not exist.
+#  - An absent /etc/motd is a successful no-op.
+#  - An already empty regular /etc/motd is a successful no-op.
+#  - A directory at /etc/motd is an error.
 #  - Designed for Debian-family Linux systems, but works on general Linux.
 #
 #  Requirements:
-#  - Linux operating system
-#  - sudo privileges for modifying /etc/motd
-#  - Commands: sudo, awk, sh, test
+#  - Linux system.
+#  - The invoking user must have sudo privileges.
+#
+#  Exit Status:
+#  0: Success, including an absent or already empty /etc/motd, or help/version output.
+#  1: Unsupported system, sudo failure, directory target, or clear failure.
+#  126: A required command exists but is not executable.
+#  127: A required command is not found.
 #
 #  Version History:
+#  v1.3 2026-09-08
+#       Treat an absent or already empty /etc/motd as a successful no-op.
 #  v1.2 2026-09-06
 #       Check uname before using it for system detection.
 #  v1.1 2026-07-11
@@ -87,6 +96,9 @@ check_sudo() {
 # Clear /etc/motd with file type validation
 clear_motd() {
     if [ -f "$MOTD_FILE" ]; then
+        if [ ! -s "$MOTD_FILE" ]; then
+            return 0
+        fi
         if ! sudo sh -c ": > \"$MOTD_FILE\""; then
             echo "[ERROR] Failed to clear $MOTD_FILE." >&2
             exit 1
@@ -96,8 +108,7 @@ clear_motd() {
         echo "[ERROR] $MOTD_FILE is a directory, no changes were made." >&2
         exit 1
     else
-        echo "[ERROR] $MOTD_FILE does not exist as a file or directory." >&2
-        exit 1
+        return 0
     fi
 }
 
@@ -108,7 +119,7 @@ main() {
     esac
 
     check_system
-    check_commands awk sh
+    check_commands sh
     check_sudo
     clear_motd
     return 0

--- a/installer/setup_ntp_restart_policy.sh
+++ b/installer/setup_ntp_restart_policy.sh
@@ -63,6 +63,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -184,7 +186,7 @@ main() {
     esac
 
     check_system
-    check_commands awk grep cmp mktemp mkdir mv rm chmod chown uname systemctl
+    check_commands awk grep cmp mktemp mkdir mv rm chmod chown systemctl
     check_sudo
 
     detect_services

--- a/installer/setup_pamd.sh
+++ b/installer/setup_pamd.sh
@@ -59,6 +59,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -158,7 +160,7 @@ main() {
     esac
 
     check_system
-    check_commands grep mv awk uname
+    check_commands grep mv awk
     check_sudo
     check_pam_file
 

--- a/installer/setup_python_symlink.sh
+++ b/installer/setup_python_symlink.sh
@@ -50,6 +50,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -118,11 +120,11 @@ main() {
     case "$1" in
         -h|--help|-v|--version) usage ;;
         -u|--uninstall)
-            check_environment apt-get dpkg uname grep
+            check_environment apt-get dpkg grep
             uninstall_python_symlink
             ;;
         "")
-            check_environment apt-get uname
+            check_environment apt-get
             install_python_symlink
             ;;
         *)

--- a/installer/setup_rsyslog_cron.sh
+++ b/installer/setup_rsyslog_cron.sh
@@ -67,6 +67,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -212,7 +214,7 @@ main() {
 
     check_system
     check_scripts
-    check_commands awk find grep cmp chown chmod cp mktemp rsyslogd uname rm
+    check_commands awk find grep cmp chown chmod cp mktemp rsyslogd rm
     check_sudo
     check_source_file
     check_target_dir

--- a/installer/setup_rsyslog_logrotate.sh
+++ b/installer/setup_rsyslog_logrotate.sh
@@ -135,6 +135,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -440,7 +442,7 @@ main() {
     esac
 
     check_system
-    check_commands awk cp cmp grep cat rm chown chmod mkdir systemctl uname
+    check_commands awk cp cmp grep cat rm chown chmod mkdir systemctl
     check_sudo
     check_target
     ensure_journald_dir

--- a/installer/setup_rsyslog_postfix.sh
+++ b/installer/setup_rsyslog_postfix.sh
@@ -74,6 +74,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -249,7 +251,7 @@ main() {
 
     check_system
     check_scripts
-    check_commands awk find grep cmp chown chmod cp mktemp mv rsyslogd uname rm
+    check_commands awk find grep cmp chown chmod cp mktemp mv rsyslogd rm
     check_sudo
     check_source_file
     check_target_dir

--- a/installer/setup_securetty.sh
+++ b/installer/setup_securetty.sh
@@ -18,12 +18,27 @@
 #      ./setup_securetty.sh
 #
 #  Warning:
-#  Using this script can decrease system security by allowing root access from any
-#  terminal. It should only be used when absolutely necessary and in secure environments.
-#  This script does nothing if /etc/securetty is a directory, which might be the case
-#  in some systems like macOS.
+#  - Using this script can decrease system security by allowing root access
+#    from any terminal. It should only be used when absolutely necessary and
+#    in secure environments.
+#  - This script does nothing if /etc/securetty is a directory, which might
+#    be the case in some systems like macOS.
+#  - An absent /etc/securetty is a successful no-op.
+#  - An already empty regular /etc/securetty is a successful no-op.
+#
+#  Requirements:
+#  - Linux system.
+#  - The invoking user must have sudo privileges.
+#
+#  Exit Status:
+#  0: Success, including absent, directory, or already empty no-op states, or help/version output.
+#  1: Unsupported system, sudo failure, or clear failure.
+#  126: A required command exists but is not executable.
+#  127: A required command is not found.
 #
 #  Version History:
+#  v1.9 2026-09-08
+#       Treat non-actionable or already empty /etc/securetty states as successful no-ops.
 #  v1.8 2026-09-06
 #       Check uname before using it for system detection.
 #  v1.7 2026-07-11
@@ -91,17 +106,16 @@ check_sudo() {
 # Check the type of /etc/securetty and take action
 clear_securetty() {
     if [ -f /etc/securetty ]; then
+        if [ ! -s /etc/securetty ]; then
+            return 0
+        fi
         if ! sudo sh -c ": > /etc/securetty"; then
             echo "[ERROR] Failed to clear /etc/securetty." >&2
             exit 1
         fi
         echo "[INFO] Setup completed."
-    elif [ -d /etc/securetty ]; then
-        echo "[ERROR] /etc/securetty is a directory, no changes were made." >&2
-        exit 1
     else
-        echo "[ERROR] /etc/securetty does not exist as a file or directory." >&2
-        exit 1
+        return 0
     fi
 }
 

--- a/installer/setup_tune2fs.sh
+++ b/installer/setup_tune2fs.sh
@@ -60,6 +60,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -149,7 +151,7 @@ main() {
 
     echo "[INFO] Starting tune2fs configuration..."
     check_system
-    check_commands tune2fs hostname uname seq
+    check_commands tune2fs hostname seq
     check_sudo
     HOSTNAME_S=$(hostname -s)
     echo "[INFO] Detected hostname: $HOSTNAME_S"

--- a/installer/setup_xdg_dirs_en.sh
+++ b/installer/setup_xdg_dirs_en.sh
@@ -64,6 +64,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -130,13 +132,13 @@ main() {
     check_system
 
     if [ "$SUDO_MODE" = "1" ]; then
-        check_commands apt dpkg grep uname xdg-user-dirs-gtk-update
+        check_commands apt dpkg grep xdg-user-dirs-gtk-update
         check_sudo
 
         # Install xdg-user-dirs-gtk if necessary
         install_xdg_user_dirs_gtk
     else
-        check_commands xdg-user-dirs-gtk-update uname
+        check_commands xdg-user-dirs-gtk-update
     fi
 
     # Update user directories

--- a/installer/uninstall_mecab_local.sh
+++ b/installer/uninstall_mecab_local.sh
@@ -53,6 +53,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -163,7 +165,7 @@ main() {
     fi
 
     check_system
-    check_commands rm uname
+    check_commands rm
     check_sudo
 
     echo "[INFO] Starting uninstallation process from /usr/local."

--- a/installer/vmware-rebuild-and-sign.sh
+++ b/installer/vmware-rebuild-and-sign.sh
@@ -93,6 +93,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1

--- a/test/erase_history_test.py
+++ b/test/erase_history_test.py
@@ -37,8 +37,12 @@
 #    - Detect self invocation via PATH lookup and keep it
 #    - Detect self invocation via alias names in environment and keep it
 #    - Delete the last line normally when the last entry is not self invocation
+#    - Report a missing history file as status 1.
+#    - Return success without prompting or rewriting when no removable lines exist.
 #
 #  Version History:
+#  v1.3 2026-09-08
+#       Cover missing-file failure and no-removable-line no-op behavior.
 #  v1.2 2026-02-25
 #       Update self invocation tests for path-based detection and add symlink coverage.
 #       Support alias-based self invocation via ERASE_HISTORY_SELF_NAMES.
@@ -481,6 +485,99 @@ class EraseHistoryTest(unittest.TestCase):
 
             # Remove the last line normally
             self.assertEqual("cmd1\ncmd2\n", _read_file(history_path))
+        finally:
+            try:
+                for fn in os.listdir(tmpdir):
+                    os.unlink(os.path.join(tmpdir, fn))
+            except Exception:
+                pass
+            try:
+                os.rmdir(tmpdir)
+            except Exception:
+                pass
+
+    def test_missing_history_file_reports_status_1(self):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            history_path = os.path.join(tmpdir, ".zsh_history")
+
+            with _StdCapture() as cap:
+                try:
+                    erase_history.erase_tail_lines(history_path, 1, False)
+                    self.fail("Expected SystemExit")
+                except SystemExit as e:
+                    self.assertEqual(1, e.code)
+
+            self.assertIn("History file does not exist", cap.err.getvalue())
+        finally:
+            try:
+                os.rmdir(tmpdir)
+            except Exception:
+                pass
+
+    def test_erase_nonquiet_no_removable_lines_skips_prompt_and_rewrite(self):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            history_path = os.path.join(tmpdir, ".zsh_history")
+            _write_file(history_path, [])
+
+            def _fail_input(prompt=""):
+                self.fail("input() must not be called when there are no removable lines")
+
+            def _fail_mkstemp(*args, **kwargs):
+                self.fail("tempfile.mkstemp() must not be called when there are no removable lines")
+
+            old_input = getattr(builtins, "input")
+            old_mkstemp = tempfile.mkstemp
+            setattr(builtins, "input", _fail_input)
+            tempfile.mkstemp = _fail_mkstemp
+            try:
+                with _StdCapture() as cap:
+                    erase_history.erase_tail_lines(history_path, 1, False)
+            finally:
+                setattr(builtins, "input", old_input)
+                tempfile.mkstemp = old_mkstemp
+
+            self.assertIn("[INFO] No history lines to remove.", cap.out.getvalue())
+            self.assertEqual("", cap.err.getvalue())
+            self.assertEqual("", _read_file(history_path))
+        finally:
+            try:
+                for fn in os.listdir(tmpdir):
+                    os.unlink(os.path.join(tmpdir, fn))
+            except Exception:
+                pass
+            try:
+                os.rmdir(tmpdir)
+            except Exception:
+                pass
+
+    def test_erase_quiet_no_removable_lines_is_silent(self):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            history_path = os.path.join(tmpdir, ".zsh_history")
+            _write_file(history_path, [])
+
+            def _fail_input(prompt=""):
+                self.fail("input() must not be called when there are no removable lines")
+
+            def _fail_mkstemp(*args, **kwargs):
+                self.fail("tempfile.mkstemp() must not be called when there are no removable lines")
+
+            old_input = getattr(builtins, "input")
+            old_mkstemp = tempfile.mkstemp
+            setattr(builtins, "input", _fail_input)
+            tempfile.mkstemp = _fail_mkstemp
+            try:
+                with _StdCapture() as cap:
+                    erase_history.erase_tail_lines(history_path, 1, True)
+            finally:
+                setattr(builtins, "input", old_input)
+                tempfile.mkstemp = old_mkstemp
+
+            self.assertEqual("", cap.out.getvalue())
+            self.assertEqual("", cap.err.getvalue())
+            self.assertEqual("", _read_file(history_path))
         finally:
             try:
                 for fn in os.listdir(tmpdir):

--- a/vmplayer-start.sh
+++ b/vmplayer-start.sh
@@ -60,6 +60,8 @@ usage() {
 
 # Check if the system is Linux
 check_system() {
+    check_commands uname
+
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1


### PR DESCRIPTION
## Problem

- repository policy did not distinguish successful state-converging no-ops from
  missing required resources or zero-input batch semantics precisely enough.
- several state-converging tools reported already-satisfied states as failures
  or performed unnecessary work.
- `check_system()` ownership of its `uname` prerequisite remained inconsistent
  across Shell Scripts.

## Change

- define contract/postcondition-based idempotency and no-op semantics in
  `doc/POLICY`, including the requirement that `check_sudo` remains an invocation
  prerequisite when the tool requires sudo privileges.
- align motd, securetty, Chromium cache, and history cleanup behavior with that
  policy.
- make every `check_system()` that directly uses `uname` own
  `check_commands uname`, without version bumps for ownership-only changes.

## Compatibility

- preserve zero-input failures in `gpx_sync.sh` and `sd_extract.sh`.
- preserve WARN + success behavior in `dashcam_sync.sh`, `fix_compinit.sh`, and
  `unfix_compinit.sh`.
- preserve existing sudo prerequisite checks, installer continuation, uninstall
  status semantics, and unrelated required-resource failures.

## Validation

- `sh -n` on every changed `.sh` file — syntax OK.
- `python3 check_header_doc.py -a --root .` — 0 issues across the repository.
- `SCRIPTS=$(pwd) sh test/check_scripts.sh` — 140/140 scripts pass with `-h`.
- `python3 test/erase_history_test.py` — 20/20 tests pass, including the two new
  tests (missing-file status 1; no-removable-lines no-op with no prompt and no
  temp-file/rewrite, verified via test-local patches that fail the test if
  `input()` or `tempfile.mkstemp()` are called).
- `python3 find_pycompat.py .` — exit 0, no new incompatibilities (only the
  expected `test/dummy.py` findings).
- Repository-wide mechanical scan: every `check_system()` that directly invokes
  `uname` now calls `check_commands uname` before that use (54 files); caller-side
  `check_commands`/`check_environment` lists had the now-redundant `uname` token
  removed only where no independent direct `uname` usage exists elsewhere in the
  same file (47 files) — `install_truecrypt.sh`, `install_veracrypt.sh`,
  `purge_kernels.sh`, and `vmware-rebuild-and-sign.sh` keep their caller-side
  `uname` declaration because they use `uname -m`/`uname -r` independently.
- Manual functional checks (temporary paths/HOME, a `sudo` shim that just execs
  its argument, no real `/etc` writes): `setup_motd.sh` and `setup_securetty.sh`
  against absent/empty/non-empty/directory states; `clear_chromium_cache.sh`
  against absent/present Web Data; `erase_history.py` against a missing file, an
  empty history file, and a history file whose only line is the self-invocation.
  All states matched the specified status/output contract.
- Confirmed unrelated files unchanged: `gpx_sync.sh`, `sd_extract.sh`,
  `dashcam_sync.sh`, `fix_compinit.sh`, `unfix_compinit.sh`,
  `server_alive_check.sh`, `vacuum-safari.sh`, `doc/FEATURES.md`, `README.md`.
- Confirmed the final diff touches exactly the four fixed no-op files, the
  `erase_history.py` test file, `doc/POLICY`, `doc/VERSIONS`, and the 54
  mechanically-selected `check_system`/`uname` ownership files (61 files total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01262BQ6giB2EyKZvjoHVVzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01262BQ6giB2EyKZvjoHVVzV)_