### PR TITLE
Fix iptables prerequisite ordering and define redundant-check policy

### DIFF
--- a/doc/POLICY
+++ b/doc/POLICY
@@ -202,6 +202,18 @@ repository is already being edited.
 - An unattended script in an environment that will never supply an optional
   capability should avoid repeatedly reporting a condition that the operator
   cannot act on. A failure the operator can act on is still reported.
+- Do not add a check whose only purpose is to reconfirm a state already
+  guaranteed by an invariant established earlier in the same run or by the
+  contract of a preceding operation that completed successfully. Such a check
+  adds a branch without distinguishing a supported runtime state.
+- Add a separate check only when the condition can vary independently in a
+  supported environment and its result changes safe control flow, diagnostics,
+  fallback behavior, or another observable choice. This applies to commands,
+  files, directories, services, configuration state, and other capabilities.
+- For example, when a successful package installation contractually provides a
+  command before its first use, do not immediately check that command again.
+  Use it when needed; an unexpected inconsistency is handled by the consuming
+  operation's existing failure path.
 
 #### 1.2.3 Environment Differences
 - Branch on what the environment provides, not on what it is called. A
@@ -1106,8 +1118,10 @@ still comes before portability.
 ### 2.3 Dependency and Environment Checks
 - Validate required external commands before the work that depends on them
   begins.
-- Use `check_commands` once near startup for external commands required by the
-  script's normal main execution.
+- Use `check_commands` once near startup for external commands that must already
+  be available for the script's normal main execution. A command that the
+  script itself guarantees to provide before its first use is not a startup
+  prerequisite and is not added to a redundant post-provision check.
 - Do not list shell built-ins in `check_commands`.
 - Do not list `awk` in the normal main-execution `check_commands` call when
   `awk` is used only by `usage()` to display the header. In the standard

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -35,6 +35,8 @@ v2.0.2 (Release Date: TBD)
   unsupported arguments, and deployment permission failures.
 - Fix setup_xdg_dirs_en.sh to install xdg-user-dirs-gtk before checking
   xdg-user-dirs-gtk-update in normal setup mode.
+- Avoid redundant checks of guaranteed postconditions and let setup_iptables.sh
+  provision iptables-restore before first use.
 
 v2.0.1 (2026-08-26)
 -------------------

--- a/installer/setup_iptables.sh
+++ b/installer/setup_iptables.sh
@@ -30,6 +30,9 @@
 #  - Exits if not running on Linux.
 #
 #  Version History:
+#  v1.6 2026-09-11
+#       Allow iptables-persistent installation to provide iptables-restore
+#       before its first use.
 #  v1.5 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -161,7 +164,7 @@ main() {
 
     check_system
     check_scripts
-    check_commands dpkg apt-get debconf-set-selections iptables-restore chmod mkdir cp systemctl dirname sh
+    check_commands dpkg apt-get debconf-set-selections chmod mkdir cp systemctl dirname sh
     check_sudo
 
     TEMPLATE_PATH="$SCRIPTS/etc/iptables/rules.v4"


### PR DESCRIPTION
### Problem
- `setup_iptables.sh` required `iptables-restore` as a startup prerequisite before `install_persistent()` had a chance to self-provision `iptables-persistent`, so a clean Debian/Ubuntu environment exited 127 before reaching its own install path.

### Change
- Removed `iptables-restore` from the startup `check_commands` call in `installer/setup_iptables.sh`.
- Added no post-install existence check for `iptables-restore`; `install_persistent()` and `load_rules()` are unchanged.
- Added a general principle to `doc/POLICY` (Common Policy, Dependencies and Optional Capabilities): do not add a check whose only purpose is to reconfirm a state already guaranteed by an invariant established earlier in the run or by the contract of a preceding successful operation; add a separate check only when the condition can vary independently and its result changes observable behavior. The principle applies to commands, files, directories, services, and configuration state generally, not only to this script.
- Aligned the Shell Script `check_commands` startup-prerequisite rule in `doc/POLICY` with that principle: a command the script itself guarantees to provide before its first use is not a startup prerequisite.
- Bumped `installer/setup_iptables.sh` to `v1.6 2026-09-11`.
- Added one bullet to the existing unreleased `v2.0.2 (Release Date: TBD)` entry in `doc/VERSIONS`.

### Compatibility
- Install command, rule file handling, rule loading, service restart, options, configuration, and normal logging are unchanged.
- No new dependency, test code, or README/FEATURES changes.
- The new policy is not applied to any other script in this PR; cross-application is out of scope.
- No probe was added for state that a successful package-provisioning step already guarantees.

### Validation
- `sh -n installer/setup_iptables.sh` — exit 0.
- `python3 check_header_doc.py -a` — exit 0.
- `SCRIPTS=$(pwd) bash test/check_scripts.sh` — 140/140 scripts passed, including `setup_iptables.sh -h`.
- Controlled smoke verification (outside the repository, no files added to it): ran `installer/setup_iptables.sh` inside an isolated mount namespace with `/etc` tmpfs-mounted so no real host state could be affected, using temporary PATH stubs for `sudo`, `dpkg`, `apt-get`, `debconf-set-selections`, and `systemctl` (no real package installation, service restart, or privilege escalation occurred), plus wrapper stubs for `mkdir`/`cp`/`chmod` that forwarded to the real binaries operating only inside the isolated tmpfs. `iptables-restore` was absent from PATH at startup; the script did not exit 127, ran `install_persistent()`, had the fake `apt-get install` provision a fake `iptables-restore` before its first use, and `load_rules()` invoked it successfully. Script exited 0. Confirmed afterward that the real `/etc/iptables` directory, the real `dpkg` package database, and the real `systemctl`/service state were all untouched.
- Changed files: exactly `installer/setup_iptables.sh`, `doc/POLICY`, `doc/VERSIONS` (`git diff --check` clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017YWmhCtTharjTMrY1LtVGV