### PR TITLE
Normalize common Shell Script prerequisite helpers

### DIFF
--- a/anthy_create_aa_dic.sh
+++ b/anthy_create_aa_dic.sh
@@ -49,7 +49,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1

--- a/apt-upgrade.sh
+++ b/apt-upgrade.sh
@@ -72,6 +72,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/check_reboot.sh
+++ b/check_reboot.sh
@@ -70,7 +70,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1

--- a/check_sshd_config.sh
+++ b/check_sshd_config.sh
@@ -83,6 +83,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/doc/POLICY
+++ b/doc/POLICY
@@ -1113,8 +1113,9 @@ still comes before portability.
   `awk` is used only by `usage()` to display the header. In the standard
   header-extracting `usage()` function, `usage()` owns that dependency and
   calls `check_commands awk` immediately before invoking `awk`.
-- Do not list `sudo` in `check_commands` when `check_sudo` establishes `sudo`
-  availability with `sudo -v`.
+- Do not list `sudo` in the normal main-execution `check_commands` call when
+  `check_sudo` owns that dependency. `check_sudo` calls `check_commands sudo`
+  immediately before invoking `sudo -v`.
 - Detect an external command used only by an optional or conditional operation
   at the point where that operation is selected.
 - Use the following POSIX-compliant helper for commands checked through
@@ -1155,6 +1156,9 @@ check_commands() {
   `check_commands` helper solely so that `usage()` can own that prerequisite
   is a prerequisite ownership normalization. By maintainer decision, that
   normalization alone does not bump the executable version.
+- Adding `check_commands sudo` at the start of `check_sudo` is a prerequisite
+  ownership normalization. By maintainer decision, that normalization alone
+  does not bump the executable version.
 - Do not perform a generic network-connectivity preflight merely because a
   later operation uses the network. Apply the Network Operations policy in
   1.4.3.

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -22,7 +22,8 @@ v2.0.2 (Release Date: TBD)
   starting installation.
 - Make setup_scripts.sh preserve failures from both configured-collection and
   current-directory execute-permission passes.
-- Make check_system own uname prerequisite checks across Shell Scripts.
+- Make usage, check_system, and check_sudo own awk, uname, and sudo
+  prerequisite checks across Shell Scripts.
 - Align ClamAV cron deployment with its tracked definition and remove the deployed
   wrapper on uninstall.
 - Fix setup_sysadmin_scripts.sh usage examples and prerequisite error output.
@@ -30,7 +31,6 @@ v2.0.2 (Release Date: TBD)
 - Preserve the user's GPG keyring context when installing APT signing keys.
 - Align munin-sync installer prerequisites and Linux-only uninstall behavior.
 - Align state-converging no-op results with repository-wide idempotency rules.
-- Make usage own awk prerequisite checks across Shell Scripts.
 - Align munin-sync runtime and installer contracts for silent cron operation,
   unsupported arguments, and deployment permission failures.
 

--- a/dpkg-hold.sh
+++ b/dpkg-hold.sh
@@ -86,7 +86,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -109,6 +108,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/fix_compinit.sh
+++ b/fix_compinit.sh
@@ -86,7 +86,6 @@ usage() {
 # Check if the system is macOS
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Darwin" ]; then
         echo "[ERROR] This script is intended for macOS only." >&2
         exit 1
@@ -109,6 +108,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/get-device.sh
+++ b/get-device.sh
@@ -76,7 +76,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1

--- a/get-mountpoint.sh
+++ b/get-mountpoint.sh
@@ -80,7 +80,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1

--- a/get-serial.sh
+++ b/get-serial.sh
@@ -66,7 +66,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1

--- a/git-create-repo.sh
+++ b/git-create-repo.sh
@@ -102,6 +102,7 @@ usage() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/gpg-import.sh
+++ b/gpg-import.sh
@@ -83,7 +83,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -106,6 +105,7 @@ check_user() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/hadoop-start.sh
+++ b/hadoop-start.sh
@@ -67,6 +67,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/configure_sysctl.sh
+++ b/installer/configure_sysctl.sh
@@ -95,7 +95,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -104,6 +103,7 @@ check_system() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/create_emergencyadmin.sh
+++ b/installer/create_emergencyadmin.sh
@@ -50,7 +50,6 @@ usage() {
 # Check if the system is macOS
 check_system() {
     check_commands uname
-
     if [ "$(uname)" != "Darwin" ]; then
         echo "[ERROR] This script is intended for macOS only." >&2
         exit 1
@@ -73,6 +72,7 @@ check_commands() {
 
 # Check if the user has sudo privileges
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/debian_apt.sh
+++ b/installer/debian_apt.sh
@@ -107,6 +107,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }
@@ -117,6 +118,7 @@ usage() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/debian_desktop_apt.sh
+++ b/installer/debian_desktop_apt.sh
@@ -89,6 +89,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }
@@ -100,7 +101,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     os="$(uname -s 2>/dev/null)"
     if [ "$os" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
@@ -110,6 +110,7 @@ check_system() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/debian_desktop_setup.sh
+++ b/installer/debian_desktop_setup.sh
@@ -48,12 +48,27 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }
         in_header && /^# ?/ { print substr($0, 3) }
     ' "$0"
     exit 0
+}
+
+# Check if required commands are available and executable
+check_commands() {
+    for cmd in "$@"; do
+        cmd_path=$(command -v "$cmd" 2>/dev/null)
+        if [ -z "$cmd_path" ]; then
+            echo "[ERROR] Command '$cmd' is not installed. Please install $cmd and try again." >&2
+            exit 127
+        elif [ ! -x "$cmd_path" ]; then
+            echo "[ERROR] Command '$cmd' is not executable. Please check the permissions." >&2
+            exit 126
+        fi
+    done
 }
 
 # Verify script environment

--- a/installer/debian_env.sh
+++ b/installer/debian_env.sh
@@ -61,6 +61,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }
@@ -102,6 +103,7 @@ check_commands() {
 
 # Check if the user has sudo privileges
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/debian_gnome_flashback_setup.sh
+++ b/installer/debian_gnome_flashback_setup.sh
@@ -73,6 +73,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }
@@ -84,7 +85,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     os="$(uname -s 2>/dev/null)"
     if [ "$os" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2

--- a/installer/debian_gnome_setup.sh
+++ b/installer/debian_gnome_setup.sh
@@ -53,6 +53,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }
@@ -64,7 +65,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     os="$(uname -s 2>/dev/null)"
     if [ "$os" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2

--- a/installer/debian_init.sh
+++ b/installer/debian_init.sh
@@ -81,6 +81,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }
@@ -92,7 +93,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1

--- a/installer/debian_setup.sh
+++ b/installer/debian_setup.sh
@@ -97,6 +97,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }
@@ -108,7 +109,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -140,6 +140,7 @@ setup_environment() {
 
 # Check if the user has sudo privileges
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/debian_xfce_setup.sh
+++ b/installer/debian_xfce_setup.sh
@@ -58,6 +58,7 @@
 
 # Display full script header information extracted from the top comment block
 usage() {
+    check_commands awk
     awk '
         BEGIN { in_header = 0 }
         /^#+$/ && length($0) >= 10 { if (!in_header) { in_header = 1; next } else exit }
@@ -69,7 +70,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     os="$(uname -s 2>/dev/null)"
     if [ "$os" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2

--- a/installer/disable_freshclam_syslog.sh
+++ b/installer/disable_freshclam_syslog.sh
@@ -59,7 +59,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -68,6 +67,7 @@ check_system() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/install_R_libs.sh
+++ b/installer/install_R_libs.sh
@@ -89,6 +89,7 @@ check_config() {
 
 # Check if the user has sudo privileges
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/install_apache_log_analysis.sh
+++ b/installer/install_apache_log_analysis.sh
@@ -79,7 +79,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -111,6 +110,7 @@ check_scripts() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/install_autoconf.sh
+++ b/installer/install_autoconf.sh
@@ -69,7 +69,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -92,6 +91,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/install_awstats.sh
+++ b/installer/install_awstats.sh
@@ -60,7 +60,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -83,6 +82,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/install_brews.sh
+++ b/installer/install_brews.sh
@@ -75,7 +75,6 @@ usage() {
 # Check if the system is macOS
 check_system() {
     check_commands uname
-
     if [ "$(uname)" != "Darwin" ]; then
         echo "[ERROR] This script is intended for macOS only." >&2
         exit 1

--- a/installer/install_cassandra.sh
+++ b/installer/install_cassandra.sh
@@ -64,7 +64,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -87,6 +86,7 @@ check_commands() {
 
 # Check if the user has sudo privileges
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/install_chkrootkit.sh
+++ b/installer/install_chkrootkit.sh
@@ -73,7 +73,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -105,6 +104,7 @@ check_scripts() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/install_clamscan.sh
+++ b/installer/install_clamscan.sh
@@ -78,7 +78,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -109,6 +108,7 @@ check_scripts() {
 
 # Check if the user has sudo privileges
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/install_des.sh
+++ b/installer/install_des.sh
@@ -62,7 +62,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -85,6 +84,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/install_dotfiles.sh
+++ b/installer/install_dotfiles.sh
@@ -83,6 +83,7 @@ usage() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/install_fix-permissions.sh
+++ b/installer/install_fix-permissions.sh
@@ -88,7 +88,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -120,6 +119,7 @@ check_scripts() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/install_gdm_themes.sh
+++ b/installer/install_gdm_themes.sh
@@ -62,7 +62,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -85,6 +84,7 @@ check_commands() {
 
 # Check if the user has sudo privileges
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/install_gdm_themes2.sh
+++ b/installer/install_gdm_themes2.sh
@@ -62,7 +62,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -85,6 +84,7 @@ check_commands() {
 
 # Check if the user has sudo privileges
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/install_get_resources.sh
+++ b/installer/install_get_resources.sh
@@ -74,7 +74,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -106,6 +105,7 @@ check_scripts() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/install_google_chrome.sh
+++ b/installer/install_google_chrome.sh
@@ -75,7 +75,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -98,6 +97,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/install_mecab-stack.sh
+++ b/installer/install_mecab-stack.sh
@@ -147,6 +147,7 @@ check_commands() {
 
 # Check if the user has sudo privileges
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/install_munin-symlink.sh
+++ b/installer/install_munin-symlink.sh
@@ -67,7 +67,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -98,6 +97,7 @@ check_scripts() {
 
 # Check if the user has sudo privileges
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/install_munin-sync.sh
+++ b/installer/install_munin-sync.sh
@@ -97,7 +97,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -128,6 +127,7 @@ check_scripts() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/install_munin.sh
+++ b/installer/install_munin.sh
@@ -66,7 +66,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1

--- a/installer/install_ncurses.sh
+++ b/installer/install_ncurses.sh
@@ -92,6 +92,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if [ "$SUDO" = "sudo" ] && ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access or specify 'no-sudo'." >&2
         exit 1

--- a/installer/install_paco.sh
+++ b/installer/install_paco.sh
@@ -73,7 +73,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -96,6 +95,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/install_python.sh
+++ b/installer/install_python.sh
@@ -91,6 +91,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if [ "$SUDO" = "sudo" ] && ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access or specify 'no-sudo'." >&2
         exit 1

--- a/installer/install_resin.sh
+++ b/installer/install_resin.sh
@@ -69,7 +69,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -92,6 +91,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/install_rsync_backup.sh
+++ b/installer/install_rsync_backup.sh
@@ -85,7 +85,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -117,6 +116,7 @@ check_scripts() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/install_ruby.sh
+++ b/installer/install_ruby.sh
@@ -91,6 +91,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if [ "$SUDO" = "sudo" ] && ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access or specify 'no-sudo'." >&2
         exit 1

--- a/installer/install_run_tests.sh
+++ b/installer/install_run_tests.sh
@@ -82,7 +82,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -105,6 +104,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/install_talib.sh
+++ b/installer/install_talib.sh
@@ -69,7 +69,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -92,6 +91,7 @@ check_commands() {
 
 # Check if user has sudo privileges
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/install_truecrypt.sh
+++ b/installer/install_truecrypt.sh
@@ -59,7 +59,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -82,6 +81,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/install_veracrypt.sh
+++ b/installer/install_veracrypt.sh
@@ -59,7 +59,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -82,6 +81,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/install_zsh.sh
+++ b/installer/install_zsh.sh
@@ -95,6 +95,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if [ "$SUDO" = "sudo" ] && ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access or specify 'no-sudo'." >&2
         exit 1

--- a/installer/macos_finder_settings.sh
+++ b/installer/macos_finder_settings.sh
@@ -57,7 +57,6 @@ usage() {
 # Check if the system is macOS
 check_system() {
     check_commands uname
-
     if [ "$(uname)" != "Darwin" ]; then
         echo "[ERROR] This script is intended for macOS only." >&2
         exit 1

--- a/installer/macos_setup.sh
+++ b/installer/macos_setup.sh
@@ -83,7 +83,6 @@ usage() {
 # Check if the system is macOS
 check_system() {
     check_commands uname
-
     if [ "$(uname)" != "Darwin" ]; then
         echo "[ERROR] This script is intended for macOS only." >&2
         exit 1
@@ -115,6 +114,7 @@ setup_environment() {
 
 # Check if the user has sudo privileges
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/macos_system_folder_localizations.sh
+++ b/installer/macos_system_folder_localizations.sh
@@ -57,7 +57,6 @@ usage() {
 # Check if the system is macOS
 check_system() {
     check_commands uname
-
     if [ "$(uname)" != "Darwin" ]; then
         echo "[ERROR] This script is intended for macOS only." >&2
         exit 1
@@ -66,6 +65,7 @@ check_system() {
 
 # Check if the user has sudo privileges
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges for system directories." >&2
         exit 1

--- a/installer/munin_plugins_links.sh
+++ b/installer/munin_plugins_links.sh
@@ -61,7 +61,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -84,6 +83,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/purge_apt_cache.sh
+++ b/installer/purge_apt_cache.sh
@@ -57,7 +57,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -88,6 +87,7 @@ check_commands() {
 
 # Check if the user has sudo privileges
 check_sudo() {
+    check_commands sudo
     if ! sudo -v >/dev/null 2>&1; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/purge_kernels.sh
+++ b/installer/purge_kernels.sh
@@ -66,7 +66,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -97,6 +96,7 @@ check_commands() {
 
 # Check if the user has sudo privileges
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/reinstall_brew.sh
+++ b/installer/reinstall_brew.sh
@@ -80,7 +80,6 @@ usage() {
 # Check if the system is macOS
 check_system() {
     check_commands uname
-
     if [ "$(uname)" != "Darwin" ]; then
         echo "[ERROR] This script is intended for macOS only." >&2
         exit 1
@@ -111,6 +110,7 @@ check_scripts() {
 
 # Check if the user has sudo privileges
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges." >&2
         exit 1

--- a/installer/remove-tracker.sh
+++ b/installer/remove-tracker.sh
@@ -78,7 +78,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -101,6 +100,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/set_ipv6_macos.sh
+++ b/installer/set_ipv6_macos.sh
@@ -55,7 +55,6 @@ usage() {
 # Check if the system is macOS
 check_system() {
     check_commands uname
-
     if [ "$(uname)" != "Darwin" ]; then
         echo "[ERROR] This script is intended for macOS only." >&2
         exit 1

--- a/installer/setup_aliases.sh
+++ b/installer/setup_aliases.sh
@@ -57,7 +57,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -96,6 +95,7 @@ check_script() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/setup_apache2_ssl.sh
+++ b/installer/setup_apache2_ssl.sh
@@ -92,7 +92,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -124,6 +123,7 @@ check_scripts() {
 
 # Check if the user has sudo privileges
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/setup_aptconf.sh
+++ b/installer/setup_aptconf.sh
@@ -51,7 +51,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -83,6 +82,7 @@ check_scripts() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/setup_crontab.sh
+++ b/installer/setup_crontab.sh
@@ -68,7 +68,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -91,6 +90,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/setup_dos_guard.sh
+++ b/installer/setup_dos_guard.sh
@@ -59,7 +59,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -91,6 +90,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/setup_iptables.sh
+++ b/installer/setup_iptables.sh
@@ -60,7 +60,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -77,6 +76,7 @@ check_scripts() {
 
 # Check if the user has sudo privileges
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/setup_jupyter_themes.sh
+++ b/installer/setup_jupyter_themes.sh
@@ -70,6 +70,7 @@ check_commands() {
 
 # Check if the user has sudo privileges
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges." >&2
         exit 1

--- a/installer/setup_karabiner-elements.sh
+++ b/installer/setup_karabiner-elements.sh
@@ -54,7 +54,6 @@ usage() {
 # Check if the system is macOS
 check_system() {
     check_commands uname
-
     if [ "$(uname)" != "Darwin" ]; then
         echo "[ERROR] This script is intended for macOS only." >&2
         exit 1

--- a/installer/setup_memcached_conf.sh
+++ b/installer/setup_memcached_conf.sh
@@ -58,7 +58,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -81,6 +80,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/setup_motd.sh
+++ b/installer/setup_motd.sh
@@ -65,7 +65,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -88,6 +87,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/setup_ntp_restart_policy.sh
+++ b/installer/setup_ntp_restart_policy.sh
@@ -65,7 +65,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -88,6 +87,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/setup_pamd.sh
+++ b/installer/setup_pamd.sh
@@ -61,7 +61,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -84,6 +83,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/setup_python_symlink.sh
+++ b/installer/setup_python_symlink.sh
@@ -52,7 +52,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -61,6 +60,7 @@ check_system() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/setup_rsyslog_cron.sh
+++ b/installer/setup_rsyslog_cron.sh
@@ -69,7 +69,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -101,6 +100,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/setup_rsyslog_logrotate.sh
+++ b/installer/setup_rsyslog_logrotate.sh
@@ -137,7 +137,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -160,6 +159,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/setup_rsyslog_postfix.sh
+++ b/installer/setup_rsyslog_postfix.sh
@@ -76,7 +76,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -108,6 +107,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/setup_securetty.sh
+++ b/installer/setup_securetty.sh
@@ -75,7 +75,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -98,6 +97,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/setup_sysadmin_scripts.sh
+++ b/installer/setup_sysadmin_scripts.sh
@@ -104,6 +104,7 @@ usage() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/setup_tune2fs.sh
+++ b/installer/setup_tune2fs.sh
@@ -62,7 +62,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -71,6 +70,7 @@ check_system() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/setup_xdg_dirs_en.sh
+++ b/installer/setup_xdg_dirs_en.sh
@@ -66,7 +66,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -89,6 +88,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/uninstall_mecab_local.sh
+++ b/installer/uninstall_mecab_local.sh
@@ -55,7 +55,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -78,6 +77,7 @@ check_commands() {
 
 # Check if the user has sudo privileges
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/installer/vmware-rebuild-and-sign.sh
+++ b/installer/vmware-rebuild-and-sign.sh
@@ -95,7 +95,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1
@@ -118,6 +117,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/restart-sshd.sh
+++ b/restart-sshd.sh
@@ -79,6 +79,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/unfix_compinit.sh
+++ b/unfix_compinit.sh
@@ -85,7 +85,6 @@ usage() {
 # Check if the system is macOS
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Darwin" ]; then
         echo "[ERROR] This script is intended for macOS only." >&2
         exit 1
@@ -108,6 +107,7 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    check_commands sudo
     if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
         exit 1

--- a/vmplayer-start.sh
+++ b/vmplayer-start.sh
@@ -62,7 +62,6 @@ usage() {
 # Check if the system is Linux
 check_system() {
     check_commands uname
-
     if [ "$(uname -s 2>/dev/null)" != "Linux" ]; then
         echo "[ERROR] This script is intended for Linux systems only." >&2
         exit 1


### PR DESCRIPTION
## Summary

- Unify the prerequisite ownership of `usage()`, `check_system()`, and `check_sudo()` across Shell Scripts so each function owns the external command it directly needs: `usage()` owns `awk`, `check_system()` owns `uname`, and `check_sudo()` owns `sudo`.
- Standardize the placement so `check_commands ...` is the first statement of each function with no blank line before the function's existing processing continues.
- `check_sudo()` failure semantics after this change: missing `sudo` reports `127`, a present-but-non-executable `sudo` reports `126` (both via `check_commands`), and a `sudo -v` privilege failure still reports `1` as before.
- `installer/debian_desktop_setup.sh` previously had no `check_commands()` at all; a new `check_commands()` function (matching the repository's canonical implementation, also documented in `doc/POLICY`) was added so `usage()` can own its `awk` prerequisite. `cron/bin/` scripts were excluded from this change, since they are unattended automation scripts, per explicit direction.
- Updated `doc/POLICY` so the `check_sudo`/`sudo` ownership wording matches the new pattern (previously it read the opposite way) and documented that this normalization alone does not bump executable versions.
- Updated `doc/VERSIONS` to merge the existing separate `check_system`/`uname` and `usage`/`awk` release bullets under the current unreleased `v2.0.2 (Release Date: TBD)` entry into one bullet that also covers `check_sudo`/`sudo`.
- No executable version numbers, `Version History` entries, or the repository version heading were changed.

## Validation

- Target function structural validation (custom script): all in-scope `usage()` bodies match the canonical form with `check_commands awk` first and no blank line before `awk '`; all `check_system()` bodies have `check_commands uname` first with no following blank line; all `check_sudo()` bodies have `check_commands sudo` first with no following blank line — PASS.
- `sh -n` syntax check on all 88 changed Shell Scripts — PASS, no errors.
- `SCRIPTS=<repo root> test/check_scripts.sh` — 140/140 scripts passed `-h` validation, exit status `0` — PASS.
- `python check_header_doc.py -a` — completed with exit status `0`, no header inconsistencies — PASS.
- `git diff --check` — PASS, no whitespace errors.
- Diff review — Shell Script changes are limited to the three target functions' prerequisite ownership; documentation changes are limited to the two specified `doc/POLICY` bullets and the `doc/VERSIONS` bullet consolidation; no version numbers, `Version History` entries, or unrelated files changed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015XzDvL3kkh3jB9e3jNVGaj