### PR TITLE
Skip unavailable nightly Python checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,13 @@ It exits with a non-zero status when any test fails.
 
 A second layer runs nightly from `cron/bin/run_tests`, which drives
 `run_tests.sh` once per configured Python and Ruby version and then applies the
-repository-wide checks: the shell script validation (`test/check_scripts.sh`),
-the header documentation check (`check_header_doc.py -a`), a Python
-code-quality dry run (`pyck.py`) against the top-level `*.py` files and
-`test/*.py`, and the compatibility check (`find_pycompat.py`). Checks that
-belong to the repository as a whole, rather than to one interpreter version,
-are wired there instead of into `run_tests.sh`.
+repository-wide shell script validation (`test/check_scripts.sh`) and header
+documentation check (`check_header_doc.py -a`). When their checker scripts are
+available, it also runs the Python code-quality dry run (`pyck.py`) against the
+top-level `*.py` files and `test/*.py`, and the compatibility check
+(`find_pycompat.py`). Checks that belong to the repository as a whole, rather
+than to one interpreter version, are wired there instead of into
+`run_tests.sh`.
 
 ---
 

--- a/cron/bin/run_tests
+++ b/cron/bin/run_tests
@@ -8,9 +8,9 @@
 #  in Python and Ruby. It loads configuration settings from an external
 #  configuration file, iterates through specified versions of Python and Ruby
 #  to run tests, runs a repository-wide shell script validation check, a
-#  repository-wide header documentation check, a pyck.py dry-run Python
-#  code-quality check, and a find_pycompat.py compatibility check, with the
-#  pyck.py and compatibility checks using the first Python version in the
+#  repository-wide header documentation check and, when available, a pyck.py
+#  dry-run Python code-quality check and a find_pycompat.py compatibility
+#  check, with the pyck.py and compatibility checks using the first Python
 #  loop. It is intended to be executed automatically via cron jobs and sends
 #  a summary email only when ADMIN_MAIL_ADDRESS is configured.
 #
@@ -44,8 +44,8 @@
 #  - The script is designed to be run in environments where Python and Ruby
 #    are used for development and testing.
 #  - In addition to language-specific tests, the script runs repository-wide
-#    checks for shell scripts, header documentation, Python code quality, and
-#    Python compatibility.
+#    shell script and header checks. Python code-quality and compatibility
+#    checks run only when their checker scripts are available.
 #  - The pyck.py dry-run requires autopep8, flake8, autoflake, and isort to be
 #    installed in the first configured Python environment's bin directory.
 #  - Ensure the specified Python and Ruby versions are installed and accessible.
@@ -58,6 +58,8 @@
 #  4. Configuration variables not set.
 #
 #  Version History:
+#  v3.1 2026-09-12
+#       Skip missing pyck.py and find_pycompat.py checks without failing the run.
 #  v3.0 2026-09-06
 #       Add pyck.py dry-run to nightly repository checks and use the first
 #       configured Python environment for its formatter and linter commands.
@@ -231,9 +233,7 @@ run_pyck() {
     fi
 
     if [ ! -f "$SCRIPTS/pyck.py" ]; then
-        record_failure
-        mark_failure
-        return 1
+        return 0
     fi
 
     echo >> "$JOBLOG" 2>&1
@@ -263,9 +263,7 @@ run_compatibility_check() {
     fi
 
     if [ ! -f "$SCRIPTS/find_pycompat.py" ]; then
-        record_failure
-        mark_failure
-        return 1
+        return 0
     fi
 
     echo "=== Checking Python compatibility with Python $first_python_version. ===" >> "$JOBLOG" 2>&1

--- a/doc/POLICY
+++ b/doc/POLICY
@@ -947,11 +947,12 @@ document changed.
   and exits non-zero when any of them fails.
 - The nightly `cron/bin/run_tests` job is the second layer. It drives
   `run_tests.sh` once per configured Python and Ruby version, then runs
-  `test/check_scripts.sh` (which exercises every shell script through `-h`),
-  `check_header_doc.py -a`, a `pyck.py` dry-run against the top-level Python
-  files and the Python files directly under `test/`, using the first
-  configured Python environment, and the `find_pycompat.py` compatibility
-  check across the repository, and mails the result to the administrator.
+  `test/check_scripts.sh` (which exercises every shell script through `-h`)
+  and `check_header_doc.py -a`. When their checker scripts are available, it
+  also runs a `pyck.py` dry-run against the top-level Python files and the
+  Python files directly under `test/`, using the first configured Python
+  environment, and the `find_pycompat.py` compatibility check across the
+  repository. It mails the result to the administrator.
 - A check that belongs to the repository as a whole, rather than to one
   interpreter version, is wired into the cron job rather than into
   `run_tests.sh`, so that it runs once per night instead of once per

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -14,8 +14,8 @@ v2.0.2 (Release Date: TBD)
   actual check results.
 - Separate pyck.py formatter and linter ignore policies, excluding W503 and W504
   from Flake8 while retaining the existing checks for other rules.
-- Run pyck.py in dry-run mode as a nightly repository-wide Python code-quality
-  check using the configured Python environment.
+- Run pyck.py and find_pycompat.py as optional nightly repository-wide Python
+  checks when their checker scripts are available.
 - Make pyck.py return non-zero for formatter or linter execution failures while
   keeping lint findings and dry-run change candidates advisory.
 - Make default-install installers show usage for unsupported arguments instead of


### PR DESCRIPTION
### Summary

- pyck.py / find_pycompat.py absence is a silent successful skip
- checker-present failures still affect nightly status
- README / POLICY / executable header align with optional checker semantics

### Validation

- syntax
- existing shell validation
- header documentation validation
- missing pyck.py smoke
- missing find_pycompat.py smoke
- checker-present failure semantics
- final diff scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)