### PR TITLE
Align installer prerequisites with execution paths

### DIFF
--- a/doc/POLICY
+++ b/doc/POLICY
@@ -214,6 +214,11 @@ repository is already being edited.
   command before its first use, do not immediately check that command again.
   Use it when needed; an unexpected inconsistency is handled by the consuming
   operation's existing failure path.
+- When omitting a check is non-obvious because an earlier operation or package
+  contract establishes the required state, leave a concise adjacent code
+  comment if a future maintainer could otherwise reasonably reintroduce the
+  redundant check. The comment explains the invariant that makes the extra
+  check unnecessary; it does not merely restate the code.
 
 #### 1.2.3 Environment Differences
 - Branch on what the environment provides, not on what it is called. A
@@ -1132,6 +1137,13 @@ still comes before portability.
   immediately before invoking `sudo -v`.
 - Detect an external command used only by an optional or conditional operation
   at the point where that operation is selected.
+- A command used only by a conditional execution path may still be validated
+  before side effects begin when it is a normal prerequisite of the supported
+  environment and delaying the check would only move a predictable failure
+  until after earlier work has already been performed.
+- A mode that explicitly disables a facility, such as a no-sudo mode, must not
+  require that facility's command or privilege validation. Select the mode
+  first, then validate only the prerequisites of that mode.
 - Use the following POSIX-compliant helper for commands checked through
   `check_commands`; it maps a missing command to `127` and a present but
   non-executable command to `126`:

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -33,10 +33,8 @@ v2.0.2 (Release Date: TBD)
 - Align state-converging no-op results with repository-wide idempotency rules.
 - Align munin-sync runtime and installer contracts for silent cron operation,
   unsupported arguments, and deployment permission failures.
-- Fix setup_xdg_dirs_en.sh to install xdg-user-dirs-gtk before checking
-  xdg-user-dirs-gtk-update in normal setup mode.
-- Avoid redundant checks of guaranteed postconditions and let setup_iptables.sh
-  provision iptables-restore before first use.
+- Align prerequisite checks with actual execution paths and remove redundant
+  or contradictory checks.
 
 v2.0.1 (2026-08-26)
 -------------------

--- a/git-create-repo.sh
+++ b/git-create-repo.sh
@@ -59,6 +59,9 @@
 #  home directory. This behavior can be overridden with the --sudo or --no-sudo options.
 #
 #  Version History:
+#  v2.2 2026-09-11
+#       Honor explicit --no-sudo regardless of repository path and parse
+#       documented options after positional arguments.
 #  v2.1 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -201,42 +204,93 @@ delete_git_repo() {
 parse_arguments() {
     dry_run=false
     delete_repo=false
-    explicit_sudo=""
+    explicit_sudo=auto
     user="git"
     group="git"
+    positional_only=false
+    positional_count=0
+    repo_name=""
+    repo_base_path=""
 
     while [ $# -gt 0 ]; do
-        case "$1" in
-            --dry-run) dry_run=true ;;
-            --delete) delete_repo=true ;;
-            --sudo) explicit_sudo="sudo" ;;
-            --no-sudo) explicit_sudo="" ;;
-            --user) user="$2"; shift ;;
-            --group) group="$2"; shift ;;
-            -h|--help) usage ;;
-            --) shift; break ;;
-            -*) usage ;;
-            *) break ;;
+        if [ "$positional_only" = false ]; then
+            case "$1" in
+                --dry-run)
+                    dry_run=true
+                    shift
+                    continue
+                    ;;
+                --delete)
+                    delete_repo=true
+                    shift
+                    continue
+                    ;;
+                --sudo)
+                    explicit_sudo=sudo
+                    shift
+                    continue
+                    ;;
+                --no-sudo)
+                    explicit_sudo=no-sudo
+                    shift
+                    continue
+                    ;;
+                --user)
+                    user="$2"
+                    shift 2
+                    continue
+                    ;;
+                --group)
+                    group="$2"
+                    shift 2
+                    continue
+                    ;;
+                -h|--help)
+                    usage
+                    ;;
+                --)
+                    positional_only=true
+                    shift
+                    continue
+                    ;;
+                -*)
+                    usage
+                    ;;
+            esac
+        fi
+
+        positional_count=$((positional_count + 1))
+        case "$positional_count" in
+            1) repo_name="$1" ;;
+            2) repo_base_path="$1" ;;
+            *) usage ;;
         esac
         shift
     done
 
-    if [ "$#" -lt 1 ]; then
+    if [ -z "$repo_name" ]; then
         usage
     fi
 
-    repo_name=$1
-    repo_base_path=${2:-"/var/lib/git"}
+    repo_base_path="${repo_base_path:-/var/lib/git}"
     repo_full_path="${repo_base_path}/${repo_name}.git"
 
-    if [ -z "$explicit_sudo" ]; then
-        case "$repo_base_path" in
-            $HOME*) use_sudo="" ;;
-            *) use_sudo="sudo" ;;
-        esac
-    else
-        use_sudo="$explicit_sudo"
-    fi
+    # Keep explicit no-sudo distinct from automatic path-based sudo selection;
+    # otherwise a system path would silently override the user's no-sudo choice.
+    case "$explicit_sudo" in
+        sudo)
+            use_sudo="sudo"
+            ;;
+        no-sudo)
+            use_sudo=""
+            ;;
+        *)
+            case "$repo_base_path" in
+                $HOME*) use_sudo="" ;;
+                *) use_sudo="sudo" ;;
+            esac
+            ;;
+    esac
 }
 
 # Main entry point of the script

--- a/installer/debian_env.sh
+++ b/installer/debian_env.sh
@@ -39,6 +39,9 @@
 #  - Errors from underlying scripts should be resolved based on their output.
 #
 #  Version History:
+#  v2.2 2026-09-11
+#       Let locales package provisioning establish locale-gen and update-locale
+#       instead of requiring them before setup begins.
 #  v2.1 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -112,11 +115,12 @@ check_sudo() {
 
 # Set locale ja_JP.UTF-8
 set_locale_jp() {
-    # Install `locales` package if `/etc/locale.gen` does not exist
-    if [ ! -f /etc/locale.gen ]; then
+    # Install `locales` package if not already installed
+    if ! dpkg -s locales >/dev/null 2>&1; then
         sudo apt-get install -y locales
-        echo "ja_JP.UTF-8 UTF-8" | sudo tee -a /etc/locale.gen
     fi
+    # The installed locales package guarantees locale-gen and update-locale.
+    # Do not recheck those commands after package provisioning.
 
     # Append `ja_JP.UTF-8 UTF-8` to `/etc/locale.gen` if not already present
     if ! grep -q '^ja_JP.UTF-8' /etc/locale.gen; then
@@ -162,7 +166,7 @@ main() {
 
     check_environment
     setup_environment
-    check_commands tee locale locale-gen update-locale grep groupadd
+    check_commands dpkg tee locale grep groupadd
     check_sudo
 
     set_locale_jp

--- a/installer/install_munin.sh
+++ b/installer/install_munin.sh
@@ -6,7 +6,9 @@
 #  Description:
 #  This script installs and configures Munin and Munin-node,
 #  ensuring necessary permissions and configurations are applied
-#  automatically without requiring manual edits.
+#  automatically without requiring manual edits. Apache, this script's
+#  required and managed web server, is installed together with Munin so
+#  the Apache service and htpasswd it provides are ready for configuration.
 #
 #  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/scripts
@@ -23,6 +25,7 @@
 #  - The script is designed for Debian-based systems.
 #  - Internet connectivity is required for package installation.
 #  - Ensure that $SCRIPTS is set correctly before execution.
+#  - Apache is installed and managed by this script as a required service.
 #
 #  Exit Status:
 #  - If the system is not Linux, the script exits with an error.
@@ -30,6 +33,10 @@
 #  - Errors from underlying commands should be resolved based on their output.
 #
 #  Version History:
+#  v1.7 2026-09-11
+#       Provision Apache with Munin so htpasswd and the restarted Apache
+#       service are established by package installation instead of startup
+#       checks.
 #  v1.6 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -95,13 +102,25 @@ check_commands() {
     done
 }
 
+# Check if the user has sudo privileges
+check_sudo() {
+    check_commands sudo
+    if ! sudo -v 2>/dev/null; then
+        echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access." >&2
+        exit 1
+    fi
+}
+
 # Install Munin and dependencies
 install_munin() {
     echo "[INFO] Installing Munin and dependencies..."
-    if ! sudo apt-get -y install munin munin-node; then
+    if ! sudo apt-get -y install munin munin-node apache2; then
         echo "[ERROR] Failed to install Munin packages." >&2
         exit 1
     fi
+    # The installed apache2 package establishes the Apache service and pulls in
+    # apache2-utils, which provides htpasswd. Do not recheck those package
+    # postconditions here.
 }
 
 # Configure Munin
@@ -151,7 +170,8 @@ main() {
     # Perform initial checks
     check_system
     check_scripts
-    check_commands sudo systemctl apt-get htpasswd cp chown chmod rm ln
+    check_commands systemctl apt-get cp chown chmod rm ln
+    check_sudo
 
     # Run the installation process
     install_munin

--- a/installer/install_ncurses.sh
+++ b/installer/install_ncurses.sh
@@ -40,6 +40,8 @@
 #  - Must be executed in a shell environment with internet access.
 #
 #  Version History:
+#  v2.9 2026-09-11
+#       Require sudo only on execution paths that select sudo mode.
 #  v2.8 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -92,8 +94,10 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    # No-sudo mode must not depend on sudo; validate sudo only after sudo mode is selected.
+    [ "$SUDO" = "sudo" ] || return 0
     check_commands sudo
-    if [ "$SUDO" = "sudo" ] && ! sudo -v 2>/dev/null; then
+    if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access or specify 'no-sudo'." >&2
         exit 1
     fi
@@ -204,7 +208,11 @@ main() {
     esac
 
     # Perform initial checks
-    check_commands wget make sudo tar awk mkdir cp uname rm
+    # cp is used only by the optional source-saving path, but it is a
+    # near-universal coreutil; check it eagerly here so a missing command
+    # fails fast instead of only after a full build and install have
+    # already completed.
+    check_commands wget make tar awk mkdir uname rm cp
 
     # Run the installation process
     setup_environment "$@"

--- a/installer/install_python.sh
+++ b/installer/install_python.sh
@@ -40,6 +40,8 @@
 #  - Must be executed in a shell environment with internet access.
 #
 #  Version History:
+#  v2.8 2026-09-11
+#       Require sudo only on execution paths that select sudo mode.
 #  v2.7 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -91,8 +93,10 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    # No-sudo mode must not depend on sudo; validate sudo only after sudo mode is selected.
+    [ "$SUDO" = "sudo" ] || return 0
     check_commands sudo
-    if [ "$SUDO" = "sudo" ] && ! sudo -v 2>/dev/null; then
+    if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access or specify 'no-sudo'." >&2
         exit 1
     fi
@@ -220,7 +224,11 @@ main() {
     esac
 
     # Perform initial checks
-    check_commands curl sudo make tar awk mkdir cp chown uname rm
+    # cp and chown are used only by the optional source-saving path, but they
+    # are near-universal coreutils; check them eagerly here so a missing
+    # command fails fast instead of only after a full build and install
+    # have already completed.
+    check_commands curl make tar awk mkdir uname rm cp chown
 
     # Run the installation process
     setup_environment "$@"

--- a/installer/install_ruby.sh
+++ b/installer/install_ruby.sh
@@ -40,6 +40,8 @@
 #  - Must be executed in a shell environment with internet access.
 #
 #  Version History:
+#  v3.8 2026-09-11
+#       Require sudo only on execution paths that select sudo mode.
 #  v3.7 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -91,8 +93,10 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    # No-sudo mode must not depend on sudo; validate sudo only after sudo mode is selected.
+    [ "$SUDO" = "sudo" ] || return 0
     check_commands sudo
-    if [ "$SUDO" = "sudo" ] && ! sudo -v 2>/dev/null; then
+    if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access or specify 'no-sudo'." >&2
         exit 1
     fi
@@ -219,7 +223,11 @@ main() {
     esac
 
     # Perform initial checks
-    check_commands curl sudo make tar awk mkdir cp chown uname rm
+    # cp and chown are used only by the optional source-saving path, but they
+    # are near-universal coreutils; check them eagerly here so a missing
+    # command fails fast instead of only after a full build and install
+    # have already completed.
+    check_commands curl make tar awk mkdir uname rm cp chown
 
     # Run the installation process
     setup_environment "$@"

--- a/installer/install_zsh.sh
+++ b/installer/install_zsh.sh
@@ -45,6 +45,8 @@
 #  - Must be executed in a shell environment with internet access.
 #
 #  Version History:
+#  v1.8 2026-09-11
+#       Require sudo only on execution paths that select sudo mode.
 #  v1.7 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -95,8 +97,10 @@ check_commands() {
 
 # Check if the user has sudo privileges (password may be required)
 check_sudo() {
+    # No-sudo mode must not depend on sudo; validate sudo only after sudo mode is selected.
+    [ "$SUDO" = "sudo" ] || return 0
     check_commands sudo
-    if [ "$SUDO" = "sudo" ] && ! sudo -v 2>/dev/null; then
+    if ! sudo -v 2>/dev/null; then
         echo "[ERROR] This script requires sudo privileges. Please run as a user with sudo access or specify 'no-sudo'." >&2
         exit 1
     fi
@@ -228,7 +232,11 @@ main() {
     esac
 
     # Perform initial checks
-    check_commands wget make sudo tar awk mkdir cp chown uname rm
+    # cp and chown are used only by the optional source-saving path, but they
+    # are near-universal coreutils; check them eagerly here so a missing
+    # command fails fast instead of only after a full build and install
+    # have already completed.
+    check_commands wget make tar awk mkdir uname rm cp chown
 
     USER_SPECIFIED_VERSION=0
     if [ -n "$1" ]; then

--- a/installer/setup_iptables.sh
+++ b/installer/setup_iptables.sh
@@ -111,6 +111,8 @@ install_persistent() {
     else
         echo "[INFO] iptables-persistent already installed."
     fi
+    # The iptables-persistent package state established above guarantees
+    # iptables-restore before load_rules(). Do not add a redundant command check.
 }
 
 # Apply template if needed

--- a/installer/setup_jupyter_themes.sh
+++ b/installer/setup_jupyter_themes.sh
@@ -20,10 +20,13 @@
 #
 #  Requirements:
 #  - Must be executed on macOS/Linux.
-#  - Requires `pip`, `jupyter`, and `jt` installed.
+#  - Requires `pip` at the configured Python prefix.
+#  - Installs `jupyterthemes` (providing `jt`) automatically if missing.
 #  - Requires sudo privileges unless a second argument is provided.
 #
 #  Version History:
+#  v1.6 2026-09-11
+#       Install jupyterthemes when missing instead of requiring jt before setup.
 #  v1.5 2026-07-11
 #       Replace the awk {n,} interval expression in usage() with a portable
 #       equivalent, since mawk on some systems matches it incorrectly.
@@ -94,9 +97,14 @@ setup_environment() {
 # Install Jupyter theme
 install_jupyter_theme() {
     if ! "$PIP" show jupyterthemes >/dev/null 2>&1; then
-        echo "[ERROR] jupyterthemes is not installed. Install it manually before running this script." >&2
-        exit 1
+        echo "[INFO] Installing jupyterthemes..."
+        if ! $SUDO "$PIP" install jupyterthemes; then
+            echo "[ERROR] Failed to install jupyterthemes." >&2
+            exit 1
+        fi
     fi
+    # The installed jupyterthemes package provides jt at this Python prefix.
+    # Do not add a separate post-install jt existence check.
 
     echo "[INFO] Applying Jupyter theme settings..."
     if ! "$JT" -t monokai -f inconsolata -N -T -fs 10 -nfs 10 -ofs 10 -cellw 90% -lineh 140; then
@@ -120,7 +128,7 @@ main() {
     esac
 
     setup_environment "$@"
-    check_commands "$PIP" "$JT"
+    check_commands "$PIP"
     install_jupyter_theme
     echo "[INFO] Jupyter theme setup completed successfully."
     return 0

--- a/installer/setup_nvim.sh
+++ b/installer/setup_nvim.sh
@@ -29,6 +29,8 @@
 #  - NeoVim must be installed and available in PATH.
 #
 #  Version History:
+#  v1.4 2026-09-11
+#       Remove the redundant post-check_commands nvim existence branch.
 #  v1.3 2026-09-06
 #       Show usage for unsupported arguments instead of starting installation.
 #  v1.2 2026-07-11
@@ -129,11 +131,9 @@ create_vim_symlink() {
 install() {
     check_commands mkdir cp ln nvim
 
+    # nvim was validated above; command -v here retrieves its path for the
+    # symlink and is not a second existence check.
     nvim_path=$(find_nvim_path)
-    if [ -z "$nvim_path" ]; then
-        echo "[ERROR] nvim not found in PATH." >&2
-        exit 1
-    fi
 
     create_config_dir
     copy_vimrc

--- a/installer/setup_xdg_dirs_en.sh
+++ b/installer/setup_xdg_dirs_en.sh
@@ -27,6 +27,9 @@
 #    -n, --no-sudo    Skip any sudo/apt operations and only update user dirs
 #
 #  Version History:
+#  v2.0 2026-09-11
+#       Avoid rechecking xdg-user-dirs-gtk-update after normal-mode package
+#       provisioning while retaining the prerequisite check in no-sudo mode.
 #  v1.9 2026-09-10
 #       Allow normal setup to install xdg-user-dirs-gtk before checking
 #       xdg-user-dirs-gtk-update.
@@ -110,6 +113,8 @@ install_xdg_user_dirs_gtk() {
     else
         echo "xdg-user-dirs-gtk is already installed."
     fi
+    # The xdg-user-dirs-gtk package state established here guarantees
+    # xdg-user-dirs-gtk-update. Do not add a redundant post-install check.
 }
 
 # Update user directories and check for success
@@ -141,9 +146,9 @@ main() {
 
         # Install xdg-user-dirs-gtk if necessary
         install_xdg_user_dirs_gtk
-
-        check_commands xdg-user-dirs-gtk-update
     else
+        # No-sudo mode performs no provisioning, so xdg-user-dirs-gtk-update
+        # remains an external prerequisite in this mode.
         check_commands xdg-user-dirs-gtk-update
     fi
 


### PR DESCRIPTION
### Problem
- Several installers required, at startup, a capability they themselves provision later (e.g. `iptables-restore`, `xdg-user-dirs-gtk-update`, `locale-gen`/`update-locale`, `jt`, `htpasswd`), so a clean environment failed before reaching the script's own self-provisioning path.
- `--no-sudo` execution paths in several installers still depended on `sudo`, which they never invoke on that path.
- Prerequisite checks already satisfied by an earlier successful operation were sometimes reconfirmed redundantly.
- `git-create-repo.sh`'s explicit `--no-sudo` state was indistinguishable from "unspecified," so a system repository path silently overrode it, and its parser could not parse documented options placed after positional arguments.

### Change
- `setup_xdg_dirs_en.sh`: normal mode no longer rechecks `xdg-user-dirs-gtk-update` after installing `xdg-user-dirs-gtk`; `--no-sudo` mode still requires it as an external prerequisite.
- `debian_env.sh`: locale package installation is now gated on `dpkg -s locales`, and `locale-gen`/`update-locale` are no longer startup prerequisites (the installed `locales` package guarantees them).
- `setup_jupyter_themes.sh`: installs `jupyterthemes` via the configured `pip` when missing, instead of requiring `jt` to already exist.
- `install_munin.sh`: installs `apache2` alongside `munin`/`munin-node` so it provides the Apache service and `htpasswd`; startup no longer requires `htpasswd` or unconditional `sudo`, using a standard `check_sudo` instead.
- `setup_iptables.sh`: comment-only change documenting the existing invariant in `install_persistent()`; no behavior or version change (its fix already shipped in #131).
- `install_python.sh`, `install_ruby.sh`, `install_zsh.sh`, `install_ncurses.sh`: `sudo` is no longer a startup prerequisite; `check_sudo()` returns immediately in no-sudo mode instead of checking for `sudo`. `cp`/`chown` remain startup prerequisites in these scripts, since they are near-universal coreutils and checking them only at the point of use would let a full download/build/install run to completion before failing on a missing command.
- `setup_nvim.sh`: removed the redundant branch that re-checked `nvim`'s existence immediately after `check_commands ... nvim` had already validated it.
- `git-create-repo.sh`: `--no-sudo` is now honored regardless of repository path (tracked as a distinct state from "unspecified"), and the argument parser accepts its documented options before or after positional arguments, erroring on a 3rd positional argument.
- `doc/POLICY`: added a rule to leave a rationale comment where omitting a check is non-obvious; a rule that a command may still be validated eagerly on a conditional path when it is a normal prerequisite of the supported environment and deferring the check would only move a predictable failure past work already done; a rule that a mode explicitly disabling a facility (e.g. no-sudo) must not require that facility's prerequisites.
- `doc/VERSIONS`: consolidated the prior iptables/XDG bullets and this pass into a single bullet under the existing unreleased `v2.0.2 (Release Date: TBD)` entry.

### Compatibility
- No new external dependency. `debian_env.sh` adds `dpkg` as a startup prerequisite, but it is a pre-existing Debian platform command, not a new dependency.
- `install_munin.sh` installs `apache2` (which pulls in `apache2-utils`, providing `htpasswd`) alongside `munin`/`munin-node`; `apache2-utils` is not installed explicitly.
- No test code, README, or `doc/FEATURES.md` changes.
- The new POLICY rules are not applied to any script outside this PR's 13-file scope.
- No probe was added for state a prior successful operation already guarantees.

### Validation
- `sh -n` on all changed executables — exit 0 for each.
- `python3 check_header_doc.py -a` — exit 0.
- `SCRIPTS=$(pwd) bash test/check_scripts.sh` — 140/140 scripts passed, including `-h` for every changed script.
- `git-create-repo.sh` targeted `--dry-run` checks in a temporary directory (no real repository created): options before positional args and options after positional args both skip sudo, print the dry-run message, and exit 0 without creating anything; a 3rd positional argument produces the usage message.
- Source review confirmed each changed self-provisioning/mode-selection/eager-check site behaves as described above and carries a rationale comment.
- Confirmed no-sudo mode in `install_python.sh`/`install_ruby.sh`/`install_zsh.sh`/`install_ncurses.sh` never invokes `sudo`, checked both statically and by exercising the actual `check_sudo()` logic against a `sudo` stub that fails loudly if called.
- No real package, firewall, locale, Apache, or Jupyter environment was modified by any validation step.
- Changed files: exactly the 13 files in scope (`git diff --check` clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017YWmhCtTharjTMrY1LtVGV