### PR TITLE
Update remaining id774.net download URLs to HTTPS

### DIFF
--- a/installer/install_des.sh
+++ b/installer/install_des.sh
@@ -22,6 +22,8 @@
 #  -n   Do not save source files after installation.
 #
 #  Version History:
+#  v2.9 2026-09-10
+#       Use HTTPS for the id774.net DES archive download.
 #  v2.8 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -134,7 +136,7 @@ install_des() {
     cd install_des || exit 1
 
     echo "[INFO] Downloading software archive..."
-    if ! wget http://id774.net/archive/kmdes.tar.gz; then
+    if ! wget https://id774.net/archive/kmdes.tar.gz; then
         echo "[ERROR] Failed to download kmdes.tar.gz." >&2
         exit 1
     fi

--- a/installer/install_gdm_themes.sh
+++ b/installer/install_gdm_themes.sh
@@ -24,6 +24,8 @@
 #  - This script is intended for Linux systems only.
 #
 #  Version History:
+#  v2.8 2026-09-10
+#       Use HTTPS for the id774.net GDM themes archive download.
 #  v2.7 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -100,7 +102,7 @@ install_gdm_themes() {
     fi
 
     echo "[INFO] Downloading GDM themes archive..."
-    if ! wget http://id774.net/archive/gdmthemes.tar.gz; then
+    if ! wget https://id774.net/archive/gdmthemes.tar.gz; then
         echo "[ERROR] Failed to download gdmthemes.tar.gz." >&2
         exit 1
     fi

--- a/installer/install_gdm_themes2.sh
+++ b/installer/install_gdm_themes2.sh
@@ -24,6 +24,8 @@
 #  - This script is intended for Linux systems only.
 #
 #  Version History:
+#  v2.8 2026-09-10
+#       Use HTTPS for the id774.net GDM Themes 2 archive download.
 #  v2.7 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -100,7 +102,7 @@ install_gdm_themes2() {
     fi
 
     echo "[INFO] Downloading GDM themes archive..."
-    if ! wget http://id774.net/archive/gdmthemes2.tar.gz; then
+    if ! wget https://id774.net/archive/gdmthemes2.tar.gz; then
         echo "[ERROR] Failed to download gdmthemes2.tar.gz." >&2
         exit 1
     fi


### PR DESCRIPTION
## Summary

- The prior HTTPS migration of README, LICENSE, and source header `id774.net` links has already been merged into `master`.
- This PR updates the 3 remaining archive download URLs from `http://id774.net` to `https://id774.net`.
- Per `doc/POLICY`'s versioning rule, this is treated as an observable-behavior change (the `wget` connection scheme changes), so each of the 3 executables' Version History was bumped by one step with a new entry, without touching any existing entry.
- No changes to repository release version, `doc/VERSIONS`, README, LICENSE, POLICY, test code, or dependencies.

## Changed files

- `installer/install_des.sh`: `http://id774.net/archive/kmdes.tar.gz` → `https://id774.net/archive/kmdes.tar.gz`; Version History v2.8 → v2.9 (2026-09-10)
- `installer/install_gdm_themes.sh`: `http://id774.net/archive/gdmthemes.tar.gz` → `https://id774.net/archive/gdmthemes.tar.gz`; Version History v2.7 → v2.8 (2026-09-10)
- `installer/install_gdm_themes2.sh`: `http://id774.net/archive/gdmthemes2.tar.gz` → `https://id774.net/archive/gdmthemes2.tar.gz`; Version History v2.7 → v2.8 (2026-09-10)

## Validation (actual results)

- Download URLs are HTTPS as specified: PASS
- No implementation changes other than URL scheme: PASS
- Version History has exactly one new entry per file, existing entries untouched: PASS
- No changes to README, LICENSE, POLICY, FEATURES, `doc/VERSIONS`: PASS
- No changes to test code or dependencies: PASS
- No file mode changes: PASS
- `sh -n` syntax check on all 3 files: PASS
- `git diff --check`: PASS (0 whitespace errors)
- HTTPS endpoint verification: Not possible in this sandboxed environment — the outbound proxy rejects the TLS tunnel to `id774.net` ("Proxy tunneling failed: Forbidden") for hosts outside its allowlist. No files were downloaded/saved for this check, and the URL was not reverted or changed as a result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)