### PR TITLE
Fix XDG installer prerequisite ordering

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -33,6 +33,8 @@ v2.0.2 (Release Date: TBD)
 - Align state-converging no-op results with repository-wide idempotency rules.
 - Align munin-sync runtime and installer contracts for silent cron operation,
   unsupported arguments, and deployment permission failures.
+- Fix setup_xdg_dirs_en.sh to install xdg-user-dirs-gtk before checking
+  xdg-user-dirs-gtk-update in normal setup mode.
 
 v2.0.1 (2026-08-26)
 -------------------

--- a/installer/setup_xdg_dirs_en.sh
+++ b/installer/setup_xdg_dirs_en.sh
@@ -27,6 +27,9 @@
 #    -n, --no-sudo    Skip any sudo/apt operations and only update user dirs
 #
 #  Version History:
+#  v1.9 2026-09-10
+#       Allow normal setup to install xdg-user-dirs-gtk before checking
+#       xdg-user-dirs-gtk-update.
 #  v1.8 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -133,11 +136,13 @@ main() {
     check_system
 
     if [ "$SUDO_MODE" = "1" ]; then
-        check_commands apt dpkg grep xdg-user-dirs-gtk-update
+        check_commands apt dpkg grep
         check_sudo
 
         # Install xdg-user-dirs-gtk if necessary
         install_xdg_user_dirs_gtk
+
+        check_commands xdg-user-dirs-gtk-update
     else
         check_commands xdg-user-dirs-gtk-update
     fi


### PR DESCRIPTION
### Problem

- `setup_xdg_dirs_en.sh` requires `xdg-user-dirs-gtk-update` as a prerequisite before it installs the package that provides it in normal mode.
- On a clean environment, that command does not exist yet, so the script exits with status 127 before the install path is ever reached.

### Change

- Remove `xdg-user-dirs-gtk-update` from the initial `check_commands` call in normal mode.
- Run `check_commands xdg-user-dirs-gtk-update` immediately after `install_xdg_user_dirs_gtk`.
- Keep the `--no-sudo` / `-n` prerequisite check unchanged.
- Bump the executable version to `v1.9`.
- Add a bullet to the current unreleased `doc/VERSIONS` entry.

### Compatibility

- The package install command and package detection are unchanged.
- `--no-sudo` / `-n` semantics are unchanged.
- Existing status 1 / 126 / 127 semantics are preserved.
- No unrelated installer behavior, output, options, or configuration changed.
- No new dependency or test code added.

### Validation

- Shell Script syntax (`sh -n installer/setup_xdg_dirs_en.sh`): PASS (status 0)
- Header validation (`python3 check_header_doc.py -a --root .`): PASS (status 0)
- Existing installer help validation (`SCRIPTS="$(pwd)" sh test/check_scripts.sh`): PASS (140/140 scripts succeeded, including `setup_xdg_dirs_en.sh -h`)
- Normal mode prerequisite-order smoke verification: PASS — with a controlled PATH shim (`apt`/`dpkg`/`sudo` stubs, `xdg-user-dirs-gtk-update` absent until the fake install creates it), the script installs `xdg-user-dirs-gtk` before checking `xdg-user-dirs-gtk-update`, does not exit 127 on the initially-missing command, and reaches `update_xdg_dirs` successfully (exit 0).
- Post-install missing-command smoke verification: PASS — with the same shim but no `xdg-user-dirs-gtk-update` created after install, the script reaches the install step, then exits 127 at the post-install `check_commands`, and `update_xdg_dirs` is not reached.
- `--no-sudo` invariant verification: PASS — with `apt`/`dpkg`/`sudo` shims that fail loudly if invoked, `--no-sudo`/`-n` never calls them; it exits 127 when `xdg-user-dirs-gtk-update` is missing and succeeds (exit 0) when it is present.
- Diff validation (`git diff --check`): PASS (status 0); only `installer/setup_xdg_dirs_en.sh` and `doc/VERSIONS` are changed, matching the specified scope.

All controlled smoke-verification shims were scratchpad-only and were not added to the repository.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Cgvg4Ak5AqEyd9HJyuAch