### PR TITLE
Own usage awk dependency

### DIFF
--- a/anthy_create_aa_dic.sh
+++ b/anthy_create_aa_dic.sh
@@ -37,6 +37,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/apache_log_analysis.sh
+++ b/apache_log_analysis.sh
@@ -102,6 +102,7 @@ FEED_BOT_UA_RE='(feedfetcher-google|googlebot|bingbot|yandexbot|baiduspider|duck
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/apt-upgrade.sh
+++ b/apt-upgrade.sh
@@ -47,12 +47,27 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }
         in_header && /^# ?/ { print substr($0, 3) }
     ' "$0"
     exit 0
+}
+
+# Check if required commands are available and executable
+check_commands() {
+    for cmd in "$@"; do
+        cmd_path=$(command -v "$cmd" 2>/dev/null)
+        if [ -z "$cmd_path" ]; then
+            echo "[ERROR] Command '$cmd' is not installed. Please install $cmd and try again." >&2
+            exit 127
+        elif [ ! -x "$cmd_path" ]; then
+            echo "[ERROR] Command '$cmd' is not executable. Please check the permissions." >&2
+            exit 126
+        fi
+    done
 }
 
 # Check if the user has sudo privileges (password may be required)

--- a/brew-upgrade.sh
+++ b/brew-upgrade.sh
@@ -44,12 +44,27 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }
         in_header && /^# ?/ { print substr($0, 3) }
     ' "$0"
     exit 0
+}
+
+# Check if required commands are available and executable
+check_commands() {
+    for cmd in "$@"; do
+        cmd_path=$(command -v "$cmd" 2>/dev/null)
+        if [ -z "$cmd_path" ]; then
+            echo "[ERROR] Command '$cmd' is not installed. Please install $cmd and try again." >&2
+            exit 127
+        elif [ ! -x "$cmd_path" ]; then
+            echo "[ERROR] Command '$cmd' is not executable. Please check the permissions." >&2
+            exit 126
+        fi
+    done
 }
 
 # Check if Homebrew is installed

--- a/check_reboot.sh
+++ b/check_reboot.sh
@@ -58,6 +58,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }
@@ -172,7 +173,7 @@ main() {
     esac
 
     check_system
-    check_commands awk sed id
+    check_commands sed id
 
     # Track whether any method indicates a reboot requirement.
     reboot_required=0

--- a/check_sshd_config.sh
+++ b/check_sshd_config.sh
@@ -58,6 +58,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/cleanup-junk-files.sh
+++ b/cleanup-junk-files.sh
@@ -59,6 +59,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/clear_chromium_cache.sh
+++ b/clear_chromium_cache.sh
@@ -51,12 +51,27 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }
         in_header && /^# ?/ { print substr($0, 3) }
     ' "$0"
     exit 0
+}
+
+# Check if required commands are available and executable
+check_commands() {
+    for cmd in "$@"; do
+        cmd_path=$(command -v "$cmd" 2>/dev/null)
+        if [ -z "$cmd_path" ]; then
+            echo "[ERROR] Command '$cmd' is not installed. Please install $cmd and try again." >&2
+            exit 127
+        elif [ ! -x "$cmd_path" ]; then
+            echo "[ERROR] Command '$cmd' is not executable. Please check the permissions." >&2
+            exit 126
+        fi
+    done
 }
 
 # Clear Chromium "Web Data" directory

--- a/cltmp.sh
+++ b/cltmp.sh
@@ -87,6 +87,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/dashcam_sync.sh
+++ b/dashcam_sync.sh
@@ -66,12 +66,27 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }
         in_header && /^# ?/ { print substr($0, 3) }
     ' "$0"
     exit 0
+}
+
+# Check if required commands are available and executable
+check_commands() {
+    for cmd in "$@"; do
+        cmd_path=$(command -v "$cmd" 2>/dev/null)
+        if [ -z "$cmd_path" ]; then
+            echo "[ERROR] Command '$cmd' is not installed. Please install $cmd and try again." >&2
+            exit 127
+        elif [ ! -x "$cmd_path" ]; then
+            echo "[ERROR] Command '$cmd' is not executable. Please check the permissions." >&2
+            exit 126
+        fi
+    done
 }
 
 # Determine the script's directory

--- a/doc/POLICY
+++ b/doc/POLICY
@@ -1109,8 +1109,10 @@ still comes before portability.
 - Use `check_commands` once near startup for external commands required by the
   script's normal main execution.
 - Do not list shell built-ins in `check_commands`.
-- Do not list `awk` in `check_commands` when `awk` is used only by `usage()` to
-  display the header.
+- Do not list `awk` in the normal main-execution `check_commands` call when
+  `awk` is used only by `usage()` to display the header. In the standard
+  header-extracting `usage()` function, `usage()` owns that dependency and
+  calls `check_commands awk` immediately before invoking `awk`.
 - Do not list `sudo` in `check_commands` when `check_sudo` establishes `sudo`
   availability with `sudo -v`.
 - Detect an external command used only by an optional or conditional operation
@@ -1148,6 +1150,11 @@ check_commands() {
   ownership normalization. By maintainer decision, that normalization alone
   does not bump the executable version. If the same executable has another
   behavior change, apply the normal versioning rules to that other change.
+- Moving a usage-only `awk` prerequisite into `usage()`, removing the
+  now-redundant main-execution `awk` check, or adding the standard
+  `check_commands` helper solely so that `usage()` can own that prerequisite
+  is a prerequisite ownership normalization. By maintainer decision, that
+  normalization alone does not bump the executable version.
 - Do not perform a generic network-connectivity preflight merely because a
   later operation uses the network. Apply the Network Operations policy in
   1.4.3.

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -30,6 +30,7 @@ v2.0.2 (Release Date: TBD)
 - Preserve the user's GPG keyring context when installing APT signing keys.
 - Align munin-sync installer prerequisites and Linux-only uninstall behavior.
 - Align state-converging no-op results with repository-wide idempotency rules.
+- Make usage own awk prerequisite checks across Shell Scripts.
 
 v2.0.1 (2026-08-26)
 -------------------

--- a/dpkg-hold.sh
+++ b/dpkg-hold.sh
@@ -74,6 +74,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/exif_drop.sh
+++ b/exif_drop.sh
@@ -57,6 +57,7 @@ JHEAD=jhead
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/fav-pins-on-fastladder.sh
+++ b/fav-pins-on-fastladder.sh
@@ -42,6 +42,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/filter_history.sh
+++ b/filter_history.sh
@@ -56,6 +56,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/fix_compinit.sh
+++ b/fix_compinit.sh
@@ -74,6 +74,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/fluent-start.sh
+++ b/fluent-start.sh
@@ -46,6 +46,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/get-device.sh
+++ b/get-device.sh
@@ -64,6 +64,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/get-fastladder-db.sh
+++ b/get-fastladder-db.sh
@@ -45,6 +45,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/get-feeds-from-fastladder.sh
+++ b/get-feeds-from-fastladder.sh
@@ -43,6 +43,7 @@ DBFILE="$HOME/fastladder/db/fastladder.db"
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/get-mountpoint.sh
+++ b/get-mountpoint.sh
@@ -68,6 +68,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/get-serial.sh
+++ b/get-serial.sh
@@ -54,6 +54,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/get_resources.sh
+++ b/get_resources.sh
@@ -72,12 +72,27 @@ OS_NAME=$(uname)
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }
         in_header && /^# ?/ { print substr($0, 3) }
     ' "$0"
     exit 0
+}
+
+# Check if required commands are available and executable
+check_commands() {
+    for cmd in "$@"; do
+        cmd_path=$(command -v "$cmd" 2>/dev/null)
+        if [ -z "$cmd_path" ]; then
+            echo "[ERROR] Command '$cmd' is not installed. Please install $cmd and try again." >&2
+            exit 127
+        elif [ ! -x "$cmd_path" ]; then
+            echo "[ERROR] Command '$cmd' is not executable. Please check the permissions." >&2
+            exit 126
+        fi
+    done
 }
 
 # Check if a command exists

--- a/git-all-pull.sh
+++ b/git-all-pull.sh
@@ -85,6 +85,7 @@ SHOW_HELP=false
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/git-archive-repo.sh
+++ b/git-archive-repo.sh
@@ -56,6 +56,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }
@@ -150,7 +151,7 @@ main() {
 
     SCRIPT_DIR=$(dirname "$0")
 
-    check_commands awk basename dirname rm tar
+    check_commands basename dirname rm tar
     load_configuration
 
     create_archive "$GITHUB_SRC" "$GITHUB_ARCHIVE" || exit $?

--- a/git-co-remote-branch.sh
+++ b/git-co-remote-branch.sh
@@ -51,6 +51,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/git-create-repo.sh
+++ b/git-create-repo.sh
@@ -91,6 +91,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }
@@ -241,7 +242,7 @@ parse_arguments() {
 main() {
     parse_arguments "$@"
 
-    check_commands awk git
+    check_commands git
 
     if [ "$use_sudo" = "sudo" ]; then
         check_sudo

--- a/git-follow-origin.sh
+++ b/git-follow-origin.sh
@@ -54,6 +54,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/git-symlink.sh
+++ b/git-symlink.sh
@@ -62,6 +62,7 @@ UNINSTALL=false
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/gpg-import.sh
+++ b/gpg-import.sh
@@ -71,6 +71,7 @@ dearmored_file=""
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/gpx_sync.sh
+++ b/gpx_sync.sh
@@ -108,6 +108,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/hadoop-start.sh
+++ b/hadoop-start.sh
@@ -42,12 +42,27 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }
         in_header && /^# ?/ { print substr($0, 3) }
     ' "$0"
     exit 0
+}
+
+# Check if required commands are available and executable
+check_commands() {
+    for cmd in "$@"; do
+        cmd_path=$(command -v "$cmd" 2>/dev/null)
+        if [ -z "$cmd_path" ]; then
+            echo "[ERROR] Command '$cmd' is not installed. Please install $cmd and try again." >&2
+            exit 127
+        elif [ ! -x "$cmd_path" ]; then
+            echo "[ERROR] Command '$cmd' is not executable. Please check the permissions." >&2
+            exit 126
+        fi
+    done
 }
 
 # Check if the user has sudo privileges (password may be required)

--- a/insta_sync.sh
+++ b/insta_sync.sh
@@ -85,6 +85,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/insta_update.sh
+++ b/insta_update.sh
@@ -117,6 +117,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/configure_sysctl.sh
+++ b/installer/configure_sysctl.sh
@@ -83,6 +83,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/create_emergencyadmin.sh
+++ b/installer/create_emergencyadmin.sh
@@ -38,6 +38,7 @@ FULLNAME="Emergency Admin"
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/create_ubygems.sh
+++ b/installer/create_ubygems.sh
@@ -60,6 +60,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/disable_freshclam_syslog.sh
+++ b/installer/disable_freshclam_syslog.sh
@@ -47,6 +47,7 @@ OVERRIDE_FILE="$OVERRIDE_DIR/override.conf"
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_R_libs.sh
+++ b/installer/install_R_libs.sh
@@ -40,12 +40,27 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }
         in_header && /^# ?/ { print substr($0, 3) }
     ' "$0"
     exit 0
+}
+
+# Check if required commands are available and executable
+check_commands() {
+    for cmd in "$@"; do
+        cmd_path=$(command -v "$cmd" 2>/dev/null)
+        if [ -z "$cmd_path" ]; then
+            echo "[ERROR] Command '$cmd' is not installed. Please install $cmd and try again." >&2
+            exit 127
+        elif [ ! -x "$cmd_path" ]; then
+            echo "[ERROR] Command '$cmd' is not executable. Please check the permissions." >&2
+            exit 126
+        fi
+    done
 }
 
 # Check if R is installed

--- a/installer/install_apache_log_analysis.sh
+++ b/installer/install_apache_log_analysis.sh
@@ -67,6 +67,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_autoconf.sh
+++ b/installer/install_autoconf.sh
@@ -57,6 +57,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_awstats.sh
+++ b/installer/install_awstats.sh
@@ -48,6 +48,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_brews.sh
+++ b/installer/install_brews.sh
@@ -63,6 +63,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_cassandra.sh
+++ b/installer/install_cassandra.sh
@@ -52,6 +52,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_chkrootkit.sh
+++ b/installer/install_chkrootkit.sh
@@ -61,6 +61,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_clamscan.sh
+++ b/installer/install_clamscan.sh
@@ -66,6 +66,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_conda.sh
+++ b/installer/install_conda.sh
@@ -66,6 +66,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_des.sh
+++ b/installer/install_des.sh
@@ -50,6 +50,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_dotfiles.sh
+++ b/installer/install_dotfiles.sh
@@ -72,6 +72,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_dotvim.sh
+++ b/installer/install_dotvim.sh
@@ -62,6 +62,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_fix-permissions.sh
+++ b/installer/install_fix-permissions.sh
@@ -76,6 +76,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_gdm_themes.sh
+++ b/installer/install_gdm_themes.sh
@@ -50,6 +50,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_gdm_themes2.sh
+++ b/installer/install_gdm_themes2.sh
@@ -50,6 +50,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_gems.sh
+++ b/installer/install_gems.sh
@@ -71,6 +71,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_get_resources.sh
+++ b/installer/install_get_resources.sh
@@ -62,6 +62,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_google_chrome.sh
+++ b/installer/install_google_chrome.sh
@@ -63,6 +63,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_mecab-stack.sh
+++ b/installer/install_mecab-stack.sh
@@ -112,6 +112,7 @@ SAVE_SOURCE=1
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_munin-symlink.sh
+++ b/installer/install_munin-symlink.sh
@@ -55,6 +55,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_munin-sync.sh
+++ b/installer/install_munin-sync.sh
@@ -83,6 +83,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_munin.sh
+++ b/installer/install_munin.sh
@@ -54,6 +54,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_ncurses.sh
+++ b/installer/install_ncurses.sh
@@ -67,6 +67,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_paco.sh
+++ b/installer/install_paco.sh
@@ -61,6 +61,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_pip.sh
+++ b/installer/install_pip.sh
@@ -70,6 +70,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_python.sh
+++ b/installer/install_python.sh
@@ -66,6 +66,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_resin.sh
+++ b/installer/install_resin.sh
@@ -57,6 +57,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_rsync_backup.sh
+++ b/installer/install_rsync_backup.sh
@@ -73,6 +73,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_ruby.sh
+++ b/installer/install_ruby.sh
@@ -66,6 +66,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_run_tests.sh
+++ b/installer/install_run_tests.sh
@@ -70,6 +70,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_talib.sh
+++ b/installer/install_talib.sh
@@ -57,6 +57,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_truecrypt.sh
+++ b/installer/install_truecrypt.sh
@@ -47,6 +47,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_veracrypt.sh
+++ b/installer/install_veracrypt.sh
@@ -47,6 +47,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/install_zsh.sh
+++ b/installer/install_zsh.sh
@@ -70,6 +70,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/macos_finder_settings.sh
+++ b/installer/macos_finder_settings.sh
@@ -45,6 +45,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/macos_setup.sh
+++ b/installer/macos_setup.sh
@@ -71,6 +71,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/macos_system_folder_localizations.sh
+++ b/installer/macos_system_folder_localizations.sh
@@ -45,6 +45,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/munin_plugins_links.sh
+++ b/installer/munin_plugins_links.sh
@@ -49,6 +49,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/purge_apt_cache.sh
+++ b/installer/purge_apt_cache.sh
@@ -45,6 +45,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/purge_kernels.sh
+++ b/installer/purge_kernels.sh
@@ -54,6 +54,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/reinstall_brew.sh
+++ b/installer/reinstall_brew.sh
@@ -68,6 +68,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/remove-tracker.sh
+++ b/installer/remove-tracker.sh
@@ -66,6 +66,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/set_ipv6_macos.sh
+++ b/installer/set_ipv6_macos.sh
@@ -43,6 +43,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/setup_aliases.sh
+++ b/installer/setup_aliases.sh
@@ -45,6 +45,7 @@ ALIASES_FILE="/etc/aliases"
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/setup_apache2_ssl.sh
+++ b/installer/setup_apache2_ssl.sh
@@ -80,6 +80,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/setup_aptconf.sh
+++ b/installer/setup_aptconf.sh
@@ -39,6 +39,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/setup_crontab.sh
+++ b/installer/setup_crontab.sh
@@ -56,6 +56,7 @@ CHANGES_MADE=0
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/setup_dos_guard.sh
+++ b/installer/setup_dos_guard.sh
@@ -47,6 +47,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/setup_dot_ipython.sh
+++ b/installer/setup_dot_ipython.sh
@@ -60,6 +60,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/setup_iptables.sh
+++ b/installer/setup_iptables.sh
@@ -48,6 +48,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/setup_jupyter_themes.sh
+++ b/installer/setup_jupyter_themes.sh
@@ -45,6 +45,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/setup_karabiner-elements.sh
+++ b/installer/setup_karabiner-elements.sh
@@ -42,6 +42,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/setup_memcached_conf.sh
+++ b/installer/setup_memcached_conf.sh
@@ -46,6 +46,7 @@ CONF_FILE="/etc/memcached.conf"
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/setup_motd.sh
+++ b/installer/setup_motd.sh
@@ -53,6 +53,7 @@ MOTD_FILE="/etc/motd"
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/setup_ntp_restart_policy.sh
+++ b/installer/setup_ntp_restart_policy.sh
@@ -53,6 +53,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/setup_nvim.sh
+++ b/installer/setup_nvim.sh
@@ -43,6 +43,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/setup_pamd.sh
+++ b/installer/setup_pamd.sh
@@ -49,6 +49,7 @@ PAM_FILE="/etc/pam.d/su"
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/setup_python_symlink.sh
+++ b/installer/setup_python_symlink.sh
@@ -40,6 +40,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/setup_rsyslog_cron.sh
+++ b/installer/setup_rsyslog_cron.sh
@@ -57,6 +57,7 @@ TARGET_FILE="$TARGET_DIR/10-cron.conf"
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }
@@ -214,7 +215,7 @@ main() {
 
     check_system
     check_scripts
-    check_commands awk find grep cmp chown chmod cp mktemp rsyslogd rm
+    check_commands find grep cmp chown chmod cp mktemp rsyslogd rm
     check_sudo
     check_source_file
     check_target_dir

--- a/installer/setup_rsyslog_logrotate.sh
+++ b/installer/setup_rsyslog_logrotate.sh
@@ -125,6 +125,7 @@ JOURNALD_DROPIN="${JOURNALD_DIR}/99-storage-limits.conf"
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/setup_rsyslog_postfix.sh
+++ b/installer/setup_rsyslog_postfix.sh
@@ -64,6 +64,7 @@ RENAME_DONE=0
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }
@@ -251,7 +252,7 @@ main() {
 
     check_system
     check_scripts
-    check_commands awk find grep cmp chown chmod cp mktemp mv rsyslogd rm
+    check_commands find grep cmp chown chmod cp mktemp mv rsyslogd rm
     check_sudo
     check_source_file
     check_target_dir

--- a/installer/setup_securetty.sh
+++ b/installer/setup_securetty.sh
@@ -63,6 +63,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/setup_sysadmin_scripts.sh
+++ b/installer/setup_sysadmin_scripts.sh
@@ -93,6 +93,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/setup_tune2fs.sh
+++ b/installer/setup_tune2fs.sh
@@ -50,6 +50,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/setup_xdg_dirs_en.sh
+++ b/installer/setup_xdg_dirs_en.sh
@@ -54,6 +54,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/uninstall_mecab_local.sh
+++ b/installer/uninstall_mecab_local.sh
@@ -43,6 +43,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/installer/vmware-rebuild-and-sign.sh
+++ b/installer/vmware-rebuild-and-sign.sh
@@ -83,6 +83,7 @@ SIGN_FILE_PRIMARY="/usr/src/linux-headers-$KVER/scripts/sign-file"
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/platex2pdf.sh
+++ b/platex2pdf.sh
@@ -47,6 +47,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/put-fastladder-db.sh
+++ b/put-fastladder-db.sh
@@ -45,6 +45,7 @@ HOST="${2:-harpuia}"
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/remove-repo.sh
+++ b/remove-repo.sh
@@ -52,12 +52,27 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }
         in_header && /^# ?/ { print substr($0, 3) }
     ' "$0"
     exit 0
+}
+
+# Check if required commands are available and executable
+check_commands() {
+    for cmd in "$@"; do
+        cmd_path=$(command -v "$cmd" 2>/dev/null)
+        if [ -z "$cmd_path" ]; then
+            echo "[ERROR] Command '$cmd' is not installed. Please install $cmd and try again." >&2
+            exit 127
+        elif [ ! -x "$cmd_path" ]; then
+            echo "[ERROR] Command '$cmd' is not executable. Please check the permissions." >&2
+            exit 126
+        fi
+    done
 }
 
 # Check if a directory is a Git repository.

--- a/remove_space_eol.sh
+++ b/remove_space_eol.sh
@@ -45,6 +45,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/restart-sshd.sh
+++ b/restart-sshd.sh
@@ -54,12 +54,27 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }
         in_header && /^# ?/ { print substr($0, 3) }
     ' "$0"
     exit 0
+}
+
+# Check if required commands are available and executable
+check_commands() {
+    for cmd in "$@"; do
+        cmd_path=$(command -v "$cmd" 2>/dev/null)
+        if [ -z "$cmd_path" ]; then
+            echo "[ERROR] Command '$cmd' is not installed. Please install $cmd and try again." >&2
+            exit 127
+        elif [ ! -x "$cmd_path" ]; then
+            echo "[ERROR] Command '$cmd' is not executable. Please check the permissions." >&2
+            exit 126
+        fi
+    done
 }
 
 # Check if the user has sudo privileges (password may be required)

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -76,12 +76,27 @@ export PYTHONDONTWRITEBYTECODE=1
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }
         in_header && /^# ?/ { print substr($0, 3) }
     ' "$0"
     exit 0
+}
+
+# Check if required commands are available and executable
+check_commands() {
+    for cmd in "$@"; do
+        cmd_path=$(command -v "$cmd" 2>/dev/null)
+        if [ -z "$cmd_path" ]; then
+            echo "[ERROR] Command '$cmd' is not installed. Please install $cmd and try again." >&2
+            exit 127
+        elif [ ! -x "$cmd_path" ]; then
+            echo "[ERROR] Command '$cmd' is not executable. Please check the permissions." >&2
+            exit 126
+        fi
+    done
 }
 
 # Check if the SCRIPTS variable is unset or empty

--- a/sd_extract.sh
+++ b/sd_extract.sh
@@ -83,6 +83,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/send_files.sh
+++ b/send_files.sh
@@ -86,6 +86,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/server_alive_check.sh
+++ b/server_alive_check.sh
@@ -112,6 +112,7 @@ STALE_THRESHOLD=600
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/setup_scripts.sh
+++ b/setup_scripts.sh
@@ -78,6 +78,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/test/check_scripts.sh
+++ b/test/check_scripts.sh
@@ -62,6 +62,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/tree.sh
+++ b/tree.sh
@@ -53,6 +53,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/unfix_compinit.sh
+++ b/unfix_compinit.sh
@@ -73,6 +73,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/vacuum-fastladder-db.sh
+++ b/vacuum-fastladder-db.sh
@@ -53,6 +53,7 @@ DB_PATH="$DB_DIR/fastladder.db"
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/vacuum-safari.sh
+++ b/vacuum-safari.sh
@@ -39,12 +39,27 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }
         in_header && /^# ?/ { print substr($0, 3) }
     ' "$0"
     exit 0
+}
+
+# Check if required commands are available and executable
+check_commands() {
+    for cmd in "$@"; do
+        cmd_path=$(command -v "$cmd" 2>/dev/null)
+        if [ -z "$cmd_path" ]; then
+            echo "[ERROR] Command '$cmd' is not installed. Please install $cmd and try again." >&2
+            exit 127
+        elif [ ! -x "$cmd_path" ]; then
+            echo "[ERROR] Command '$cmd' is not executable. Please check the permissions." >&2
+            exit 126
+        fi
+    done
 }
 
 # Check if sqlite3 command is available

--- a/vmplayer-start.sh
+++ b/vmplayer-start.sh
@@ -50,6 +50,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }

--- a/xmap.sh
+++ b/xmap.sh
@@ -33,6 +33,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }


### PR DESCRIPTION
## Problem

- standard `usage()` directly invokes `awk`.
- a missing `awk` can fail before the unconditional `exit 0`, hiding the missing
  prerequisite behind a successful process status.
- ownership is inconsistent with the repository rule that a helper owns the
  external commands it directly uses.

## Change

- make every standard header-extracting `usage()` call `check_commands awk`
  immediately before `awk`, with no blank line between them.
- remove `awk` from normal main prerequisite lists only where its only use is
  `usage()`.
- add the repository-standard `check_commands()` helper where a target script
  does not already have it.
- make the ownership and no-version rule permanent in `doc/POLICY`.

## Compatibility

- keep normal help/version output and status 0 when `awk` is usable.
- keep independent main-execution `awk` prerequisites where they are actually
  needed.
- do not change any executable or test version.
- do not change business logic, installer continuation, sudo checks, system
  checks, or configuration semantics.
- excludes the deployed/auto-managed scripts under `cron/bin/`.
- excludes the `installer/debian_*.sh` Debian setup family, since those run
  during initial/minimal Debian installation where `awk` availability is not
  guaranteed at that point in the setup sequence.

## Validation

- Target inventory: mechanically scanned the tree for the standard
  header-extraction `usage()` signature — 141 files matched the pattern (135
  `.sh` files plus 6 extensionless `cron/bin/*` copies). Excluded from this
  change: the 11 files under `cron/bin/` and the 9 `installer/debian_*.sh`
  files, leaving 121 target files. None of the 121 already owned
  `check_commands awk`. Some lacked a `check_commands()` helper entirely and
  had it added; some had `awk` in a main-execution `check_commands`/
  `check_environment` list, kept where `awk` is used independently elsewhere
  in the file and removed where its only use is `usage()`.
- `sh -n` on all 121 target files — syntax OK.
- `python3 check_header_doc.py -a --root .` — 0 issues across the repository.
- `SCRIPTS=$(pwd) sh test/check_scripts.sh` — 140/140 scripts pass with `-h`.
- Missing-awk representative smoke (temporary PATH shim excluding `awk`, not
  committed): `check_reboot.sh` (pre-existing `check_commands()`) and
  `clear_chromium_cache.sh` (newly added `check_commands()`) both `-h` with
  status 127, the standard `[ERROR] Command 'awk' is not installed...`
  message, no usage header output, and no shell-generated "not found" error.
- Ordinary help/version smoke with `awk` on `PATH`: same two files, `-h` and
  `--version` produce identical, unchanged usage output at status 0.
- Version/history invariant: grepped every changed file's diff for
  added/removed `#  vX.Y` lines — zero matches; no executable or test version
  or Version History entry changed.
- Final diff scope: exactly the 121 target files plus `doc/POLICY` and
  `doc/VERSIONS` (123 files); confirmed `README.md`, `doc/FEATURES.md`,
  everything under `cron/bin/`, and every `installer/debian_*.sh` file are
  unchanged, and no new trailing whitespace was introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01262BQ6giB2EyKZvjoHVVzV