### PR TITLE
Update id774.net header URL to HTTPS

### DIFF
--- a/add_hr_h2.py
+++ b/add_hr_h2.py
@@ -29,7 +29,7 @@
 #  The script updates the input file in place by default, or writes to a
 #  separate output file when OUTPUT is specified.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/anthy_create_aa_dic.sh
+++ b/anthy_create_aa_dic.sh
@@ -8,7 +8,7 @@
 #  method, using ASCII art (AA) entries. It converts an MS-IME format
 #  dictionary to the Canna format using the convert_msime2cannna.rb script.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/aozora_prepare.rb
+++ b/aozora_prepare.rb
@@ -8,7 +8,7 @@
 #  standardization. It converts the encoding, removes annotations, replaces
 #  full-width spaces, and standardizes newlines.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/apache_blog_analysis.py
+++ b/apache_blog_analysis.py
@@ -34,7 +34,7 @@
 #  to /etc/cron.exec by installer/install_apache_log_analysis.sh and
 #  invoked independently by cron/bin/apache_log_analysis.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/apache_calculater.py
+++ b/apache_calculater.py
@@ -14,7 +14,7 @@
 #  in <script_dir>/etc/, <script_dir>/../etc/ and /etc/cron.config in that order.
 #  It is designed to provide insights into web server traffic and client behavior.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/apache_log_analysis.sh
+++ b/apache_log_analysis.sh
@@ -14,7 +14,7 @@
 #  deployed apache_blog_analysis.py script; this script does not compute
 #  them, to avoid two scripts implementing the same aggregation.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/apt-upgrade.sh
+++ b/apt-upgrade.sh
@@ -12,7 +12,7 @@
 #    4. Cleans up unnecessary cached packages (`apt-get autoclean`).
 #    5. Removes unused packages and dependencies (`apt-get autoremove`).
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/brew-upgrade.sh
+++ b/brew-upgrade.sh
@@ -13,7 +13,7 @@
 #    5. Upgrades all outdated packages (`brew upgrade`).
 #    6. Cleans up old versions and caches (`brew cleanup`).
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/cal.py
+++ b/cal.py
@@ -10,7 +10,7 @@
 #  the system's 'cal' command. In non-Unix systems, it uses Python's calendar
 #  module for printing.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/check_header_doc.py
+++ b/check_header_doc.py
@@ -21,7 +21,7 @@
 #  is inspected; the script does not analyze code or comments outside the
 #  header block.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/check_reboot.sh
+++ b/check_reboot.sh
@@ -18,7 +18,7 @@
 #     - This check is executed only when needrestart is installed and
 #       the script runs as root (recommended for accurate inspection).
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/check_sshd_config.sh
+++ b/check_sshd_config.sh
@@ -7,7 +7,7 @@
 #  This script checks the SSH daemon configuration and TCP Wrappers access control
 #  settings for both macOS and Linux.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/chmodtree.py
+++ b/chmodtree.py
@@ -38,7 +38,7 @@
 #  defense against a matched path being replaced by a symbolic link between
 #  the find scan and the chown call.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/cleanup-junk-files.sh
+++ b/cleanup-junk-files.sh
@@ -8,7 +8,7 @@
 #  It targets files like .DS_Store, ._* AppleDouble files, temporary
 #  Unix files ending with '.un~', and __pycache__ directories.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/clear_chromium_cache.sh
+++ b/clear_chromium_cache.sh
@@ -7,7 +7,7 @@
 #  This script provides options to remove Chromium's "Web Data" directory.
 #  It no longer forcefully terminates Chromium processes.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/cltmp.sh
+++ b/cltmp.sh
@@ -40,7 +40,7 @@
 #  - macOS uses trash(1) for user-visible directories when available for a non-root user.
 #  - Linux purges $HOME/.local/share/Trash when the directory exists.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/convert_msime2canna.rb
+++ b/convert_msime2canna.rb
@@ -8,7 +8,7 @@
 #  compatible with the Canna Japanese input method system. It specifically
 #  targets entries labeled as "顔文字" (emoji) and formats them accordingly.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/cron/bin/apache_log_analysis
+++ b/cron/bin/apache_log_analysis
@@ -8,7 +8,7 @@
 #  It is intended to be executed automatically by cron and uses helper
 #  scripts to process access logs and extract useful patterns.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/cron/bin/chkrootkit
+++ b/cron/bin/chkrootkit
@@ -8,7 +8,7 @@
 #  It is designed to be run automatically via cron, logs the result to a
 #  designated file, and optionally sends an email alert if infections are found.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/cron/bin/clamscan
+++ b/cron/bin/clamscan
@@ -8,7 +8,7 @@
 #  executed automatically via cron. It delegates scanning to an external
 #  script (clamscan.sh), records logs, and optionally emails the results.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/cron/bin/clamscan.sh
+++ b/cron/bin/clamscan.sh
@@ -10,7 +10,7 @@
 #  - Runs `clamscan` recursively on the target directories.
 #  - Logs scan results to a specified log file.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/cron/bin/fix-permissions.sh
+++ b/cron/bin/fix-permissions.sh
@@ -8,7 +8,7 @@
 #  directories and files to ensure they are set correctly. It logs all
 #  operations and sends the log file to the administrator via email.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/cron/bin/get_resources
+++ b/cron/bin/get_resources
@@ -12,7 +12,7 @@
 #  script (default: /etc/cron.exec/server_alive_check.sh), it will be
 #  executed as an optional post-check. If absent, it is silently skipped.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/cron/bin/munin-symlink.sh
+++ b/cron/bin/munin-symlink.sh
@@ -17,7 +17,7 @@
 #  This script is intended to be executed periodically via cron,
 #  typically every 5 minutes.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/cron/bin/munin-sync.sh
+++ b/cron/bin/munin-sync.sh
@@ -18,7 +18,7 @@
 #  silent and exits 0 even when individual operational steps fail.
 #  Startup prerequisite failures remain diagnostic and non-zero.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/cron/bin/rsync_backup
+++ b/cron/bin/rsync_backup
@@ -8,7 +8,7 @@
 #  backup using rsync. If the trigger file is found, it runs the
 #  backup script, logs the result, and optionally sends the log via email.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/cron/bin/rsync_backup.sh
+++ b/cron/bin/rsync_backup.sh
@@ -98,7 +98,7 @@
 #    permission normalization is skipped, and the backup focuses on preserving
 #    ordinary file contents.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/cron/bin/run_tests
+++ b/cron/bin/run_tests
@@ -14,7 +14,7 @@
 #  loop. It is intended to be executed automatically via cron jobs and sends
 #  a summary email only when ADMIN_MAIL_ADDRESS is configured.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/dashcam_sync.sh
+++ b/dashcam_sync.sh
@@ -9,7 +9,7 @@
 #  requires a configuration file named 'dashcam_sync.conf' for specifying
 #  source and destination directories.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/dirsize.py
+++ b/dirsize.py
@@ -13,7 +13,7 @@
 #  for sizes within subdirectories and is designed for simplicity, providing
 #  a clear overview of the immediate directory contents.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/dot_files/dot_emacs
+++ b/dot_files/dot_emacs
@@ -1,6 +1,6 @@
 ;;; dot_emacs --- Entry point for DOT_EMACS initialization -*- lexical-binding: t; -*-
 
-;; Author: id774 (More info: http://id774.net)
+;; Author: id774 (More info: https://id774.net)
 ;; Source Code: https://github.com/id774/dot_emacs
 ;; License: The GPL version 3, or LGPL version 3 (Dual License).
 ;; Contact: idnanashi@gmail.com

--- a/dpkg-hold.sh
+++ b/dpkg-hold.sh
@@ -10,7 +10,7 @@
 #  view usage instructions. The script includes an environment check to
 #  ensure it is run on a compatible Debian-based system.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/du.py
+++ b/du.py
@@ -11,7 +11,7 @@
 #  exclude hidden directories (those starting with '.') in the report.
 #  This script is designed to work exclusively on macOS.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/els.py
+++ b/els.py
@@ -10,7 +10,7 @@
 #  It displays detailed file metadata, including permissions, size, owner,
 #  group, and timestamps, formatted for easy reading.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/erase_history.py
+++ b/erase_history.py
@@ -10,7 +10,7 @@
 #  corresponds to this script invocation, that entry is preserved and
 #  the preceding N lines are removed instead.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/exif_drop.sh
+++ b/exif_drop.sh
@@ -7,7 +7,7 @@
 #  This script searches for image files with GPS information in their
 #  EXIF data and removes this data using jhead for privacy reasons.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/fav-pins-on-fastladder.sh
+++ b/fav-pins-on-fastladder.sh
@@ -9,7 +9,7 @@
 #  - Extracting favorite pinned links.
 #  - Deleting all existing pins.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/filter_history.sh
+++ b/filter_history.sh
@@ -17,7 +17,7 @@
 #  - Checks for required commands before execution.
 #  - Displays a diff of the changes made to the history file.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/find_pycompat.py
+++ b/find_pycompat.py
@@ -19,7 +19,7 @@
 #  If compatibility issues are detected in scripts other than dummy.py, the script
 #  exits with a return code of 1 to indicate the presence of such issues.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/find_range.py
+++ b/find_range.py
@@ -13,7 +13,7 @@
 #  without modification time. Note: By default, all input and output times are treated as UTC,
 #  unless the '--localtime' option is used to use the local timezone instead.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/fix_anchor.py
+++ b/fix_anchor.py
@@ -36,7 +36,7 @@
 #  The script updates the input file in place by default, or writes to a
 #  separate output file when OUTPUT is specified.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/fix_compinit.sh
+++ b/fix_compinit.sh
@@ -17,7 +17,7 @@
 #  is designed to run exclusively on macOS (Darwin) and will exit with an
 #  error code on other operating systems.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/flatdirs.py
+++ b/flatdirs.py
@@ -14,7 +14,7 @@
 #  to prevent accidental execution. Make sure to review the displayed directory
 #  before proceeding.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/fluent-start.sh
+++ b/fluent-start.sh
@@ -9,7 +9,7 @@
 #  sending test messages. This version improves POSIX compatibility and
 #  adds error handling for missing commands.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/format_html.py
+++ b/format_html.py
@@ -18,7 +18,7 @@
 #  Notes:
 #  - This is a lightweight formatter, not a full HTML validator or repair tool
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/get-device.sh
+++ b/get-device.sh
@@ -26,7 +26,7 @@
 #    - Standardized error codes (see below) allow scripts to branch
 #      logic depending on the type of failure.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/get-fastladder-db.sh
+++ b/get-fastladder-db.sh
@@ -9,7 +9,7 @@
 #  - Ensures required commands are available before execution.
 #  - Creates a backup of the existing database before overwriting.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/get-feeds-from-fastladder.sh
+++ b/get-feeds-from-fastladder.sh
@@ -8,7 +8,7 @@
 #  - A list of all feed titles.
 #  - The total count of feeds.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/get-mountpoint.sh
+++ b/get-mountpoint.sh
@@ -26,7 +26,7 @@
 #        B) Tie breaker 1: prefer root mountpoint "/".
 #        C) Tie breaker 2: prefer non-removable-like FS over vfat/msdos/exfat/iso9660/squashfs.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/get-serial.sh
+++ b/get-serial.sh
@@ -13,7 +13,7 @@
 #    - Output: the serial number only (no extra decoration) on success.
 #    - Errors: messages to stderr and deterministic exit codes.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/get_resources.sh
+++ b/get_resources.sh
@@ -8,7 +8,7 @@
 #  It adapts to the running environment (Linux or macOS) and uses
 #  alternative commands or options when necessary.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/git-all-pull.sh
+++ b/git-all-pull.sh
@@ -8,7 +8,7 @@
 #  local directories. It also checks for and creates symbolic links from
 #  the home directory to these repositories.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/git-archive-repo.sh
+++ b/git-archive-repo.sh
@@ -11,7 +11,7 @@
 #  The script loads a configuration file named 'git-archive-repo.conf',
 #  which must define the source and archive paths described below.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/git-co-remote-branch.sh
+++ b/git-co-remote-branch.sh
@@ -10,7 +10,7 @@
 #  on the remote repository but not yet locally. It checks for Git installation
 #  before proceeding.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/git-create-repo.sh
+++ b/git-create-repo.sh
@@ -10,7 +10,7 @@
 #  the use of sudo. The default repository path is set to /var/lib/git if not
 #  specified. It checks for Git installation before proceeding.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/git-follow-origin.sh
+++ b/git-follow-origin.sh
@@ -9,7 +9,7 @@
 #  incorporating updates from a specified user's repository.
 #  It checks for Git installation before proceeding.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/git-symlink.sh
+++ b/git-symlink.sh
@@ -12,7 +12,7 @@
 #  directory. With the uninstall option, it removes home symlinks whose names
 #  match first-level directory names under the bases.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/gpg-import.sh
+++ b/gpg-import.sh
@@ -10,7 +10,7 @@
 #  /usr/share/keyrings/PUBKEY.gpg with mode 0644, for use with APT's
 #  signed-by= option. Only works on Debian-based Linux systems.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/gpx_sync.sh
+++ b/gpx_sync.sh
@@ -15,7 +15,7 @@
 #  - Set RSYNC_HOSTS as a space-separated list (e.g., "harpuia wyvern") to rsync
 #    to multiple hosts. If RSYNC_HOSTS is unset, the legacy RSYNC_HOST is used.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/hadoop-start.sh
+++ b/hadoop-start.sh
@@ -8,7 +8,7 @@
 #  and TaskTracker) using the specified command (e.g., start, stop).
 #  It ensures POSIX compatibility and includes error handling for missing arguments.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/html2yaml.py
+++ b/html2yaml.py
@@ -12,7 +12,7 @@
 #  by scripts or programs. Now, it checks for the necessary libraries
 #  and exits with an error message if they are not installed.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/image_resize.py
+++ b/image_resize.py
@@ -9,7 +9,7 @@
 #  resizes each image, and saves it to the output directory. This version includes
 #  error handling for environments where the PIL library is not installed.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/insta_downloader.py
+++ b/insta_downloader.py
@@ -13,7 +13,7 @@
 #  into filenames, thus ensuring each download is unique. Additionally,
 #  it now allows setting custom file permissions for the downloaded photos.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/insta_sync.sh
+++ b/insta_sync.sh
@@ -12,7 +12,7 @@
 #  various settings. The script checks if all necessary configuration variables
 #  are set and terminates with an error if any are missing.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/insta_update.sh
+++ b/insta_update.sh
@@ -15,7 +15,7 @@
 #  'insta_update.conf', specifying necessary settings. The script is intended
 #  for POSIX-compliant shell environments.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/insta_video_downloader.py
+++ b/insta_video_downloader.py
@@ -12,7 +12,7 @@
 #  re-downloading of already acquired videos by incorporating post IDs
 #  into filenames, thus ensuring each download is unique.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/configure_sysctl.sh
+++ b/installer/configure_sysctl.sh
@@ -15,7 +15,7 @@
 #  - This script emits only sysctl keys that actually exist on the running kernel
 #    (it probes /proc/sys). This avoids warnings on both older and newer kernels.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/create_emergencyadmin.sh
+++ b/installer/create_emergencyadmin.sh
@@ -9,7 +9,7 @@
 #  FileVault-enabled user. This is intended to provide a backup unlock
 #  method for encrypted systems.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/create_ubygems.sh
+++ b/installer/create_ubygems.sh
@@ -13,7 +13,7 @@
 #  tools and plugins, such as older Vim plugins, that rely on `ubygems.rb`
 #  being present.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/debian_apt.sh
+++ b/installer/debian_apt.sh
@@ -47,7 +47,7 @@
 #  The script also performs apt-get update/upgrade, autoclean, and autoremove
 #  before grouped installs to keep the system current and lean.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/debian_desktop_apt.sh
+++ b/installer/debian_desktop_apt.sh
@@ -35,7 +35,7 @@
 #        * Networking and remote: wireshark, xtightvncviewer
 #        * Torrents: bittorrent-gui, ktorrent, qbittorrent
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/debian_desktop_setup.sh
+++ b/installer/debian_desktop_setup.sh
@@ -12,7 +12,7 @@
 #  This script does not perform desktop package installation. It only
 #  invokes per-DE setup scripts placed under $HOME/scripts/installer/.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/debian_env.sh
+++ b/installer/debian_env.sh
@@ -17,7 +17,7 @@
 #    - Filesystem tuning:
 #        * Execute setup_tune2fs.sh for ext filesystem parameter adjustments.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/debian_gnome_flashback_setup.sh
+++ b/installer/debian_gnome_flashback_setup.sh
@@ -26,7 +26,7 @@
 #    - Optional: reset gnome-panel to defaults on user confirmation
 #    - Confirm before applying settings and before optional gnome-panel reset
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/debian_gnome_setup.sh
+++ b/installer/debian_gnome_setup.sh
@@ -20,7 +20,7 @@
 #    - Disable services: mask background services for a server-like desktop (Tracker/GOA/Evolution/Rygel)
 #    - Confirm before applying settings
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/debian_init.sh
+++ b/installer/debian_init.sh
@@ -24,7 +24,7 @@
 #        * Desktop packages (debian_desktop_apt.sh) and DE specific settings
 #          (debian_desktop_setup.sh) can be included by passing a desktop option.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/debian_setup.sh
+++ b/installer/debian_setup.sh
@@ -42,7 +42,7 @@
 #    - Cleanup:
 #        * Remove the user's ~/.bash_history.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/debian_xfce_setup.sh
+++ b/installer/debian_xfce_setup.sh
@@ -27,7 +27,7 @@
 #                            install xset-rate autostart entry
 #    - Confirm before applying settings
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/disable_freshclam_syslog.sh
+++ b/installer/disable_freshclam_syslog.sh
@@ -9,7 +9,7 @@
 #  log messages from appearing in syslog. It creates a systemd drop-in
 #  override file and restarts the affected service.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_R_libs.sh
+++ b/installer/install_R_libs.sh
@@ -7,7 +7,7 @@
 #  This script installs a predefined set of R libraries by sourcing
 #  the configuration file `install_mylibs.R`.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_apache_log_analysis.sh
+++ b/installer/install_apache_log_analysis.sh
@@ -9,7 +9,7 @@
 #  - Installing scheduled cron job into /etc/cron.exec for log analysis.
 #  - Ensuring proper file and directory permissions.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_autoconf.sh
+++ b/installer/install_autoconf.sh
@@ -9,7 +9,7 @@
 #  - Compiling and installing it to the system.
 #  - Optionally saving the source files for future use.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_awstats.sh
+++ b/installer/install_awstats.sh
@@ -11,7 +11,7 @@
 #  - Ensures proper permissions on log files.
 #  - Restarts Apache and updates AWStats statistics.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_brews.sh
+++ b/installer/install_brews.sh
@@ -9,7 +9,7 @@
 #  configured for development, text processing, system administration,
 #  and other tasks.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_cassandra.sh
+++ b/installer/install_cassandra.sh
@@ -9,7 +9,7 @@
 #  - Installing required dependencies.
 #  - Configuring necessary directories and permissions.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_chkrootkit.sh
+++ b/installer/install_chkrootkit.sh
@@ -11,7 +11,7 @@
 #  an initial scan and create /var/log/chkrootkit/log.expected from log.today
 #  if it does not exist, so that only future diffs trigger alerts.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_clamscan.sh
+++ b/installer/install_clamscan.sh
@@ -12,7 +12,7 @@
 #  - Ensuring the necessary directories and log files exist.
 #  - Setting appropriate permissions.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_conda.sh
+++ b/installer/install_conda.sh
@@ -9,7 +9,7 @@
 #  dependencies for scientific computing, data analysis, machine
 #  learning, and Hugging Face work are installed and ready for use.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_des.sh
+++ b/installer/install_des.sh
@@ -9,7 +9,7 @@
 #  archive, extracted, compiled, and installed.
 #  Source files are saved to /usr/local/src/crypt/des unless the -n option is specified.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_dotfiles.sh
+++ b/installer/install_dotfiles.sh
@@ -9,7 +9,7 @@
 #  It ensures consistent user configurations by copying predefined dotfiles
 #  to appropriate locations, managing permissions, and applying necessary settings.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_dotvim.sh
+++ b/installer/install_dotvim.sh
@@ -13,7 +13,7 @@
 #    same files (for NeoVim compatibility).
 #  - Use --uninstall to remove installed dot_vim configurations.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_fix-permissions.sh
+++ b/installer/install_fix-permissions.sh
@@ -10,7 +10,7 @@
 #  - Deploying a log rotation configuration to manage log size.
 #  - Installing the `fix-permissions` script as a daily cron job.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_gdm_themes.sh
+++ b/installer/install_gdm_themes.sh
@@ -9,7 +9,7 @@
 #  - Extracting and installing the themes in the correct directory.
 #  - Setting appropriate ownership and permissions.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_gdm_themes2.sh
+++ b/installer/install_gdm_themes2.sh
@@ -9,7 +9,7 @@
 #  - Extracting and installing the themes in the correct directory.
 #  - Setting appropriate ownership and permissions.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_gems.sh
+++ b/installer/install_gems.sh
@@ -10,7 +10,7 @@
 #  supported via the HTTP_PROXY environment variable, ensuring
 #  compatibility with various network configurations.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_get_resources.sh
+++ b/installer/install_get_resources.sh
@@ -9,7 +9,7 @@
 #  It ensures that the required directories and log files exist, sets appropriate
 #  permissions, and deploys cron jobs for resource reporting.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_google_chrome.sh
+++ b/installer/install_google_chrome.sh
@@ -35,7 +35,7 @@
 #      requires the availability of chmod and is safe to run repeatedly because
 #      the operation is idempotent.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_mecab-stack.sh
+++ b/installer/install_mecab-stack.sh
@@ -18,7 +18,7 @@
 #  which is removed after installation unless errors occur. Sources can optionally
 #  be preserved under /usr/local/src/mecab-stack unless the '-n' flag is given.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_munin-symlink.sh
+++ b/installer/install_munin-symlink.sh
@@ -9,7 +9,7 @@
 #  configuring a cron job for periodic execution. It ensures correct
 #  permissions are set for all deployed files.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_munin-sync.sh
+++ b/installer/install_munin-sync.sh
@@ -9,7 +9,7 @@
 #  configurations, and configuring or removing cron jobs for periodic execution.
 #  It ensures the correct permissions are set and removed cleanly.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_munin.sh
+++ b/installer/install_munin.sh
@@ -8,7 +8,7 @@
 #  ensuring necessary permissions and configurations are applied
 #  automatically without requiring manual edits.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_ncurses.sh
+++ b/installer/install_ncurses.sh
@@ -9,7 +9,7 @@
 #  - Compiling and installing the package to a specified or default location.
 #  - Saving source files only when installing with sudo.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_paco.sh
+++ b/installer/install_paco.sh
@@ -9,7 +9,7 @@
 #  - Compiling and installing the package.
 #  - Optionally saving the source files for future use.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_pip.sh
+++ b/installer/install_pip.sh
@@ -12,7 +12,7 @@
 #  script supports environments with or without proxy settings, making it
 #  suitable for various network configurations.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_python.sh
+++ b/installer/install_python.sh
@@ -9,7 +9,7 @@
 #  - Compiling and installing the package to a specified or default location.
 #  - Saving source files only when installing with sudo.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_resin.sh
+++ b/installer/install_resin.sh
@@ -9,7 +9,7 @@
 #  - Compiling and installing the application.
 #  - Optionally saving the source files for future use.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_rsync_backup.sh
+++ b/installer/install_rsync_backup.sh
@@ -11,7 +11,7 @@
 #  It ensures that the necessary directories and log files exist, sets
 #  appropriate permissions, and deploys all required files securely.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_ruby.sh
+++ b/installer/install_ruby.sh
@@ -9,7 +9,7 @@
 #  - Compiling and installing the package to a specified or default location.
 #  - Saving source files only when installing with sudo.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_run_tests.sh
+++ b/installer/install_run_tests.sh
@@ -10,7 +10,7 @@
 #  configuration file to secure locations, sets appropriate permissions,
 #  and schedules the tests to run automatically via a cron job.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_talib.sh
+++ b/installer/install_talib.sh
@@ -9,7 +9,7 @@
 #  - Compiling and installing the package.
 #  - Optionally saving the source files for future use.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_truecrypt.sh
+++ b/installer/install_truecrypt.sh
@@ -9,7 +9,7 @@
 #  properly sets permissions. The script is designed specifically for Linux
 #  systems and does not support Windows or macOS.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_veracrypt.sh
+++ b/installer/install_veracrypt.sh
@@ -9,7 +9,7 @@
 #  properly sets permissions. The script automatically determines the system
 #  architecture and installs the predefined version (1.25.9).
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/install_zsh.sh
+++ b/installer/install_zsh.sh
@@ -9,7 +9,7 @@
 #  - Compiling and installing the package to a specified or default location.
 #  - Saving source files only when installing with sudo.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/macos_finder_settings.sh
+++ b/installer/macos_finder_settings.sh
@@ -11,7 +11,7 @@
 #  - Preventing .DS_Store files on network shares.
 #  - Restarting SystemUIServer to apply changes.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/macos_setup.sh
+++ b/installer/macos_setup.sh
@@ -27,7 +27,7 @@
 #    - Cleanup:
 #        * Remove the user's shell history (~/.bash_history only).
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/macos_system_folder_localizations.sh
+++ b/installer/macos_system_folder_localizations.sh
@@ -7,7 +7,7 @@
 #  This script enables or disables system folder localization by creating
 #  or removing `.localized` files in key system directories.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/munin_plugins_links.sh
+++ b/installer/munin_plugins_links.sh
@@ -9,7 +9,7 @@
 #  It also handles specific plugin removal and service restart. It checks
 #  for the presence of Munin before proceeding.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/purge_apt_cache.sh
+++ b/installer/purge_apt_cache.sh
@@ -12,7 +12,7 @@
 #  - It will permanently remove residual config files of APT packages.
 #  - Ensure to review the script before running it.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/purge_kernels.sh
+++ b/installer/purge_kernels.sh
@@ -14,7 +14,7 @@
 #  - Excludes the currently running kernel from the removal list.
 #  - Safely removes only outdated kernels while preserving system stability.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/reinstall_brew.sh
+++ b/installer/reinstall_brew.sh
@@ -16,7 +16,7 @@
 #  - Running install_brews.sh for required packages.
 #  - Running fix_compinit.sh to fix compinit issues.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/remove-tracker.sh
+++ b/installer/remove-tracker.sh
@@ -8,7 +8,7 @@
 #  processes and packages from a Debian-based system. Tracker is a file
 #  indexing and search service commonly found in GNOME environments.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/set_ipv6_macos.sh
+++ b/installer/set_ipv6_macos.sh
@@ -15,7 +15,7 @@
 #  - Requires sudo for modifying network settings.
 #  - Exits with return code 1 if executed on a non-macOS system.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/setup_aliases.sh
+++ b/installer/setup_aliases.sh
@@ -17,7 +17,7 @@
 #  This helps centralize cron and system-generated mail notifications to
 #  root (or its alias target), while cleaning up unread or orphaned mail.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/setup_apache2_ssl.sh
+++ b/installer/setup_apache2_ssl.sh
@@ -36,7 +36,7 @@
 #  - This keeps the distributed template names stable while ensuring
 #    that the deployed file names match the target host identity.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/setup_aptconf.sh
+++ b/installer/setup_aptconf.sh
@@ -6,7 +6,7 @@
 #  Description:
 #  This script deploys a custom `apt.conf` file and allows manual editing.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/setup_crontab.sh
+++ b/installer/setup_crontab.sh
@@ -10,7 +10,7 @@
 #  Additionally, it ensures that the required directories (/etc/cron.weekday
 #  and /etc/cron.weekend) exist by creating them if necessary.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/setup_dos_guard.sh
+++ b/installer/setup_dos_guard.sh
@@ -10,7 +10,7 @@
 #    - Ensure apache-evasive fail2ban filter exists
 #    - Enable Apache module and reload services
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/setup_dot_ipython.sh
+++ b/installer/setup_dot_ipython.sh
@@ -8,7 +8,7 @@
 #  It creates IPython profiles, copies necessary startup files, and sets appropriate
 #  permissions.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/setup_iptables.sh
+++ b/installer/setup_iptables.sh
@@ -9,7 +9,7 @@
 #  and ensures the rules are automatically restored on boot via
 #  netfilter-persistent. It is designed for use on Debian-based systems.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/setup_jupyter_themes.sh
+++ b/installer/setup_jupyter_themes.sh
@@ -9,7 +9,7 @@
 #  - Configuring monokai theme settings.
 #  - Ensuring environment readiness before execution.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/setup_karabiner-elements.sh
+++ b/installer/setup_karabiner-elements.sh
@@ -9,7 +9,7 @@
 #  - Copying a predefined configuration file to the appropriate location.
 #  - Creating a backup of an existing configuration file if present.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/setup_memcached_conf.sh
+++ b/installer/setup_memcached_conf.sh
@@ -12,7 +12,7 @@
 #  commented, no edits are made. The operation is idempotent and uses only
 #  POSIX-compliant utilities without creating backups.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/setup_motd.sh
+++ b/installer/setup_motd.sh
@@ -9,7 +9,7 @@
 #  POSIX-compliant utilities without creating backups. If /etc/motd does
 #  not exist, the script exits successfully without changes.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/setup_ntp_restart_policy.sh
+++ b/installer/setup_ntp_restart_policy.sh
@@ -24,7 +24,7 @@
 #    - Runs `systemctl daemon-reload` only when changes are made.
 #    - Does not restart services automatically.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/setup_nvim.sh
+++ b/installer/setup_nvim.sh
@@ -13,7 +13,7 @@
 #  - Removes the entire ~/.config/nvim directory.
 #  - Removes the symlink ~/.local/bin/vim if it is a link.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/setup_pamd.sh
+++ b/installer/setup_pamd.sh
@@ -12,7 +12,7 @@
 #  in the desired state or absent, no edits are made. The script is
 #  idempotent and uses only POSIX-compliant utilities without creating backups.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/setup_python_symlink.sh
+++ b/installer/setup_python_symlink.sh
@@ -11,7 +11,7 @@
 #  An uninstall option is also provided:
 #  - Removes the package 'python-is-python3' if it is installed.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/setup_rsyslog_cron.sh
+++ b/installer/setup_rsyslog_cron.sh
@@ -20,7 +20,7 @@
 #    - If not, it deploys 10-cron.conf only when content differs or missing.
 #    - It validates configuration with 'rsyslogd -N1' and restarts rsyslog.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/setup_rsyslog_logrotate.sh
+++ b/installer/setup_rsyslog_logrotate.sh
@@ -24,7 +24,7 @@
 #        SystemMaxUse=500M
 #        RuntimeMaxUse=200M
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/setup_rsyslog_postfix.sh
+++ b/installer/setup_rsyslog_postfix.sh
@@ -24,7 +24,7 @@
 #      :syslogtag, startswith, "postfix/" /var/log/postfix.log
 #      & stop
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/setup_securetty.sh
+++ b/installer/setup_securetty.sh
@@ -8,7 +8,7 @@
 #  to enable root login from any TTY device. This might be necessary for certain
 #  system administration tasks or policy changes.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/setup_sysadmin_scripts.sh
+++ b/installer/setup_sysadmin_scripts.sh
@@ -8,7 +8,7 @@
 #  It allows specifying the installation path and supports uninstalling all scripts.
 #  The script handles setting file permissions and ownership appropriately.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/setup_tune2fs.sh
+++ b/installer/setup_tune2fs.sh
@@ -8,7 +8,7 @@
 #  using tune2fs. It disables periodic checks, sets reserved blocks,
 #  and applies settings for various storage configurations.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/setup_xdg_dirs_en.sh
+++ b/installer/setup_xdg_dirs_en.sh
@@ -9,7 +9,7 @@
 #  Documents, Downloads, Music, etc., and allows customization of these
 #  directory paths.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/uninstall_mecab_local.sh
+++ b/installer/uninstall_mecab_local.sh
@@ -9,7 +9,7 @@
 #  It scans and deletes known binaries, libraries, headers, configuration files,
 #  and dictionaries placed in /usr/local by custom installation scripts.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/installer/vmware-rebuild-and-sign.sh
+++ b/installer/vmware-rebuild-and-sign.sh
@@ -10,7 +10,7 @@
 #  skipped. After signing, it runs depmod and attempts to modprobe both
 #  modules. Designed for Secure Boot environments on Debian-family systems.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/list_file_counts.py
+++ b/list_file_counts.py
@@ -9,7 +9,7 @@
 #  file counts for all subdirectories directly under the given directory.
 #  The output is sorted in descending order by file count for better clarity.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/luksmount.py
+++ b/luksmount.py
@@ -16,7 +16,7 @@
 #  /mnt/user/<name>. This script does not unmount volumes and does not
 #  close mappings.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/md5.py
+++ b/md5.py
@@ -8,7 +8,7 @@
 #  individual files, directories, and input strings, and supports various output
 #  formats including a quiet mode that only displays checksums.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/namecalc.py
+++ b/namecalc.py
@@ -9,7 +9,7 @@
 #  performs calculations to output a graphical representation of the
 #  numerological analysis. This can be used for names or any other strings.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/namecalc.rb
+++ b/namecalc.rb
@@ -9,7 +9,7 @@
 #  performs calculations to output a graphical representation of the
 #  numerological analysis. This can be used for names or any other strings.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/platex2pdf.sh
+++ b/platex2pdf.sh
@@ -8,7 +8,7 @@
 #  encodings and using platex or uplatex depending on the document class.
 #  It requires platex, uplatex, dvipdfmx, and nkf to be installed.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/png_info.py
+++ b/png_info.py
@@ -8,7 +8,7 @@
 #  width, height, bit depth, and color type. It supports handling
 #  multiple files and uses glob patterns for file selection.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/put-fastladder-db.sh
+++ b/put-fastladder-db.sh
@@ -7,7 +7,7 @@
 #  This script vacuums and transfers the Fastladder SQLite database to a
 #  remote server via `rsync`.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/pyck.py
+++ b/pyck.py
@@ -38,7 +38,7 @@
 #  formatted with the same pyck policy regardless of the current working
 #  directory or configuration files surrounding the target.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/pyping.py
+++ b/pyping.py
@@ -8,7 +8,7 @@
 #  It can display results either immediately (faster) or in ascending
 #  order of IP addresses for better readability.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/remove-repo.sh
+++ b/remove-repo.sh
@@ -9,7 +9,7 @@
 #  symbolic links in the home directory. It checks if the directory is a Git
 #  repository before removing it. Includes a dry-run mode for simulation.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/remove_space_eol.sh
+++ b/remove_space_eol.sh
@@ -7,7 +7,7 @@
 #  This script removes trailing whitespace from each line in the specified files.
 #  It's useful for cleaning up source code files and other text files.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/restart-sshd.sh
+++ b/restart-sshd.sh
@@ -7,7 +7,7 @@
 #  This script restarts the SSH daemon. It supports both macOS (using
 #  launchctl) and Linux systems (using systemctl).
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -9,7 +9,7 @@
 #  the paths and versions of Python and Ruby being used, and checks if each
 #  test passes or fails, along with skipped test cases.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/sd_extract.sh
+++ b/sd_extract.sh
@@ -13,7 +13,7 @@
 #  of the process, the script reports the files that failed to copy and exits with a
 #  non-zero status if any errors occurred.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/send_files.sh
+++ b/send_files.sh
@@ -14,7 +14,7 @@
 #  address, archive source, archive password file name, and password
 #  length are loaded from an external config file.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/server_alive_check.sh
+++ b/server_alive_check.sh
@@ -18,7 +18,7 @@
 #  excluded from alerts even if stale. A separate log message is displayed
 #  when only VM-prefixed hosts are stale.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/setup_scripts.sh
+++ b/setup_scripts.sh
@@ -9,7 +9,7 @@
 #  - Grants execute permissions to all files with .sh, .py, or .rb extensions under the entire collection.
 #  - Grants execute permissions to all files under scripts/cron/bin regardless of extension.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/show_version.py
+++ b/show_version.py
@@ -15,7 +15,7 @@
 #  installation is never mistaken for a simply absent one. It also
 #  shows the Python version upon request.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/simple_passwd.py
+++ b/simple_passwd.py
@@ -8,7 +8,7 @@
 #  special symbols from the password. If symbols are enabled, at least
 #  one symbol is guaranteed to be included in the password.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/simple_passwd.rb
+++ b/simple_passwd.rb
@@ -8,7 +8,7 @@
 #  special symbols from the password. If symbols are enabled, at least
 #  one symbol is guaranteed to be included in the password.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/swapext.py
+++ b/swapext.py
@@ -8,7 +8,7 @@
 #  It walks through the directory, renaming files from one extension to another.
 #  It now includes dry-run capability and safety confirmation before execution.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/tcmount.py
+++ b/tcmount.py
@@ -12,7 +12,7 @@
 #  name as an argument and choosing between TrueCrypt and VeraCrypt.
 #  It also supports external container mounts with an explicit target.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/add_hr_h2_test.py
+++ b/test/add_hr_h2_test.py
@@ -12,7 +12,7 @@
 #  <hr> detection, newline style detection, argument parsing, input file
 #  validation, UTF-8 handling, and file read/write behavior.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/aozora_prepare_test.rb
+++ b/test/aozora_prepare_test.rb
@@ -8,7 +8,7 @@
 #  text files for improved readability. It verifies encoding conversion,
 #  ruby annotation removal, full-width space replacement, and newline normalization.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/apache_blog_analysis_test.py
+++ b/test/apache_blog_analysis_test.py
@@ -10,7 +10,7 @@
 #  asset-confirmation and session time boundaries, ignore-list resolution
 #  from an unrelated working directory, and a fixture-based end-to-end run.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/apache_calculater_test.py
+++ b/test/apache_calculater_test.py
@@ -9,7 +9,7 @@
 #  human-readable output formatting. Tests are deterministic and do not
 #  depend on external ignore list files.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/apache_log_analysis_cron_test.py
+++ b/test/apache_log_analysis_cron_test.py
@@ -9,7 +9,7 @@
 #  The wrapper is copied into a temporary directory with its production
 #  paths rewritten to fixtures, so no system directory is touched.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/cal_test.py
+++ b/test/cal_test.py
@@ -8,7 +8,7 @@
 #  uses Python's calendar module as fallback. It verifies help output,
 #  fallback behavior, and correct dispatch to system cal.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/check_header_doc_test.py
+++ b/test/check_header_doc_test.py
@@ -11,7 +11,7 @@
 #  the header doc block is ignored. It also tests quiet mode, --all-files,
 #  and directory scanning via --root.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/check_scripts.sh
+++ b/test/check_scripts.sh
@@ -20,7 +20,7 @@
 #  This script is intended as a lightweight automated health check
 #  for installer and setup scripts within a project.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/chmodtree_test.py
+++ b/test/chmodtree_test.py
@@ -14,7 +14,7 @@
 #  links from ownership normalization and the --chown-symlinks opt-in,
 #  command availability checks, and exit status propagation.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/convert_msime2canna_test.rb
+++ b/test/convert_msime2canna_test.rb
@@ -8,7 +8,7 @@
 #  IME dictionary into a format suitable for Canna. It checks for correct
 #  conversion of emoji entries and proper usage output.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/dirsize_test.py
+++ b/test/dirsize_test.py
@@ -7,7 +7,7 @@
 #  Tests the functionality of the dirsize.py script, including file size
 #  conversion and directory existence check.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/du_test.py
+++ b/test/du_test.py
@@ -7,7 +7,7 @@
 #  This test suite validates the disk usage reporting functionality of du.py,
 #  including directory checks, output parsing, and hidden directory filtering.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/dummy.py
+++ b/test/dummy.py
@@ -11,7 +11,7 @@
 #  serves as a test case to verify that the find_pycompat.py script can successfully identify
 #  compatibility issues with older versions of Python.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/els_test.py
+++ b/test/els_test.py
@@ -10,7 +10,7 @@
 #  error handling and edge cases. The test suite does not modify
 #  actual file system contents but uses mocking where applicable.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/erase_history_test.py
+++ b/test/erase_history_test.py
@@ -9,7 +9,7 @@
 #  quiet mode. Tests focus on argument parsing, safety limits, confirmation
 #  handling, output formatting, and atomic file updates.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/find_pycompat_test.py
+++ b/test/find_pycompat_test.py
@@ -16,7 +16,7 @@
 #  to require spaces around it. These tests ensure that the updated patterns accurately identify
 #  the intended features without false positives or negatives.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/find_range_test.py
+++ b/test/find_range_test.py
@@ -12,7 +12,7 @@
 #  with the '-l' option, ensuring both UTC and local timezone outputs are
 #  correctly formatted and calculated.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/fix_anchor_test.py
+++ b/test/fix_anchor_test.py
@@ -13,7 +13,7 @@
 #  validation, content validation, UTF-8 handling, and file read/write
 #  behavior.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/flatdirs_test.py
+++ b/test/flatdirs_test.py
@@ -12,7 +12,7 @@
 #  script behavior under various conditions without altering the actual
 #  file system.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/format_html_test.py
+++ b/test/format_html_test.py
@@ -13,7 +13,7 @@
 #  input/output validation,
 #  argument parsing, UTF-8 file handling, and main entry point behavior.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/html2yaml_test.py
+++ b/test/html2yaml_test.py
@@ -9,7 +9,7 @@
 #  YAML format. The tests depend on BeautifulSoup and PyYAML libraries. If these
 #  libraries are not installed, the tests will be skipped.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/image_resize_test.py
+++ b/test/image_resize_test.py
@@ -9,7 +9,7 @@
 #  for files in a specified directory. Mock objects are used to simulate
 #  file system operations and interactions with the Pillow library.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/insta_downloader_test.py
+++ b/test/insta_downloader_test.py
@@ -12,7 +12,7 @@
 #  in different scenarios without affecting external systems or generating
 #  unwanted network traffic.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/insta_video_downloader_test.py
+++ b/test/insta_video_downloader_test.py
@@ -12,7 +12,7 @@
 #  in different scenarios without affecting external systems or generating
 #  unwanted network traffic.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/list_file_counts_test.py
+++ b/test/list_file_counts_test.py
@@ -9,7 +9,7 @@
 #  counting, subdirectory listing, sorting, and error handling. The
 #  tests are designed to ensure robust performance and correctness.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/luksmount_test.py
+++ b/test/luksmount_test.py
@@ -9,7 +9,7 @@
 #  commands (get-serial, sudo, cryptsetup, mount) and filesystem checks
 #  are mocked; no real block device, passphrase, or privilege is used.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/md5_test.py
+++ b/test/md5_test.py
@@ -7,7 +7,7 @@
 #  Tests the functionality of the md5.py script, ensuring correct MD5
 #  checksum calculation for files and strings.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/namecalc_test.py
+++ b/test/namecalc_test.py
@@ -8,7 +8,7 @@
 #  It tests the script's functionality by providing various input strings
 #  and comparing the script's output against expected results.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/namecalc_test.rb
+++ b/test/namecalc_test.rb
@@ -8,7 +8,7 @@
 #  It tests the script's functionality by providing various input strings
 #  and comparing the script's output against expected results.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/png_info_test.py
+++ b/test/png_info_test.py
@@ -7,7 +7,7 @@
 #  This test script contains unit tests for the png_info.py script.
 #  It verifies the functionality of reading basic information from PNG files.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/pyck_test.py
+++ b/test/pyck_test.py
@@ -9,7 +9,7 @@
 #  of unused imports for Python files. The script tests both dry-run
 #  and auto-fix modes.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/pyping_test.py
+++ b/test/pyping_test.py
@@ -8,7 +8,7 @@
 #  It checks whether the script correctly pings a range of IP addresses
 #  within a specified subnet and validates its output behavior.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/run_tests_test.py
+++ b/test/run_tests_test.py
@@ -9,7 +9,7 @@
 #  success keywords in the captured output. A temporary fixture directory
 #  is used as SCRIPTS so that the real test suite is not re-executed.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/show_version_test.py
+++ b/test/show_version_test.py
@@ -8,7 +8,7 @@
 #  distribution metadata, versions, and actual importability, and when
 #  printing the Python version.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/simple_passwd_test.py
+++ b/test/simple_passwd_test.py
@@ -7,7 +7,7 @@
 #  This script tests the password generation functionality of simple_passwd.py.
 #  It verifies password length and character composition with and without symbols.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/simple_passwd_test.rb
+++ b/test/simple_passwd_test.rb
@@ -7,7 +7,7 @@
 #  This test suite verifies the behavior of the simple_passwd.rb script.
 #  It checks input validation and password generation logic.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/swapext_test.py
+++ b/test/swapext_test.py
@@ -8,7 +8,7 @@
 #  the functionality of the swap_extensions function to ensure that it
 #  correctly changes the file extensions within a specified directory.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/tcmount_test.py
+++ b/test/tcmount_test.py
@@ -11,7 +11,7 @@
 #  of options, including TrueCrypt and VeraCrypt compatibility modes, and
 #  verifies that command failures propagate to the script's exit status.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/unixtime2date_test.py
+++ b/test/unixtime2date_test.py
@@ -7,7 +7,7 @@
 #  Tests the unixtime2date function assuming the local timezone is Japan (UTC+9).
 #  Note: These tests are valid only if the system's local timezone is set to Japan.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/unzip_subdir_test.py
+++ b/test/unzip_subdir_test.py
@@ -9,7 +9,7 @@
 #  skipping existing directories, safe zipfile extraction, nested directory
 #  traversal, unsafe archive member rejection, and proper help message output.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/userlist_test.py
+++ b/test/userlist_test.py
@@ -8,7 +8,7 @@
 #  above a system-specific threshold. It mocks different OS environments
 #  and simulates expected input/output behavior.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/usershells_test.py
+++ b/test/usershells_test.py
@@ -8,7 +8,7 @@
 #  login shells, excluding non-interactive accounts. It mocks both
 #  macOS (dscl) and Unix-like (/etc/passwd) environments.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/waitlock_test.rb
+++ b/test/waitlock_test.rb
@@ -7,7 +7,7 @@
 #  This test suite verifies the behavior of the waitlock.rb script.
 #  It tests proper argument handling and lockfile-waiting behavior.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/wakeonlan_test.py
+++ b/test/wakeonlan_test.py
@@ -8,7 +8,7 @@
 #  It verifies the functionality of creating and formatting magic packets,
 #  as well as sending them over the network without actually doing so.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/wget_test.py
+++ b/test/wget_test.py
@@ -12,7 +12,7 @@
 #  as expected in different scenarios without accessing external resources
 #  or modifying the real file system.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/wget_test.rb
+++ b/test/wget_test.rb
@@ -7,7 +7,7 @@
 #  This test suite verifies the behavior of the wget.rb script.
 #  It ensures proper argument handling and mocks download logic.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/wp_cachectl_test.py
+++ b/test/wp_cachectl_test.py
@@ -22,7 +22,7 @@
 #  - The tool uses OptionParser, so tests call main() after patching sys.argv.
 #  - Tests focus on behavior and call intent, not on WP-CLI output formatting.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/zero_padding_test.py
+++ b/test/zero_padding_test.py
@@ -8,7 +8,7 @@
 #  the functionality of the rename_files function to ensure that file names
 #  are correctly zero-padded to the specified number of digits.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/tree.sh
+++ b/tree.sh
@@ -9,7 +9,7 @@
 #  (those starting with a dot) are excluded by default. An option can be
 #  provided to include these hidden directories in the tree.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/unfix_compinit.sh
+++ b/unfix_compinit.sh
@@ -18,7 +18,7 @@
 #  directories. After finishing Homebrew-related tasks, you can revert these
 #  changes using `fix_compinit.sh` to restore the secure configuration.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/unixtime2date.py
+++ b/unixtime2date.py
@@ -7,7 +7,7 @@
 #  This script converts a Unix timestamp to a human-readable date format in ISO 8601.
 #  It uses Japan Standard Time (UTC+09:00) for deterministic conversion.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/unzip_subdir.py
+++ b/unzip_subdir.py
@@ -11,7 +11,7 @@
 #  extraction. Archives are extracted with Python's zipfile module
 #  and entries that would escape the target directory are rejected.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/userlist.py
+++ b/userlist.py
@@ -8,7 +8,7 @@
 #  The threshold is set based on the existence of system-specific files,
 #  distinguishing between Debian-based, RedHat-based, and macOS systems.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/usershells.py
+++ b/usershells.py
@@ -9,7 +9,7 @@
 #  excluding accounts with non-interactive shells like 'false', 'nologin', 'sync',
 #  'shutdown', and 'halt'.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/vacuum-fastladder-db.sh
+++ b/vacuum-fastladder-db.sh
@@ -7,7 +7,7 @@
 #  This script is used to vacuum and optimize the Fastladder SQLite database.
 #  It creates a new database file from the existing database after running the vacuum command.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/vacuum-safari.sh
+++ b/vacuum-safari.sh
@@ -8,7 +8,7 @@
 #  database to optimize it. Vacuuming reclaims free space and can improve
 #  performance.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/vmplayer-start.sh
+++ b/vmplayer-start.sh
@@ -8,7 +8,7 @@
 #  It uses xvfb, fluxbox, x11vnc, and vmplayer to set up a virtual desktop
 #  accessible via VNC.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/waitlock.rb
+++ b/waitlock.rb
@@ -28,7 +28,7 @@
 #  actions) as long as 'hoge.txt' exists. Once 'hoge.txt' is removed, the script
 #  will complete its execution.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/wakeonlan.py
+++ b/wakeonlan.py
@@ -7,7 +7,7 @@
 #  This script sends a Wake-on-LAN magic packet to a specified MAC address.
 #  It's designed to wake up computers remotely by using their network interface.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/wget.py
+++ b/wget.py
@@ -7,7 +7,7 @@
 #  This Python script downloads a file from a given URL and saves it
 #  locally. It mimics basic functionality of the wget command.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/wget.rb
+++ b/wget.rb
@@ -7,7 +7,7 @@
 #  This Ruby script downloads a file from a given URL and saves it
 #  locally. It is a basic implementation similar to the wget command.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/wp_cachectl.py
+++ b/wp_cachectl.py
@@ -32,7 +32,7 @@
 #  It does NOT implement allowlists, locks, or rate limits in this version.
 #  (Those can be added later if operational needs grow.)
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/xmap.sh
+++ b/xmap.sh
@@ -7,7 +7,7 @@
 #  Load user's $HOME/.Xmodmap with xmodmap when both the command and the
 #  file are available.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/zero_padding.py
+++ b/zero_padding.py
@@ -17,7 +17,7 @@
 #  includes a main function for structured execution and a separate function for
 #  argument parsing, enhancing readability and maintainability.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com


### PR DESCRIPTION
## Summary

- Mechanically changed `More info: http://id774.net` to `More info: https://id774.net` in file headers (233 files).
- No changes other than the URL scheme (`http` → `https`).
- No version changes.
- No changes to Version History, README, or other documentation.
- No test additions or changes (test files only had their own header line updated).

## Mandatory Validation (actual results)

- Old notation remaining: 0 — PASS
- Diffs other than URL scheme: 0 — PASS
- Out-of-scope changes: 0 — PASS
- Version changes: 0 — PASS
- Version History changes: 0 — PASS
- Other documentation changes: 0 — PASS
- Test changes: 0 — PASS
- Dependency changes: 0 — PASS
- `git diff --check`: PASS (0 whitespace errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)